### PR TITLE
Nissan leaf

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -45,7 +45,8 @@ static const char *TAG = "ovms-server-v2";
 #include "esp_system.h"
 
 // should this go in the .h or in the .cpp?
-typedef struct {
+typedef union {
+  struct {
   unsigned FrontLeftDoor:1;     // 0x01
   unsigned FrontRightDoor:1;    // 0x02
   unsigned ChargePort:1;        // 0x04
@@ -54,11 +55,12 @@ typedef struct {
   unsigned :1;                  // 0x20
   unsigned HandBrake:1;         // 0x40
   unsigned CarON:1;             // 0x80
-} car_doors1bits_t;
-// there has to be a better way than this, a union perhaps?
-#define car_doors1bits (*((car_doors1bits_t*)&car_doors1))
+  } bits;
+  uint8_t flags;
+} car_doors1_t;
 
-typedef struct {
+typedef union {
+  struct {
   unsigned RearLeftDoor:1;      // 0x01
   unsigned RearRightDoor:1;     // 0x02
   unsigned Frunk:1;             // 0x04
@@ -67,9 +69,9 @@ typedef struct {
   unsigned :1;                  // 0x20
   unsigned :1;                  // 0x40
   unsigned HVAC:1;              // 0x80
-} car_doors5bits_t;
-// there has to be a better way than this, a union perhaps?
-#define car_doors5bits (*((car_doors5bits_t*)&car_doors5))
+  } bits;
+  uint8_t flags;
+} car_doors5_t;
 
 OvmsServerV2 *MyOvmsServerV2 = NULL;
 size_t MyOvmsServerV2Modifier = 0;
@@ -503,31 +505,31 @@ void OvmsServerV2::TransmitMsgFirmware(bool always)
 
 void AppendDoors1(std::string *buffer)
   {
-  uint8_t car_doors1;
-  car_doors1bits.FrontLeftDoor = StandardMetrics.ms_v_door_fl->AsBool();
-  car_doors1bits.FrontRightDoor = StandardMetrics.ms_v_door_fr->AsBool();
-  car_doors1bits.ChargePort = StandardMetrics.ms_v_door_chargeport->AsBool();
-  car_doors1bits.PilotSignal = StandardMetrics.ms_v_charge_pilot->AsBool();
-  car_doors1bits.Charging = StandardMetrics.ms_v_charge_inprogress->AsBool();
-  car_doors1bits.HandBrake = StandardMetrics.ms_v_env_handbrake->AsBool();
-  car_doors1bits.CarON = StandardMetrics.ms_v_env_on->AsBool();
+  car_doors1_t car_doors1;
+  car_doors1.bits.FrontLeftDoor = StandardMetrics.ms_v_door_fl->AsBool();
+  car_doors1.bits.FrontRightDoor = StandardMetrics.ms_v_door_fr->AsBool();
+  car_doors1.bits.ChargePort = StandardMetrics.ms_v_door_chargeport->AsBool();
+  car_doors1.bits.PilotSignal = StandardMetrics.ms_v_charge_pilot->AsBool();
+  car_doors1.bits.Charging = StandardMetrics.ms_v_charge_inprogress->AsBool();
+  car_doors1.bits.HandBrake = StandardMetrics.ms_v_env_handbrake->AsBool();
+  car_doors1.bits.CarON = StandardMetrics.ms_v_env_on->AsBool();
 
   char b[5];
-  itoa(car_doors1, b, 10);
+  itoa(car_doors1.flags, b, 10);
   buffer->append(b);
   }
 
 void AppendDoors5(std::string *buffer)
   {
-  uint8_t car_doors5;
-  car_doors5bits.RearLeftDoor = StandardMetrics.ms_v_door_rl->AsBool();
-  car_doors5bits.RearRightDoor = StandardMetrics.ms_v_door_rr->AsBool();
-  car_doors5bits.Frunk = false; // should this be hood or something else?
-  car_doors5bits.Charging12V = StandardMetrics.ms_v_env_charging12v->AsBool();
-  car_doors5bits.HVAC = StandardMetrics.ms_v_env_hvac->AsBool();
+  car_doors5_t car_doors5;
+  car_doors5.bits.RearLeftDoor = StandardMetrics.ms_v_door_rl->AsBool();
+  car_doors5.bits.RearRightDoor = StandardMetrics.ms_v_door_rr->AsBool();
+  car_doors5.bits.Frunk = false; // should this be hood or something else?
+  car_doors5.bits.Charging12V = StandardMetrics.ms_v_env_charging12v->AsBool();
+  car_doors5.bits.HVAC = StandardMetrics.ms_v_env_hvac->AsBool();
 
   char b[5];
-  itoa(car_doors5, b, 10);
+  itoa(car_doors5.flags, b, 10);
   buffer->append(b);
   }
 

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -591,13 +591,17 @@ void OvmsServerV2::TransmitMsgEnvironment(bool always)
   buffer.append(",");
   buffer.append("0");  // car_doors3
   buffer.append(",");
+
+  // v2 has one "stale" flag for 4 temperatures, we say they're stale only if
+  // all are stale, IE one valid temperature makes them all valid
   bool stale_temps =
-    StandardMetrics.ms_v_temp_pem->IsStale() ||
-    StandardMetrics.ms_v_temp_motor->IsStale() ||
-    StandardMetrics.ms_v_temp_battery->IsStale() ||
+    StandardMetrics.ms_v_temp_pem->IsStale() &&
+    StandardMetrics.ms_v_temp_motor->IsStale() &&
+    StandardMetrics.ms_v_temp_battery->IsStale() &&
     StandardMetrics.ms_v_temp_charger->IsStale();
   buffer.append(stale_temps ? "0" : "1");
   buffer.append(",");
+
   buffer.append(StandardMetrics.ms_v_temp_ambient->IsStale() ? "0" : "1");
   buffer.append(",");
   buffer.append(StandardMetrics.ms_v_bat_12v->AsString("0").c_str());

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -330,7 +330,7 @@ void OvmsServerV2::TransmitMsgStat(bool always)
     StandardMetrics.ms_v_bat_range_est->IsModifiedAndClear(MyOvmsServerV2Modifier) ||
     StandardMetrics.ms_v_charge_climit->IsModifiedAndClear(MyOvmsServerV2Modifier) ||
     StandardMetrics.ms_v_charge_kwh->IsModifiedAndClear(MyOvmsServerV2Modifier) ||
-    StandardMetrics.ms_v_bat_cac->IsModifiedAndClear(MyOvmsServerV2Modifier);
+    StandardMetrics.ms_v_bat_cac->IsModifiedAndClear(MyOvmsServerV2Modifier) ||
     StandardMetrics.ms_v_bat_voltage->IsModifiedAndClear(MyOvmsServerV2Modifier) ||
     StandardMetrics.ms_v_bat_soh->IsModifiedAndClear(MyOvmsServerV2Modifier);
 

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -501,7 +501,7 @@ void OvmsServerV2::TransmitMsgFirmware(bool always)
   {
   }
 
-void AppendDoors1(std::string buffer)
+void AppendDoors1(std::string *buffer)
   {
   uint8_t car_doors1;
   car_doors1bits.FrontLeftDoor = StandardMetrics.ms_v_door_fl->AsBool();
@@ -512,12 +512,12 @@ void AppendDoors1(std::string buffer)
   car_doors1bits.HandBrake = StandardMetrics.ms_v_env_handbrake->AsBool();
   car_doors1bits.CarON = StandardMetrics.ms_v_env_on->AsBool();
 
-  std::ostringstream s;
-  s << car_doors1;
-  buffer.append(s.str().c_str());
+  char b[5];
+  itoa(car_doors1, b, 10);
+  buffer->append(b);
   }
 
-void AppendDoors5(std::string buffer)
+void AppendDoors5(std::string *buffer)
   {
   uint8_t car_doors5;
   car_doors5bits.RearLeftDoor = StandardMetrics.ms_v_door_rl->AsBool();
@@ -526,9 +526,9 @@ void AppendDoors5(std::string buffer)
   car_doors5bits.Charging12V = StandardMetrics.ms_v_env_charging12v->AsBool();
   car_doors5bits.HVAC = StandardMetrics.ms_v_env_hvac->AsBool();
 
-  std::ostringstream s;
-  s << car_doors5;
-  buffer.append(s.str().c_str());
+  char b[5];
+  itoa(car_doors5, b, 10);
+  buffer->append(b);
   }
 
 void OvmsServerV2::TransmitMsgEnvironment(bool always)
@@ -565,7 +565,7 @@ void OvmsServerV2::TransmitMsgEnvironment(bool always)
   std::string buffer;
   buffer.reserve(512);
   buffer.append("MP-0 D");
-  AppendDoors1(buffer);
+  AppendDoors1(&buffer);
   buffer.append(",");
   buffer.append("0");  // car_doors2
   buffer.append(",");
@@ -604,7 +604,7 @@ void OvmsServerV2::TransmitMsgEnvironment(bool always)
   buffer.append(",");
   buffer.append("0");  // car_12vline_ref
   buffer.append(",");
-  AppendDoors5(buffer);
+  AppendDoors5(&buffer);
   buffer.append(",");
   buffer.append(StandardMetrics.ms_v_temp_charger->AsString("0").c_str());
   buffer.append(",");

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -230,8 +230,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameEVBus(CAN_frame_t* p_frame)
       break;
     case 0x284:
     {
-      // TODO
-      //vehicle_nissanleaf_car_on(TRUE);
+      vehicle_nissanleaf_car_on(true);
 
       uint16_t car_speed16 = d[4];
       car_speed16 = car_speed16 << 8;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -92,6 +92,8 @@ OvmsVehicleNissanLeaf::~OvmsVehicleNissanLeaf()
   ESP_LOGI(TAG, "Shutdown Nissan Leaf vehicle module");
 
   m_can1->SetPowerMode(Off);
+  m_can2->SetPowerMode(Off);
+  m_can3->SetPowerMode(Off);
   MyCan.DeregisterListener(m_rxqueue);
 
   vQueueDelete(m_rxqueue);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -35,6 +35,7 @@ static const char *TAG = "v-nissanleaf";
 #include <string.h>
 #include "pcp.h"
 #include "vehicle_nissanleaf.h"
+#include "ovms_events.h"
 #include "ovms_metrics.h"
 #include "metrics_standard.h"
 
@@ -85,6 +86,10 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   m_can3->Start(CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
 
   MyCan.RegisterListener(m_rxqueue);
+
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  MyEvents.RegisterEvent(TAG, "ticker.1", std::bind(&OvmsVehicleNissanLeaf::Ticker1, this, _1, _2));
   }
 
 OvmsVehicleNissanLeaf::~OvmsVehicleNissanLeaf()
@@ -347,6 +352,21 @@ void OvmsVehicleNissanLeaf::IncomingFrame(CAN_frame_t* p_frame)
     {
     ESP_LOGI(TAG, "Can 3 Frame");
     m_can3 = NULL;
+    }
+  }
+
+void OvmsVehicleNissanLeaf::Ticker1(std::string event, void* data)
+  {
+  // FIXME
+  // detecting that on is stale and therefor should turn off probably shouldn't
+  // be done like this
+  // perhaps there should be a car on-off state tracker and event generator in
+  // the core framework?
+  // perhaps interested code should be able to subscribe to "onChange" and
+  // "onStale" events for each metric?
+  if (StandardMetrics.ms_v_env_on->IsStale())
+    {
+    vehicle_nissanleaf_car_on(false);
     }
   }
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -7,7 +7,8 @@
 ;
 ;    (C) 2011       Michael Stegen / Stegen Electronics
 ;    (C) 2011-2017  Mark Webb-Johnson
-;    (C) 2011        Sonny Chen @ EPRO/DX
+;    (C) 2011       Sonny Chen @ EPRO/DX
+;    (C) 2017       Tom Parker
 ;
 ; Permission is hereby granted, free of charge, to any person obtaining a copy
 ; of this software and associated documentation files (the "Software"), to deal
@@ -38,10 +39,6 @@ static const char *TAG = "v-nissanleaf";
 #include "ovms_events.h"
 #include "ovms_metrics.h"
 #include "metrics_standard.h"
-
-#define GEN_1_NEW_CAR_GIDS 281l
-#define GEN_1_NEW_CAR_GIDS_S "281"
-#define GEN_1_NEW_CAR_RANGE_MILES 84
 
 typedef enum
   {

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -60,7 +60,7 @@ static void NL_rxtask(void *pvParameters)
     {
     if (xQueueReceive(me->m_rxqueue, &frame, (portTickType)portMAX_DELAY)==pdTRUE)
       {
-      if (me->m_can1 == frame.origin) me->IncomingFrame(&frame);
+      me->IncomingFrame(&frame);
       }
     }
   }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -7,7 +7,8 @@
 ;
 ;    (C) 2011       Michael Stegen / Stegen Electronics
 ;    (C) 2011-2017  Mark Webb-Johnson
-;    (C) 2011        Sonny Chen @ EPRO/DX
+;    (C) 2011       Sonny Chen @ EPRO/DX
+;    (C) 2017       Tom Parker
 ;
 ; Permission is hereby granted, free of charge, to any person obtaining a copy
 ; of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +34,10 @@
 
 #include "can.h"
 #include "vehicle.h"
+
+#define GEN_1_NEW_CAR_GIDS 281l
+#define GEN_1_NEW_CAR_GIDS_S "281"
+#define GEN_1_NEW_CAR_RANGE_MILES 84
 
 using namespace std;
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -47,6 +47,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
 
   private:
     void IncomingFrameEVBus(CAN_frame_t* p_frame);
+    void Ticker1(std::string event, void* data);
 
   protected:
 


### PR DESCRIPTION
Fix bug in stat v2 server message
Fill in more of the environment v2 server messages
Ported more Nissan Leaf code from v2

Should the doors unions defined in the v2 server be in the .cpp file or the .h? They're private and don't need to be exposed to the rest of the code base.

Is there already better way to do the car off detection, which of my suggestions, if any, is most appropriate?