### PR TITLE
v2 server: make various v2 values integer

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -406,9 +406,9 @@ void OvmsServerV2::TransmitMsgStat(bool always)
   else
     buffer.append("M");
   buffer.append(",");
-  buffer.append(StandardMetrics.ms_v_charge_voltage->AsString("0").c_str());
+  buffer.append(StandardMetrics.ms_v_charge_voltage->AsString("0", Integer).c_str());
   buffer.append(",");
-  buffer.append(StandardMetrics.ms_v_charge_current->AsString("0").c_str());
+  buffer.append(StandardMetrics.ms_v_charge_current->AsString("0", Integer).c_str());
   buffer.append(",");
   buffer.append("stopped");  // car_chargestate
   buffer.append(",");
@@ -418,7 +418,7 @@ void OvmsServerV2::TransmitMsgStat(bool always)
   buffer.append(",");
   buffer.append(StandardMetrics.ms_v_bat_range_est->AsString("0",m_units_distance).c_str());
   buffer.append(",");
-  buffer.append(StandardMetrics.ms_v_charge_climit->AsString("0").c_str());
+  buffer.append(StandardMetrics.ms_v_charge_climit->AsString("0", Integer).c_str());
   buffer.append(",");
   buffer.append("0");  // charge duration
   buffer.append(",");

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -566,7 +566,12 @@ std::string OvmsMetricFloat::AsString(const char* defvalue, metric_unit_t units)
   if (m_defined)
     {
     std::ostringstream ss;
-    if ((units != Other)&&(units != m_units))
+    if (units == Integer)
+      {
+      // special case float to integer string without converting units
+      ss << (int) m_value;
+      }
+    else if ((units != Other)&&(units != m_units))
       ss << UnitConvert(m_units,units,m_value);
     else
       ss << m_value;

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -80,7 +80,8 @@ typedef enum
   MphPS         = 72,   // Mph per second
   MetersPSS     = 73,   // Meters per second^2
 
-  Percentage    = 90
+  Percentage    = 90,
+  Integer       = 91,
   } metric_unit_t;
 
 extern const char* OvmsMetricUnitLabel(metric_unit_t units);


### PR DESCRIPTION
The android client crashes on receipt of a floating point value when it's expecting an integer. This change updates charge current, line voltage and charge current limit to integral values rather than the floating point in the storage.

I chose to add another unit conversion for float to int, but I'm not sure that this i right, since it precludes users of the api from performing a unit conversion and converting to integer. Perhaps AsIntString(default, unit) is a better interface?

I also did a simple cast to int rather than a round, I'm not sure if we care too much about that?