### PR TITLE
Fix too short strncpy in v2 command responses

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -581,7 +581,7 @@ void OvmsServerV2::Transmit(const std::ostringstream& message)
   if (len==0) return;
 
   char* s = new char[len+1];
-  strncpy(s,bp,len);
+  strncpy(s,bp,len+1);
   ESP_LOGI(TAG, "Send %s",s);
 
   RC4_crypt(&m_crypto_tx1, &m_crypto_tx2, (uint8_t*)s, len);


### PR DESCRIPTION
You could argue strncpy isn't needed here because we allocated a buffer sized by strlen, so we know the buffer is big enough (or is null if new fails, and the world is about to end, I guess?). Either way, leaving out the null terminator on the string leads to mangled messages, as we transmit data until we find a null in memory.