### PR TITLE
Fix crash when deregistering metric listeners and event listeners

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_events.cpp
+++ b/vehicle/OVMS.V3/main/ovms_events.cpp
@@ -102,22 +102,32 @@ void OvmsEvents::RegisterEvent(std::string caller, std::string event, EventCallb
 
 void OvmsEvents::DeregisterEvent(std::string caller)
   {
-  for (EventMap::iterator itm=m_map.begin(); itm!=m_map.end(); ++itm)
+  EventMap::iterator itm=m_map.begin();
+  while (itm!=m_map.end())
     {
     EventCallbackList* el = itm->second;
-    for (EventCallbackList::iterator itc=el->begin(); itc!=el->end(); ++itc)
+    EventCallbackList::iterator itc=el->begin();
+    while (itc!=el->end())
       {
       EventCallbackEntry* ec = *itc;
       if (ec->m_caller == caller)
         {
-        el->erase(itc);
+        itc = el->erase(itc);
         delete ec;
+        }
+      else
+        {
+        ++itc;
         }
       }
     if (el->empty())
       {
+      itm = m_map.erase(itm);
       delete el;
-      m_map.erase(itm);
+      }
+    else
+      {
+      ++itm;
       }
     }
   }

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -318,22 +318,32 @@ void OvmsMetrics::RegisterListener(const char* caller, const char* name, MetricC
 
 void OvmsMetrics::DeregisterListener(const char* caller)
   {
-  for (MetricCallbackMap::iterator itm=m_listeners.begin(); itm!=m_listeners.end(); ++itm)
+  MetricCallbackMap::iterator itm=m_listeners.begin();
+  while (itm!=m_listeners.end())
     {
     MetricCallbackList* ml = itm->second;
-    for (MetricCallbackList::iterator itc=ml->begin(); itc!=ml->end(); ++itc)
+    MetricCallbackList::iterator itc=ml->begin();
+    while (itc!=ml->end())
       {
       MetricCallbackEntry* ec = *itc;
       if (ec->m_caller == caller)
         {
-        ml->erase(itc);
+        itc = ml->erase(itc);
         delete ec;
+        }
+      else
+        {
+        ++itc;
         }
       }
     if (ml->empty())
       {
+      itm = m_listeners.erase(itm);
       delete ml;
-      m_listeners.erase(itm);
+      }
+    else
+      {
+      ++itm;
       }
     }
   }


### PR DESCRIPTION
Erasing an iterator from the list invalidates the iterator (I guess because the memory for the backing object has been released) so you can't erase and then increment. This construction with a while loop is a bit messy but there's not much advantage to trying to keep the iterators in loop scope in these small function.

I have not audited the code for other examples of this faulty pattern