### PR TITLE
Add new metrics for Nissan Leaf (tested on MY2015 24kWh).

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -90,8 +90,6 @@ void vehicle_nissanleaf_car_on(bool isOn)
   {
   StandardMetrics.ms_v_env_on->SetValue(isOn);
   StandardMetrics.ms_v_env_awake->SetValue(isOn);
-  // We don't know if handbrake is on or off, but it's usually off when the car is on.
-  StandardMetrics.ms_v_env_handbrake->SetValue(!isOn);
 // TODO this is supposed to be a one-shot but car_parktime doesn't work in v3 yet
 // further it's not clear if we even need to do this
 //  if (isOn && car_parktime != 0)
@@ -370,6 +368,13 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         d[1] == 0x76 || // Auto
         d[1] == 0x78;   // Manual A/C on
       StandardMetrics.ms_v_env_hvac->SetValue(hvac_candidate);
+      /* These may only reflect the centre console LEDs, which
+       * means they don't change when remote CC is operating.
+       * They should be replaced when we find better signals that
+       * indicate when heating or cooling is actually occuring.
+       */
+      StandardMetrics.ms_v_env_cooling->SetValue(d[1] & 0x10);
+      StandardMetrics.ms_v_env_heating->SetValue(d[1] & 0x02);
     }
       break;
     case 0x54c:
@@ -384,6 +389,16 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       StandardMetrics.ms_v_env_temp->SetValue(ambient_temp);
       break;
     }
+    case 0x54f:
+      /* Climate control's measurement of temperature inside the car.
+       * Subtracting 14 is a bit of a guess worked out by observing how
+       * auto climate control reacts when this reaches the target setting.
+       */
+      if (d[0] != 20)
+        {
+        StandardMetrics.ms_v_env_cabintemp->SetValue(d[0] / 2.0 - 14); // App label: CHARGER
+        }
+      break;
     case 0x5bc:
     {
       uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
@@ -460,6 +475,18 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
 
   switch (p_frame->MsgID)
     {
+    case 0x180:
+      if (d[5] != 0xff)
+        {
+        StandardMetrics.ms_v_env_throttle->SetValue(d[5] / 2.00);
+        }
+      break;
+    case 0x292:
+      if (d[6] != 0xff)
+        {
+        StandardMetrics.ms_v_env_footbrake->SetValue(d[6] / 1.39);
+        }
+      break;
     case 0x355:
       if (d[6] == 0x60)
         {
@@ -470,7 +497,45 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
           m_odometer_units = Kilometers;
         }
       break;
+    case 0x385:
+      // not sure if this order is correct
+      if (d[2]) StandardMetrics.ms_v_tpms_fl_p->SetValue(d[2] / 4.0, PSI);
+      if (d[3]) StandardMetrics.ms_v_tpms_fr_p->SetValue(d[3] / 4.0, PSI);
+      if (d[4]) StandardMetrics.ms_v_tpms_rl_p->SetValue(d[4] / 4.0, PSI);
+      if (d[5]) StandardMetrics.ms_v_tpms_rr_p->SetValue(d[5] / 4.0, PSI);
+      break;
+    case 0x421:
+      switch ( (d[0] >> 3) & 7 )
+        {
+        case 0: // Parking
+        case 1: // Park
+        case 3: // Neutral
+        case 5: // undefined
+        case 6: // undefined
+          StandardMetrics.ms_v_env_gear->SetValue(0);
+          break;
+        case 2: // Reverse
+          StandardMetrics.ms_v_env_gear->SetValue(-1);
+          break;
+        case 4: // Drive
+        case 7: // Drive/B (ECO on some models)
+          StandardMetrics.ms_v_env_gear->SetValue(1);
+          break;
+        }
+      break;
+    case 0x510:
+      /* This seems to be outside temperature with half-degree C accuracy.
+       * It reacts a bit more rapidly than what we get from the battery.
+       * App label: PEM
+       */
+      if (d[7] != 0xff)
+        {
+        StandardMetrics.ms_v_inv_temp->SetValue(d[7] / 2.0 - 40);
+        }
+      break;
     case 0x5c5:
+      // This is the parking brake (which is foot-operated on some models).
+      StandardMetrics.ms_v_env_handbrake->SetValue(d[0] & 4);
       {
       uint32_t odometer;
       odometer = d[1];
@@ -483,6 +548,18 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_pos_odometer->SetValue(odometer, m_odometer_units);
         }
       }
+      break;
+    case 0x60d:
+      StandardMetrics.ms_v_door_trunk->SetValue(d[0] & 0x80);
+      StandardMetrics.ms_v_door_rr->SetValue(d[0] & 0x40);
+      StandardMetrics.ms_v_door_rl->SetValue(d[0] & 0x20);
+      StandardMetrics.ms_v_door_fr->SetValue(d[0] & 0x10);
+      StandardMetrics.ms_v_door_fl->SetValue(d[0] & 0x08);
+      StandardMetrics.ms_v_env_headlights->SetValue((d[0] & 0x02) | // dip beam
+                                                    (d[1] & 0x08)); // main beam
+      // The two lock bits are 0x10 driver door and 0x08 other doors.
+      // We should only say "locked" if both are locked.
+      StandardMetrics.ms_v_env_locked->SetValue( (d[2] & 0x18) == 0x18);
       break;
     }
   }


### PR DESCRIPTION
Added new metrics:
* ms_v_door_fl etc. from 0x60d[0]
* ms_v_env_cabintemp from 0x54f[0]
* ms_v_env_cooling, ms_v_env_heating from 0x54b[1]
* ms_v_env_footbrake from 0x292[6]
* ms_v_env_gear from 0x421[0]
* ms_v_env_handbrake from 0x5c5[0] (previously faked by vehicle_nissanleaf_car_on)
* ms_v_env_headlights from 0x60d[0..1]
* ms_v_env_locked from 0x60d[2]
* ms_v_env_throttle from 0x180[5]
* ms_v_inv_temp from 0x510[7]
* ms_v_tpms_fl_p etc. from 0x385[2..5]