### PR TITLE
Respect the users decision whether to enable or disable gps

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -706,8 +706,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   c.fieldset_start("Features");
   c.input_checkbox("Enable SMS", "enable_sms", enable_sms);
   c.input_checkbox("Enable GPS", "enable_gps", enable_gps);
-  c.input_checkbox("Use GPS time", "enable_gpstime", enable_gpstime,
-    "<p>Note: GPS &amp; GPS time support can be left disabled, vehicles will activate them as needed</p>");
+  c.input_checkbox("Use GPS time", "enable_gpstime", enable_gpstime);
   c.fieldset_end();
 
   c.hr();
@@ -1372,8 +1371,7 @@ void OvmsWebServer::HandleCfgAutoInit(PageEntry_t& p, PageContext_t& c)
     c.input_select_option(kv.first.c_str(), kv.first.c_str(), (kv.first == wifi_ssid_client));
   c.input_select_end();
 
-  c.input_checkbox("Start modem", "modem", modem,
-    "<p>Note: a vehicle module may start the modem as necessary, independantly of this option.</p>");
+  c.input_checkbox("Start modem", "modem", modem);
 
   c.input_select_start("Vehicle type", "vehicle_type");
   c.input_select_option("&mdash;", "", vehicle_type.empty());

--- a/vehicle/OVMS.V3/components/simcom/src/gsmnmea.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/gsmnmea.cpp
@@ -229,7 +229,7 @@ void GsmNMEA::IncomingLine(const std::string line)
 
     // Data complete, store:
 
-    if (m_gpstime_enabled || m_gpstime_required)
+    if (m_gpstime_enabled)
       {
       int tm = utc_to_timestamp(date, time);
       *StdMetrics.ms_m_timeutc = (int) tm;
@@ -245,9 +245,9 @@ void GsmNMEA::IncomingLine(const std::string line)
   }
 
 
-void GsmNMEA::Startup(bool force)
+void GsmNMEA::Startup()
   {
-  if (!force && !MyConfig.GetParamValueBool("modem", "enable.gps", false))
+  if (!MyConfig.GetParamValueBool("modem", "enable.gps", false))
     {
     ESP_LOGD(TAG, "GPS disabled");
     return;
@@ -289,7 +289,6 @@ GsmNMEA::GsmNMEA(GsmMux* mux, int channel)
   m_channel = channel;
   m_connected = false;
   m_gpstime_enabled = false;
-  m_gpstime_required = false;
   }
 
 GsmNMEA::~GsmNMEA()

--- a/vehicle/OVMS.V3/components/simcom/src/gsmnmea.h
+++ b/vehicle/OVMS.V3/components/simcom/src/gsmnmea.h
@@ -46,7 +46,7 @@ class GsmNMEA
 
   public:
     void IncomingLine(const std::string line);
-    void Startup(bool force=false);
+    void Startup();
     void Shutdown(bool hard=false);
 
   public:
@@ -54,7 +54,6 @@ class GsmNMEA
     int           m_channel;
     bool          m_connected;
     bool          m_gpstime_enabled;
-    bool          m_gpstime_required;
   };
 
 #endif //#ifndef __GSM_NMEA__

--- a/vehicle/OVMS.V3/components/simcom/src/simcom.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom.h
@@ -126,7 +126,6 @@ class simcom : public pcp, public InternalRamAllocated
     GsmMux       m_mux;
     GsmPPPOS     m_ppp;
     GsmNMEA      m_nmea;
-    bool         m_gps_required;
     int          m_line_unfinished;
     std::string  m_line_buffer;
 

--- a/vehicle/OVMS.V3/components/vehicle_fiat500/src/vehicle_fiat500e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_fiat500/src/vehicle_fiat500e.cpp
@@ -39,10 +39,6 @@ OvmsVehicleFiat500e::OvmsVehicleFiat500e()
   ESP_LOGI(TAG, "Start Fiat 500e vehicle module");
 
   RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
-
-  // require GPS:
-  MyEvents.SignalEvent("vehicle.require.gps", NULL);
-  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
   }
 
 OvmsVehicleFiat500e::~OvmsVehicleFiat500e()

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
@@ -326,15 +326,6 @@ OvmsVehicleKiaSoulEv::OvmsVehicleKiaSoulEv()
   cmd_xks->RegisterCommand("sjb","Send command to SJB ECU", xks_sjb, "<b1><b2><b3>", 3,3, false);
   cmd_xks->RegisterCommand("bcm","Send command to BCM ECU", xks_bcm, "<b1><b2><b3>", 3,3, false);
 
-  MyConfig.SetParamValueBool("modem","enable.gps", true);
-  MyConfig.SetParamValueBool("modem","enable.gpstime", true);
-  MyConfig.SetParamValueBool("modem","enable.net", true);
-  MyConfig.SetParamValueBool("modem","enable.sms", true);
-
-  // Require GPS.
-  MyEvents.SignalEvent("vehicle.require.gps", NULL);
-  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
-
   MyConfig.RegisterParam("xks", "Kia Soul EV spesific settings.", true, true);
   ConfigChanged(NULL);
 
@@ -355,10 +346,6 @@ OvmsVehicleKiaSoulEv::OvmsVehicleKiaSoulEv()
 OvmsVehicleKiaSoulEv::~OvmsVehicleKiaSoulEv()
   {
   ESP_LOGI(TAG, "Shutdown Kia Soul EV vehicle module");
-
-  // release GPS:
-  MyEvents.SignalEvent("vehicle.release.gps", NULL);
-  MyEvents.SignalEvent("vehicle.release.gpstime", NULL);
   }
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.cpp
@@ -58,10 +58,6 @@ OvmsVehicleMitsubishi::OvmsVehicleMitsubishi()
   memset(mi_batttemps,0,sizeof(mi_batttemps));
 
   RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
-
-  // require GPS:
-  MyEvents.SignalEvent("vehicle.require.gps", NULL);
-  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
   }
 
 OvmsVehicleMitsubishi::~OvmsVehicleMitsubishi()

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.cpp
@@ -104,10 +104,6 @@ OvmsVehicleRenaultTwizy::OvmsVehicleRenaultTwizy()
   using std::placeholders::_2;
   MyEvents.RegisterEvent(TAG, "gps.lock.acquired", std::bind(&OvmsVehicleRenaultTwizy::EventListener, this, _1, _2));
 
-  // require GPS:
-  MyEvents.SignalEvent("vehicle.require.gps", NULL);
-  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
-
   // init subsystems:
   BatteryInit();
   PowerInit();

--- a/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.cpp
@@ -59,10 +59,6 @@ OvmsVehicleThinkCity::OvmsVehicleThinkCity()
   RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
   PollSetPidList(m_can1, obdii_polls);
   PollSetState(0);
-  
-  // require GPS:
-  MyEvents.SignalEvent("vehicle.require.gps", NULL);
-  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
   }
 
 OvmsVehicleThinkCity::~OvmsVehicleThinkCity()

--- a/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.cpp
@@ -72,10 +72,6 @@ OvmsVehicleVoltAmpera::OvmsVehicleVoltAmpera()
   m_candata_timer = VA_CANDATA_TIMEOUT;
   m_range_estimated_km = 0;
 
-  // require GPS:
-  MyEvents.SignalEvent("vehicle.require.gps", NULL);
-  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
-
   // Config parameters
   MyConfig.RegisterParam("xva", "Volt/Ampera", true, true);
   m_range_rated_km = MyConfig.GetParamValueInt("xva", "range.km", 0);

--- a/vehicle/OVMS.V3/components/vehicle_zeva/src/vehicle_zeva.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_zeva/src/vehicle_zeva.cpp
@@ -40,10 +40,6 @@ OvmsVehicleZeva::OvmsVehicleZeva()
   // Change CANbus speed to either 125 or 250KBPS 
   RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_250KBPS);
 
-  // require GPS:
-  MyEvents.SignalEvent("vehicle.require.gps", NULL);
-  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
-
   StandardMetrics.ms_v_type->SetValue("ZEVA");
   StandardMetrics.ms_v_vin->SetValue("ZEVAZEVAZEVAZEVA");
 


### PR DESCRIPTION
Currently some vehicles force the OVMS GPS and thus the simcom to be enabled. Even when the users disables GSM and GPS via the web config it gets enabled. In fact various vehicle ports required gps, even though the only one using it seems to be the Twizy with its gps logging.

This pull request simply removes the "anti-feature" of forced gps & simcom.

This is sort of a design decision PR, so the following represents my point of view:
This reminds me a lot of the ["the program controls the user"](https://youtu.be/7twCCWjSnMg?t=57) term, introduced by Richard Stallman. Even though we give the user a choice to enable or disable GPS and the simcom module we ignore that decision and make the OVMS do what we want it to do, i.e. let it control the user. So by having this the OVMS acts a lot like a commercial product which does stuff you do not want it to do, even though you tell it not to, like Windows updating your PC when you don't want it to, or Android (the Google App to be specific) telling your Location to google when you don't want it to.

In the end, what do we really gain from it? What's the advantage of force enabling gps & simcom?