### PR TITLE
Display partition image versions on the Firmware setup page and ota status output

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
+++ b/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
@@ -51,6 +51,7 @@ static const char *TAG = "ota";
 #include "ovms_buffer.h"
 #include "ovms_boot.h"
 #include "ovms_netmanager.h"
+#include "ovms_version.h"
 #include "crypt_md5.h"
 
 OvmsOTA MyOTA __attribute__ ((init_priority (4400)));
@@ -83,16 +84,26 @@ int buildverscmp(std::string v1, std::string v2)
 void ota_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
   ota_info info;
+  std::string version;
   int len = 0;
   bool check_update = (strcmp(cmd->GetName(), "status")==0);
   MyOTA.GetStatus(info, check_update);
 
+  if (info.version_firmware != "")
+    len += writer->printf("Firmware:          %s\n", info.version_firmware.c_str());
   if (info.partition_running != "")
     len += writer->printf("Running partition: %s\n", info.partition_running.c_str());
   if (info.partition_boot != "")
     len += writer->printf("Boot partition:    %s\n", info.partition_boot.c_str());
-  if (info.version_firmware != "")
-    len += writer->printf("Firmware:          %s\n", info.version_firmware.c_str());
+  version = GetOVMSPartitionVersion(ESP_PARTITION_SUBTYPE_APP_FACTORY);
+  if (version != "")
+      len += writer->printf("Factory image:     %s\n", version.c_str());
+  version = GetOVMSPartitionVersion(ESP_PARTITION_SUBTYPE_APP_OTA_0);
+  if (version != "")
+      len += writer->printf("OTA_O image:       %s\n", version.c_str());
+  version = GetOVMSPartitionVersion(ESP_PARTITION_SUBTYPE_APP_OTA_1);
+  if (version != "")
+      len += writer->printf("OTA_1 image:       %s\n", version.c_str());
   if (info.version_server != "")
     {
     len += writer->printf("Server Available:  %s%s\n", info.version_server.c_str(),

--- a/vehicle/OVMS.V3/main/ovms_version.cpp
+++ b/vehicle/OVMS.V3/main/ovms_version.cpp
@@ -40,9 +40,6 @@ static const char *TAG = "version";
 #include "metrics_standard.h"
 #include "ovms_events.h"
 
-#define OVMS_VERSION_PREFIX "########OVMS_PRE########"
-#define OVMS_VERSION_POSTFIX "########OVMSPOST########"
-
 std::string GetOVMSVersion()
   {
   std::string searchversion(OVMS_VERSION_PREFIX OVMS_VERSION OVMS_VERSION_POSTFIX);

--- a/vehicle/OVMS.V3/main/ovms_version.cpp
+++ b/vehicle/OVMS.V3/main/ovms_version.cpp
@@ -31,14 +31,93 @@
 #include "ovms_log.h"
 static const char *TAG = "version";
 
-#include <esp_system.h>
+#include <esp_image_format.h>
 #include <esp_ota_ops.h>
+#include <esp_system.h>
 #include "ovms.h"
 #include "ovms_version.h"
 #include "ovms_config.h"
 #include "ovms_metrics.h"
 #include "metrics_standard.h"
 #include "ovms_events.h"
+
+
+std::string GetOVMSPartitionVersion(esp_partition_subtype_t t)
+  {
+  int i, len;
+  size_t offset;
+  size_t n, size;
+  char *cp, *cp2, *buf2;
+  std::string version;
+  const esp_partition_t *p;
+  esp_image_header_t *pfhdr;
+  esp_image_segment_header_t *header;
+  char buf[512 + 1];
+  const char prefix[] = OVMS_VERSION_PREFIX;
+  const char postfix[] = OVMS_VERSION_POSTFIX;
+
+  /* Find the partition detail */
+  p = esp_partition_find_first(ESP_PARTITION_TYPE_APP, t, NULL);
+  if (p == NULL)
+      return "";
+
+  /* Read image header */
+  pfhdr = (esp_image_header_t *)buf;
+  offset = 0;
+  if (esp_partition_read(p, offset, pfhdr, sizeof(*pfhdr)) != ESP_OK)
+      return "";
+  if (pfhdr->magic != ESP_IMAGE_HEADER_MAGIC)
+      return "";
+  if (pfhdr->segment_count > ESP_IMAGE_MAX_SEGMENTS)
+      return "";
+
+  /* Read the first segment header */
+  header = (esp_image_segment_header_t *)buf;
+  offset += sizeof(*pfhdr);
+  if (esp_partition_read(p, offset, header, sizeof(*header)) != ESP_OK)
+      return "";
+
+  /* Search for the version string */
+  offset += sizeof(*header);
+  len = header->data_len;
+  size = sizeof(buf) - 1;
+  buf2 = buf;
+  while (len > 0) {
+    n = size;
+    if (n > len)
+      n = len;
+    if (esp_partition_read(p, offset, buf2, n) != ESP_OK)
+      return "";
+    offset += n;
+
+    /* Insure EOS */
+    buf2[n] = '\0';
+    len -= n;
+
+    n = sizeof(buf) - (sizeof(prefix) + sizeof(postfix) - 2);
+    for (i = 0, cp = buf; i < n; ++i, ++cp) {
+      if (*cp != prefix[0])
+        continue;
+      if (strncmp(cp, prefix, sizeof(prefix) - 1) != 0)
+	continue;
+      cp2 = strstr(cp, postfix);
+      if (cp2 == NULL)
+	continue;
+      *cp2 = '\0';
+      cp += sizeof(prefix) - 1;
+      *cp2 = '\0';
+      version.assign(cp);
+      return version;
+    }
+
+    /* Shift the buffer left to avoid splitting the string */
+    n = (sizeof(buf) - 1) / 2;
+    buf2 = buf + n;
+    memcpy(buf, buf2, n);
+    size = n;
+  }
+  return "";
+  }
 
 std::string GetOVMSVersion()
   {

--- a/vehicle/OVMS.V3/main/ovms_version.h
+++ b/vehicle/OVMS.V3/main/ovms_version.h
@@ -33,11 +33,14 @@
 
 #include <string>
 
+#include <esp_partition.h>
+
 #define OVMS_VERSION_PREFIX "########OVMS_PRE########"
 #define OVMS_VERSION_POSTFIX "########OVMSPOST########"
 
 extern std::string GetOVMSVersion();
 extern std::string GetOVMSBuild();
 extern std::string GetOVMSHardware();
+extern std::string GetOVMSPartitionVersion(esp_partition_subtype_t);
 
 #endif //#ifndef __VFS_H__

--- a/vehicle/OVMS.V3/main/ovms_version.h
+++ b/vehicle/OVMS.V3/main/ovms_version.h
@@ -33,6 +33,9 @@
 
 #include <string>
 
+#define OVMS_VERSION_PREFIX "########OVMS_PRE########"
+#define OVMS_VERSION_POSTFIX "########OVMSPOST########"
+
 extern std::string GetOVMSVersion();
 extern std::string GetOVMSBuild();
 extern std::string GetOVMSHardware();


### PR DESCRIPTION
Add GetOVMSPartitionVersion() to ovms_version.cpp which returns the OVMS versions for the specified partition (if possible). Change ota_status() and OvmsWebServer::HandleCfgFirmware() to display image versions for each partition.