### PR TITLE
Fix build on FreeBSD and quiet lexer compile warnings

### DIFF
--- a/vehicle/OVMS.V3/components/dbc/component.mk
+++ b/vehicle/OVMS.V3/components/dbc/component.mk
@@ -9,6 +9,12 @@
 
 ifdef CONFIG_OVMS_COMP_RE_TOOLS
 
+ifeq ($(HOSTTYPE), FreeBSD)
+YACC=	bison
+else
+YACC=	yacc
+endif
+
 COMPONENT_ADD_INCLUDEDIRS:=src yacclex
 COMPONENT_SRCDIRS:=src yacclex
 COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive
@@ -20,7 +26,7 @@ $(COMPONENT_PATH)/yacclex/dbc_tokeniser.c : $(COMPONENT_PATH)/src/dbc_tokeniser.
 	lex -o $(COMPONENT_PATH)/yacclex/dbc_tokeniser.c $(COMPONENT_PATH)/src/dbc_tokeniser.l
 
 $(COMPONENT_PATH)/yacclex/dbc_parser.hpp : $(COMPONENT_PATH)/src/dbc_parser.y
-	yacc -o $(COMPONENT_PATH)/yacclex/dbc_parser.cpp -d $(COMPONENT_PATH)/src/dbc_parser.y
+	$(YACC) -o $(COMPONENT_PATH)/yacclex/dbc_parser.cpp -d $(COMPONENT_PATH)/src/dbc_parser.y
 
 dbc.o: \
 	$(COMPONENT_PATH)/yacclex/dbc_tokeniser.c \

--- a/vehicle/OVMS.V3/components/dbc/src/dbc_tokeniser.l
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc_tokeniser.l
@@ -36,6 +36,9 @@
 #include <stdio.h>
 #include <string.h>
 #include "dbc_parser.hpp"
+
+#define YY_NO_INPUT
+#define YY_NO_UNPUT
 %}
 
 %option yylineno


### PR DESCRIPTION
FreeBSD uses Berkeley Yacc (byacc) but we need to use bison. It might be better to define YACC (and LEX) at a higher level in case other lex and modules are added but I don't understand how to do that with gmake.

While we're here quiet flex "defined but not used" yyunput and input warnings in dbc_tokeniser.l.