### PR TITLE
Nissan Leaf: prevent v.e.on from going stale

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -170,9 +170,8 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_car_on(bool isOn)
   {
   if (isOn && !StandardMetrics.ms_v_env_on->AsBool())
     {
-    // Car is ON
-    StandardMetrics.ms_v_env_on->SetValue(true);
-    PollSetState(1);
+    // Log once that car is being turned on
+    ESP_LOGI(TAG,"CAR IS ON");
 
     // Reset trip values
     StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
@@ -180,10 +179,13 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_car_on(bool isOn)
     }
   else if (!isOn && StandardMetrics.ms_v_env_on->AsBool())
     {
-    // Car is OFF
-    StandardMetrics.ms_v_env_on->SetValue(false);
-    PollSetState(0);
+    // Log once that car is being turned off
+    ESP_LOGI(TAG,"CAR IS OFF");
     }
+
+  // Always set this value to prevent it from going stale
+  StandardMetrics.ms_v_env_on->SetValue(isOn);
+  PollSetState( (isOn) ? 1 : 0 );
   }
 
 ////////////////////////////////////////////////////////////////////////

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -483,6 +483,18 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
 
   switch (p_frame->MsgID)
     {
+    case 0x1da:
+    {
+      // Signed value, negative for reverse
+      // Values 0x7fff and 0x7ffe are seen during turning on of car
+      int16_t nl_rpm = (int16_t)( d[4] << 8 | d[5] );
+      if (nl_rpm != 0x7fff &&
+          nl_rpm != 0x7ffe)
+        {
+        StandardMetrics.ms_v_mot_rpm->SetValue(nl_rpm/2);
+        }
+    }
+      break;
     case 0x1db:
     {
       // sent by the LBC, measured inside the battery box


### PR DESCRIPTION
Originally the metric would be continuously set during a drive. 
A recent code change from me made that this was only done once as the car was turned on/off. However, the unintended result is that the metric will go stale during the drive.

Now adapted the code so that initializations for going into drive mode are only done once while the metric is continuously refreshed.