### PR TITLE
Add support for 33.333kHz and 83.333kHz single wire can speeds.

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/can.h
+++ b/vehicle/OVMS.V3/components/can/src/can.h
@@ -72,12 +72,18 @@ typedef enum
 // CAN link speed (100kbps -> 1MHz)
 typedef enum
   {
+  CAN_SPEED_33KBPS=33,       // CAN Node runs at 33.333kBit/s
+  CAN_SPEED_83KBPS=83,       // CAN Node runs at 83.333kBit/s
   CAN_SPEED_100KBPS=100,     // CAN Node runs at 100kBit/s
   CAN_SPEED_125KBPS=125,     // CAN Node runs at 125kBit/s
   CAN_SPEED_250KBPS=250,     // CAN Node runs at 250kBit/s
   CAN_SPEED_500KBPS=500,     // CAN Node runs at 500kBit/s
   CAN_SPEED_1000KBPS=1000    // CAN Node runs at 1000kBit/s
   } CAN_speed_t;
+
+/* Map CAN_speed_t to a Bit/s value */
+#define MAP_CAN_SPEED(s) \
+    ((s) > CAN_SPEED_83KBPS ? (((int)(s)) * 1000) : ((((int)(s)) * 1000) + 333))
 
 // CAN frame type (standard/extended)
 typedef enum

--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -163,6 +163,17 @@ esp32can::~esp32can()
 
 esp_err_t esp32can::Start(CAN_mode_t mode, CAN_speed_t speed)
   {
+  switch (speed)
+    {
+    case CAN_SPEED_33KBPS:
+    case CAN_SPEED_83KBPS:
+      /* XXX not yet */
+      ESP_LOGW(TAG,"%d not supported",speed);
+      return ESP_FAIL;
+    default:
+      break;
+    }
+
   canbus::Start(mode, speed);
 
   double __tq; // Time quantum

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -120,6 +120,12 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
   uint8_t cnf3 = 0;
   switch (m_speed)
     {
+    case CAN_SPEED_33KBPS:
+      cnf1=0x09; cnf2=0xbe; cnf3=0x07;
+      break;
+    case CAN_SPEED_83KBPS:
+      cnf1=0x03; cnf2=0xbe; cnf3=0x07;
+      break;
     case CAN_SPEED_100KBPS:
       cnf1=0x03; cnf2=0xfa; cnf3=0x87;
       break;


### PR DESCRIPTION
Only the ESP2515 can buses are supported right now so disallow these speeds with esp32can. Finally, detect and report when "can canN start" fails.