### PR TITLE
Fix for Kia e-Niro

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_kianiroev/src/kn_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kianiroev/src/kn_can_poll.cpp
@@ -120,6 +120,10 @@ void OvmsVehicleKiaNiroEv::IncomingAirCon(canbus* bus, uint16_t type, uint16_t p
 				StdMetrics.ms_v_env_temp->SetValue((data[3]/2.0)-40, Celcius);
 				StdMetrics.ms_v_env_cabintemp->SetValue((data[2]/2.0)-40, Celcius);
 				}
+			if (m_poll_ml_frame == 4)
+				{
+				StdMetrics.ms_v_pos_speed->SetValue(CAN_BYTE(5)); //Speed moved to here --TP
+				}
 			break;
 
 		case 0x0102:
@@ -233,7 +237,7 @@ void OvmsVehicleKiaNiroEv::IncomingVMCU(canbus* bus, uint16_t type, uint16_t pid
 				else if(m_poll_ml_frame==2)
 					{
 					//StdMetrics.ms_v_pos_speed->SetValue(CAN_UINT(2)/100.0);
-					StdMetrics.ms_v_pos_speed->SetValue(CAN_UINT(1)/10.0); // Alex said the other one was wrong. Maybe this is correct?
+					//StdMetrics.ms_v_pos_speed->SetValue(CAN_UINT(1)/10.0); // Alex said the other one was wrong. Maybe this is correct? No speed is in 7b3 220100 frame 4 Byte 5
 					}
 				}
 			break;

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
@@ -142,6 +142,7 @@ protected:
   uint32_t kia_battery_cum_charge; 						//Cumulated charge power
   uint32_t kia_battery_cum_discharge; 					//Cumulated discharge power
   uint32_t kia_battery_cum_op_time; 						//Cumulated operating time
+  uint32_t kia_last_battery_cum_charge;					
 
   float kia_obc_ac_voltage;
   float kia_obc_ac_current;
@@ -149,6 +150,7 @@ protected:
   float kia_last_soc;
   float kia_last_ideal_range;
   float kia_cum_charge_start; 		// Used to calculate charged power.
+  
 
   bool kia_ready_for_chargepollstate;
   bool kia_check_door_lock;


### PR DESCRIPTION
Fix for Kia e-Niro hangs OVMS when car is off and no charging.
Fix for speed reading.
Wake up polling when car starts to charge again.