### PR TITLE
PowerMgmt: New Power Management module

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -44,6 +44,11 @@ Open Vehicle Monitor System v3 - Change log
   New metrics:
     xrt.cfg.applied   -- yes = tuning has been applied to SEVCON
     xrt.cfg.ws        -- tuning profile loaded into working set
+- Powermgmt: New automatic power management module
+  Configuration via Web UI
+  Switch off SIMCOM and WiFi after certain (configurable) time period of idling/non-charging of 12V battery has lapsed.
+  Turn on previously switched off modules if 12V charging is initiated.
+  If 12V battery alert is received, shut down all the modules and OVMS after certain configurable grace period (default 30 minutes)
 
 2019-09-19 MWJ  3.2.005  OTA release
 - Default module/debug.tasks to FALSE

--- a/vehicle/OVMS.V3/components/powermgmt/component.mk
+++ b/vehicle/OVMS.V3/components/powermgmt/component.mk
@@ -1,0 +1,11 @@
+#
+# Main component makefile.
+#
+# This Makefile can be left empty. By default, it will take the sources in the
+# src/ directory, compile them and link them into lib(subdirectory_name).a
+# in the build directory. This behaviour is entirely configurable,
+# please read the ESP-IDF documents if you need to do this.
+#
+
+COMPONENT_ADD_INCLUDEDIRS := .
+COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive

--- a/vehicle/OVMS.V3/components/powermgmt/powermgmt.cpp
+++ b/vehicle/OVMS.V3/components/powermgmt/powermgmt.cpp
@@ -98,14 +98,14 @@ void powermgmt::Ticker1(std::string event, void* data)
 #ifdef CONFIG_OVMS_COMP_WIFI
       if (m_wifi_off)
         {
-        MyPeripherals->m_esp32wifi->SetPowerMode(Off);
+        MyPeripherals->m_esp32wifi->SetPowerMode(On);
         m_wifi_off = false;
         }
 #endif
 #ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
       if (m_modem_off)
         {
-        MyPeripherals->m_simcom->SetPowerMode(Off);
+        MyPeripherals->m_simcom->SetPowerMode(On);
         m_modem_off = false;
         }
 #endif

--- a/vehicle/OVMS.V3/components/powermgmt/powermgmt.cpp
+++ b/vehicle/OVMS.V3/components/powermgmt/powermgmt.cpp
@@ -1,0 +1,185 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Module:        Power Management Webserver
+;    Date:          3rd September 2019
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2019        Marko Juhanne
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#include "ovms_log.h"
+static const char *TAG = "powermgmt";
+#include "ovms_events.h"
+#include "ovms_config.h"
+#include "powermgmt.h"
+#include "ovms_peripherals.h"
+#include "metrics_standard.h"
+
+powermgmt MyPowerMgmt __attribute__ ((init_priority (8500)));
+
+powermgmt::powermgmt()
+  {
+  ESP_LOGI(TAG, "Initialising POWERMGMT (8500)");
+
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  MyEvents.RegisterEvent(TAG, "ticker.1", std::bind(&powermgmt::Ticker1, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "config.changed", std::bind(&powermgmt::ConfigChanged, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "config.mounted", std::bind(&powermgmt::ConfigChanged, this, _1, _2));
+
+  m_enabled = false;
+  m_notcharging_timer = 0;
+  m_12v_alert_timer = 0;
+  m_charging = false;
+  m_modem_off = false;
+  m_wifi_off = false;
+
+  MyConfig.RegisterParam("power", "Power management", true, true);
+  ConfigChanged("config.mounted", NULL);
+
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+  WebInit();
+#endif  
+  }
+
+powermgmt::~powermgmt()
+  {
+ #ifdef CONFIG_OVMS_COMP_WEBSERVER
+  WebCleanup();
+#endif  
+ }
+
+void powermgmt::ConfigChanged(std::string event, void* data)
+  {
+  OvmsConfigParam* param = (OvmsConfigParam*) data;
+
+  // read vehicle framework config:
+  if (!param || param->GetName() == "power")
+    {
+    m_enabled = MyConfig.GetParamValueBool("power", "enabled", false);
+    m_modemoff_delay = MyConfig.GetParamValueInt("power", "modemoff_delay", POWERMGMT_MODEMOFF_DELAY);
+    m_wifioff_delay = MyConfig.GetParamValueInt("power", "wifioff_delay", POWERMGMT_WIFIOFF_DELAY);
+    m_12v_shutdown_delay = MyConfig.GetParamValueInt("power", "12v_shutdown_delay", POWERMGMT_12V_SHUTDOWN_DELAY);
+    }
+  }
+
+void powermgmt::Ticker1(std::string event, void* data)
+  {
+  if (!m_charging)
+    m_notcharging_timer++;
+  
+  if (StandardMetrics.ms_v_env_charging12v->AsBool())
+    {
+    if (!m_charging)
+      {
+      ESP_LOGI(TAG,"Charging 12V battery..");
+      m_charging=true;
+      // Turn on WiFi and modem if they were previously turned off by us
+#ifdef CONFIG_OVMS_COMP_WIFI
+      if (m_wifi_off)
+        {
+        MyPeripherals->m_esp32wifi->SetPowerMode(Off);
+        m_wifi_off = false;
+        }
+#endif
+#ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
+      if (m_modem_off)
+        {
+        MyPeripherals->m_simcom->SetPowerMode(Off);
+        m_modem_off = false;
+        }
+#endif
+      }
+    } 
+  else
+    {
+    if (m_charging)
+      {
+      ESP_LOGI(TAG,"No longer charging 12V battery..");
+      m_charging=false;
+      m_notcharging_timer=0;
+      }
+    }
+
+  if (!m_enabled)
+    return;
+
+#ifdef CONFIG_OVMS_COMP_WIFI
+  if (m_notcharging_timer > m_wifioff_delay*60*60) // hours to seconds
+    {
+    if (MyPeripherals->m_esp32wifi->GetPowerMode()==On)
+      {
+      ESP_LOGW(TAG,"Powering off wifi");
+      MyEvents.SignalEvent("powermgmt.wifi.off",NULL);
+      vTaskDelay(500 / portTICK_PERIOD_MS); // make sure all notifications all transmitted before powerring down WiFI 
+      MyPeripherals->m_esp32wifi->SetPowerMode(Off);
+      m_wifi_off = true;
+      }
+    }
+#endif
+
+#ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
+  if (m_notcharging_timer > m_modemoff_delay*60*60) // hours to seconds
+    {
+    if (MyPeripherals->m_simcom->GetPowerMode()==On)
+      {
+      ESP_LOGW(TAG,"Powering off modem");
+      MyEvents.SignalEvent("powermgmt.modem.off",NULL);
+      vTaskDelay(500 / portTICK_PERIOD_MS); // make sure all notifications all transmitted before powerring down modem 
+      MyPeripherals->m_simcom->SetPowerMode(Off);
+      m_modem_off = true;
+      }
+    }
+#endif
+
+  if (StandardMetrics.ms_v_bat_12v_voltage_alert->AsBool())
+    {
+    m_12v_alert_timer++;
+    if (m_12v_alert_timer > m_12v_shutdown_delay*60) // minutes to seconds
+      {
+      ESP_LOGE(TAG,"Ongoing 12V battery alert time limit exceeded! Shutting down OVMS..");
+      MyEvents.SignalEvent("powermgmt.ovms.shutdown",NULL);
+      vTaskDelay(500 / portTICK_PERIOD_MS); // make sure all notifications all transmitted before powerring down OVMS
+#ifdef CONFIG_OVMS_COMP_WIFI
+      MyPeripherals->m_esp32wifi->SetPowerMode(Off);
+#endif
+#ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
+      MyPeripherals->m_simcom->SetPowerMode(Off);
+#endif
+#ifdef CONFIG_OVMS_COMP_EXTERNAL_SWCAN
+      MyPeripherals->m_mcp2515_swcan->SetPowerMode(Off);
+#endif
+#ifdef CONFIG_OVMS_COMP_ESP32CAN
+      MyPeripherals->m_esp32can->SetPowerMode(Off);
+#endif
+#ifdef CONFIG_OVMS_COMP_EXT12V
+      MyPeripherals->m_ext12v->SetPowerMode(Off);
+#endif
+      MyPeripherals->m_esp32->SetPowerMode(DeepSleep);      
+      }
+    }
+  else
+    {
+    m_12v_alert_timer = 0;
+    }
+  }

--- a/vehicle/OVMS.V3/components/powermgmt/powermgmt.h
+++ b/vehicle/OVMS.V3/components/powermgmt/powermgmt.h
@@ -42,7 +42,7 @@
 // Defaults
 #define POWERMGMT_MODEMOFF_DELAY      96 // hours
 #define POWERMGMT_WIFIOFF_DELAY       24 // hours
-#define POWERMGMT_12V_SHUTDOWN_DELAY  10 // minutes
+#define POWERMGMT_12V_SHUTDOWN_DELAY  30 // minutes
 
 class powermgmt
   {

--- a/vehicle/OVMS.V3/components/powermgmt/powermgmt.h
+++ b/vehicle/OVMS.V3/components/powermgmt/powermgmt.h
@@ -1,0 +1,85 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Module:        Power Management Webserver
+;    Date:          3rd September 2019
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2019        Marko Juhanne
+;;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#ifndef __POWERMGMT_H__
+#define __POWERMGMT_H__
+
+#include <sys/types.h>
+#include <string>
+#include <map>
+#include "ovms_command.h"
+
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+#include "ovms_webserver.h"
+#endif
+
+// Defaults
+#define POWERMGMT_MODEMOFF_DELAY      96 // hours
+#define POWERMGMT_WIFIOFF_DELAY       24 // hours
+#define POWERMGMT_12V_SHUTDOWN_DELAY  10 // minutes
+
+class powermgmt
+  {
+  public:
+    powermgmt();
+    virtual ~powermgmt();
+
+  public:
+    void Ticker1(std::string event, void* data);
+    void ConfigChanged(std::string event, void* data);
+
+  private:
+    bool m_enabled;
+    unsigned int m_notcharging_timer;
+    unsigned int m_12v_alert_timer;
+
+    unsigned int m_modemoff_delay;
+    unsigned int m_wifioff_delay;
+    unsigned int m_12v_shutdown_delay;
+    bool m_charging;
+    bool m_modem_off, m_wifi_off;
+
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+  // --------------------------------------------------------------------------
+  // Webserver subsystem
+  //  - implementation: powermgmt_web.(h,cpp)
+  // 
+  
+  public:
+    void WebInit();
+    void WebCleanup();
+    static void WebCfgPowerManagement(PageEntry_t& p, PageContext_t& c);
+
+#endif //CONFIG_OVMS_COMP_WEBSERVER
+
+  };
+
+extern powermgmt MyPowerMgmt;
+
+#endif //#ifndef __POWERMGMT_H__

--- a/vehicle/OVMS.V3/components/powermgmt/powermgmt_web.cpp
+++ b/vehicle/OVMS.V3/components/powermgmt/powermgmt_web.cpp
@@ -131,7 +131,7 @@ void powermgmt::WebCleanup()
   c.fieldset_end();
 
 #ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
-  c.input("number", "Delay before GSM modem is turned off", "modemoff_delay", modemoff_delay.c_str(), 
+  c.input("number", "Delay before SIMCOM modem is turned off", "modemoff_delay", modemoff_delay.c_str(), 
     "Default: " STR(POWERMGMT_MODEMOFF_DELAY) " hours",
     "<p>0 = disabled</p>",
     "min=\"1\" step=\"1\"", "hours");
@@ -143,7 +143,7 @@ void powermgmt::WebCleanup()
     "min=\"1\" step=\"1\"", "hours");
 
   c.input("number", "Delay before OVMS is shut down (after initial 12V battery level alert)", "12v_shutdown_delay", b12v_shutdown_delay.c_str(), 
-    "Default: " STR(POWERMGMT_12V_SHUTDOWN_DELAY) " hours",
+    "Default: " STR(POWERMGMT_12V_SHUTDOWN_DELAY) " minutes",
     "<p>If 12V battery is depleted under certain threshold, an alarm is set. OVMS waits this time period during which user can begin charging the batteries. "
     "If this period is exceeded without canceled alarm, OVMS will be shut down to prevent further battery depletion.</p>",
     "min=\"1\" step=\"1\"", "minutes");

--- a/vehicle/OVMS.V3/components/powermgmt/powermgmt_web.cpp
+++ b/vehicle/OVMS.V3/components/powermgmt/powermgmt_web.cpp
@@ -1,0 +1,158 @@
+/**
+ * Project:      Open Vehicle Monitor System
+ * Module:       Power Management Webserver
+ *
+ * (c) 2019      Marko Juhanne
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <sdkconfig.h>
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+
+#include "ovms_log.h"
+static const char *TAG = "powermgmt";
+#include "ovms_metrics.h"
+#include "ovms_config.h"
+#include "ovms_webserver.h"
+#include "powermgmt.h"
+
+using namespace std;
+
+#define _attr(text) (c.encode_html(text).c_str())
+#define _html(text) (c.encode_html(text).c_str())
+
+/**
+ * WebInit: register pages
+ */
+void powermgmt::WebInit()
+  {
+  MyWebServer.RegisterPage("/cfg/powermgmt", "Power management", WebCfgPowerManagement, PageMenu_Config, PageAuth_Cookie);
+  }
+
+void powermgmt::WebCleanup()
+  {
+  MyWebServer.DeregisterPage("/cfg/powermgmt");
+  }
+
+/**
+ * WebCfgPowerManagement: configure general parameters (URL /cfg/powermgmt)
+ */
+ void powermgmt::WebCfgPowerManagement(PageEntry_t& p, PageContext_t& c)
+  {
+  std::string error;
+  bool enabled;
+  std::string modemoff_delay, wifioff_delay, b12v_shutdown_delay;
+
+  if (c.method == "POST")
+    {
+    // process form submission:
+    enabled = (c.getvar("enabled") == "yes");
+#ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
+    modemoff_delay = c.getvar("modemoff_delay");
+#endif
+    wifioff_delay = c.getvar("wifioff_delay");
+    b12v_shutdown_delay = c.getvar("12v_shutdown_delay");
+
+    // check values
+    if (!modemoff_delay.empty()) 
+      {
+      if (modemoff_delay.find_first_not_of("0123456789") != std::string::npos)
+        error += "<li data-input=\"user_key\">Invalid Modem off delay!</li>";
+
+      if (wifioff_delay.find_first_not_of("0123456789") != std::string::npos)
+        error += "<li data-input=\"user_key\">Invalid WiFi off delay!</li>";
+
+      if (b12v_shutdown_delay.find_first_not_of("0123456789") != std::string::npos)
+        error += "<li data-input=\"user_key\">Invalid shutdown delay!</li>";
+      }
+
+
+    if (error == "")
+      {
+      // store:
+      MyConfig.SetParamValueBool("power", "enabled", enabled);
+#ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
+      MyConfig.SetParamValue("power", "modemoff_delay", modemoff_delay);
+#endif
+      MyConfig.SetParamValue("power", "wifioff_delay", wifioff_delay);
+      MyConfig.SetParamValue("power", "12v_shutdown_delay", b12v_shutdown_delay);
+
+      c.head(200);
+      c.alert("success", "<p class=\"lead\">Power management configuration saved.</p>");
+      MyWebServer.OutputHome(p, c);
+      c.done();
+      return;
+      }
+
+    // output error, return to form:
+    error = "<p class=\"lead\">Error!</p><ul class=\"errorlist\">" + error + "</ul>";
+    c.head(400);
+    c.alert("danger", error.c_str());
+    }
+  else 
+    {
+    // read configuration:
+    enabled = MyConfig.GetParamValueBool("power", "enabled", false);
+#ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
+    modemoff_delay = MyConfig.GetParamValue("power", "modemoff_delay", STR(POWERMGMT_MODEMOFF_DELAY));
+#endif
+    wifioff_delay = MyConfig.GetParamValue("power", "wifioff_delay", STR(POWERMGMT_WIFIOFF_DELAY)); 
+    b12v_shutdown_delay = MyConfig.GetParamValue("power", "12v_shutdown_delay", STR(POWERMGMT_12V_SHUTDOWN_DELAY)); 
+
+    c.head(200);
+    }
+
+  // generate form
+  c.panel_start("primary", "Power management configuration");
+  c.form_start(p.uri);
+
+  c.input_checkbox("Enable automatic power management", "enabled", enabled,
+    "<p>Most electric cars have a small 12V battery which could get depleted if OVMS is left active for long periods (weeks) without charging. "
+    "12V battery usually is charged concurrently with the larger main battery or when the drive train is enabled and the Auxiliary Power Module provides "
+    "electricity from the main battery to 12V peripherals. If power saving features are enabled, some modules can be switched off after certain time period of "
+    "inactivity (non charging)</p>");
+  c.fieldset_end();
+
+#ifdef CONFIG_OVMS_COMP_MODEM_SIMCOM
+  c.input("number", "Delay before GSM modem is turned off", "modemoff_delay", modemoff_delay.c_str(), 
+    "Default: " STR(POWERMGMT_MODEMOFF_DELAY) " hours",
+    "<p>0 = disabled</p>",
+    "min=\"1\" step=\"1\"", "hours");
+#endif
+  
+  c.input("number", "Delay before WiFi is turned off", "wifioff_delay", wifioff_delay.c_str(), 
+    "Default: " STR(POWERMGMT_WIFIOFF_DELAY) " hours",
+    "<p>0 = disabled</p>",
+    "min=\"1\" step=\"1\"", "hours");
+
+  c.input("number", "Delay before OVMS is shut down (after initial 12V battery level alert)", "12v_shutdown_delay", b12v_shutdown_delay.c_str(), 
+    "Default: " STR(POWERMGMT_12V_SHUTDOWN_DELAY) " hours",
+    "<p>If 12V battery is depleted under certain threshold, an alarm is set. OVMS waits this time period during which user can begin charging the batteries. "
+    "If this period is exceeded without canceled alarm, OVMS will be shut down to prevent further battery depletion.</p>",
+    "min=\"1\" step=\"1\"", "minutes");
+
+  c.print("<hr>");
+  c.input_button("default", "Save");
+  c.form_end();
+  c.panel_end();
+  c.done();
+  }
+
+#endif //CONFIG_OVMS_COMP_WEBSERVER

--- a/vehicle/OVMS.V3/components/pushover/src/pushover.cpp
+++ b/vehicle/OVMS.V3/components/pushover/src/pushover.cpp
@@ -93,7 +93,6 @@ bool PushoverReaderFilterCallback(OvmsNotifyType* type, const char* subtype)
 
 
 Pushover::Pushover()
-  : pcp("pushover")
   {
   ESP_LOGI(TAG, "Initialising Pushover client (8800)");
 

--- a/vehicle/OVMS.V3/components/pushover/src/pushover.h
+++ b/vehicle/OVMS.V3/components/pushover/src/pushover.h
@@ -29,14 +29,13 @@
 #ifndef __PUSHOVER_H__
 #define __PUSHOVER_H__
 
-#include "pcp.h"
 #include "ovms_config.h"
 #include "ovms_notify.h"
 #include "ovms_buffer.h"
 #include <string>
 
 
-class Pushover : public pcp, public InternalRamAllocated
+class Pushover : public InternalRamAllocated
   {
   public:
     Pushover();

--- a/vehicle/OVMS.V3/components/swcan/src/swcan.cpp
+++ b/vehicle/OVMS.V3/components/swcan/src/swcan.cpp
@@ -144,6 +144,12 @@ esp_err_t swcan::Stop()
   {
   esp_err_t ret = mcp2515::Stop();
   SetTransceiverMode(tmode_sleep);
+
+  m_status_led->Set(false);
+  m_status_led->SetDefaultState(false);
+  m_tx_led->Set(false);
+  m_rx_led->Set(false);
+
   return ret;
   }
 

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -1261,7 +1261,8 @@ void OvmsVehicle::VehicleTicker1(std::string event, void* data)
       StandardMetrics.ms_v_bat_12v_voltage_ref->SetValue(StandardMetrics.ms_v_bat_12v_voltage->AsFloat());
       }
     }
-  else if ((m_ticker % 60) == 0)
+
+  if ((m_ticker % 60) == 0)
     {
     // check 12V voltage:
     float volt = StandardMetrics.ms_v_bat_12v_voltage->AsFloat();


### PR DESCRIPTION
- Configuration via Web UI
- Switch off SIMCOM and WiFi after certain (configurable) time period of idling/non-charging of 12V battery has lapsed.
- Turn on previously switched off modules if 12V charging is initiated.
- If 12V battery alert is received, shut down all the modules and OVMS after certain configurable grace period (default 30 minutes)
