### PR TITLE
Add 40kWh GIDS and AH defines

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -45,6 +45,8 @@
 #define GEN_1_WH_PER_GID 80
 #define GEN_1_30_NEW_CAR_GIDS 356
 #define GEN_1_30_NEW_CAR_AH 79
+#define GEN_2_40_NEW_CAR_GIDS 502
+#define GEN_2_40_NEW_CAR_AH 115
 #define REMOTE_COMMAND_REPEAT_COUNT 24 // number of times to send the remote command after the first time
 #define ACTIVATION_REQUEST_TIME 10 // tenths of a second to hold activation request signal
 


### PR DESCRIPTION
Add defines for 40kWh battery pack. These batteries are becoming more and more popular as a retrofit to older Leafs, so it's high time to add this to OVMS