### PR TITLE
Add 62kWh Leaf GIDS and AH defines

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -47,6 +47,8 @@
 #define GEN_1_30_NEW_CAR_AH 79
 #define GEN_2_40_NEW_CAR_GIDS 502
 #define GEN_2_40_NEW_CAR_AH 115
+#define GEN_2_62_NEW_CAR_GIDS 775
+#define GEN_2_62_NEW_CAR_AH 176
 #define REMOTE_COMMAND_REPEAT_COUNT 24 // number of times to send the remote command after the first time
 #define ACTIVATION_REQUEST_TIME 10 // tenths of a second to hold activation request signal
 


### PR DESCRIPTION
No UI changes yet, but it's good to have the defines ready. We'll be seeing 62kWh adopters of this app soon, especially since the Nissan app works so "intermittently" to say the least.