### PR TITLE
Set the Vehicle ID as the hostname for the DHCP request parameter

### DIFF
--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -863,10 +863,12 @@ void esp32wifi::EventWifiStaState(std::string event, void* data)
   {
   if (event == "system.wifi.sta.start")
     {
-      // Set hostname for DHCP request
-      std::string vehicleid = MyConfig.GetParamValue("vehicle", "id");
-      if (vehicleid.empty()) vehicleid = "ovms";
-      ESP_ERROR_CHECK(tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, vehicleid.c_str()));
+    // Set hostname for DHCP request
+    std::string vehicleid = MyConfig.GetParamValue("vehicle", "id");
+    if (vehicleid.empty()) vehicleid = "ovms";
+    if (ESP_OK != tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, vehicleid.c_str()))
+      ESP_LOGW(TAG, "failed to set hostname");
+
     AdjustTaskPriority();
     }
   }

--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -863,6 +863,10 @@ void esp32wifi::EventWifiStaState(std::string event, void* data)
   {
   if (event == "system.wifi.sta.start")
     {
+      // Set hostname for DHCP request
+      std::string vehicleid = MyConfig.GetParamValue("vehicle", "id");
+      if (vehicleid.empty()) vehicleid = "ovms";
+      ESP_ERROR_CHECK(tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, vehicleid.c_str()));
     AdjustTaskPriority();
     }
   }


### PR DESCRIPTION
This will make DNS in the DHCP server (as seen by tools like Fing) match what is seen in MDNS

Currently this shows up as "espressif" which is annoying if you have let the Internet-of-things take over your house and have many poorly named ESP devices.