### PR TITLE
Some non-invasive changes towards esp-idf v4.0

### DIFF
--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -417,7 +417,7 @@ void esp32wifi::SetPowerMode(PowerMode powermode)
       break;
     case Sleep:
       if (!m_poweredup) PowerUp();
-      esp_wifi_set_ps(WIFI_PS_MODEM);
+      esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
       break;
     case DeepSleep:
       if (!m_poweredup) PowerUp();


### PR DESCRIPTION
components/esp32wifi/src/esp32wifi.cpp
    Change from deprecated WIFI_PS_MODEM to WIFI_PS_MIN_MODEM in
    esp32wifi::SetPowerMode()

components/spinodma/spi_master_nodma.c
    Remove older spi_signal_conn_t struct definition and use the
    one in soc/spi_periph.h