### PR TITLE
Initial support for Mercedes B250E

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/component.mk
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/component.mk
@@ -1,0 +1,14 @@
+#
+# Main component makefile.
+#
+# This Makefile can be left empty. By default, it will take the sources in the
+# src/ directory, compile them and link them into lib(subdirectory_name).a
+# in the build directory. This behaviour is entirely configurable,
+# please read the ESP-IDF documents if you need to do this.
+#
+
+ifdef CONFIG_OVMS_VEHICLE_MERCEDESB250E
+COMPONENT_ADD_INCLUDEDIRS:=src
+COMPONENT_SRCDIRS:=src
+COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive
+endif

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -75,6 +75,17 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
   uint8_t *d = p_frame->data.u8;
    
   switch (p_frame->MsgID) {
+  case 0x203: // Wheel speeds
+    {
+      /* Using wheel speed for speedo meter, as I have not yet found a better number */
+      float fl_speed = ( ((d[0]&0xf) << 8) + d[1] ) * 0.0603504; 
+      float fr_speed = ( ((d[2]&0xf) << 8) + d[3] ) * 0.0603504; 
+      float rl_speed = ( ((d[4]&0xf) << 8) + d[5] ) * 0.0603504; 
+      float rr_speed = ( ((d[5]&0xf) << 8) + d[7] ) * 0.0603504; 
+      StandardMetrics.ms_v_pos_speed->SetValue(fl_speed); // HV Voltage
+      ESP_LOGD(TAG, "Speeds: FL %3d, FR %3d, RL %3d, RR %3d", (int)fl_speed, (int)fr_speed, (int)rl_speed, (int)rr_speed);
+      break;
+    }
   case 0x34F: // Range
     {
       StandardMetrics.ms_v_bat_range_est->SetValue((float)d[7]); // HV Voltage

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -1,0 +1,58 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th March 2017
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2017  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#include "ovms_log.h"
+static const char *TAG = "v-mercedesb250e";
+
+#include <stdio.h>
+#include "vehicle_mercedesb250e.h"
+
+OvmsVehicleMercedesB250e::OvmsVehicleMercedesB250e()
+  {
+  ESP_LOGI(TAG, "Generic MERCEDESB250E vehicle module");
+  }
+
+OvmsVehicleMercedesB250e::~OvmsVehicleMercedesB250e()
+  {
+  ESP_LOGI(TAG, "Shutdown MERCEDESB250E vehicle module");
+  }
+
+class OvmsVehicleMercedesB250eInit
+  {
+  public: OvmsVehicleMercedesB250eInit();
+} MyOvmsVehicleMercedesB250eInit  __attribute__ ((init_priority (9000)));
+
+OvmsVehicleMercedesB250eInit::OvmsVehicleMercedesB250eInit()
+  {
+  ESP_LOGI(TAG, "Registering Vehicle: MERCEDESB250E (9000)");
+
+  MyVehicleFactory.RegisterVehicle<OvmsVehicleMercedesB250e>("MERCEDESB250E","Empty vehicle");
+  }
+

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -75,6 +75,12 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
   uint8_t *d = p_frame->data.u8;
    
   switch (p_frame->MsgID) {
+  case 0x105: // Motor RPM
+    {
+      int rpm = ((d[0]&0x3f) << 8) + d[1]; 
+      StandardMetrics.ms_v_mot_rpm->SetValue(rpm); // 
+      break;
+    }
   case 0x19F: // Speedo
     {
       float speed = ( ((d[0]&0xf) << 8) + d[1] ) * 0.1; 

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -105,6 +105,11 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
       StandardMetrics.ms_v_bat_12v_voltage->SetValue(d[1]*0.1); // 
       break;
     }	
+  case 0x33D: // Momentary power
+    {
+      StandardMetrics.ms_v_bat_power->SetValue(d[4]-100); // kW 
+      break;
+    }	
     // case 0x34E: // Distance Today, Distance since reset
   case 0x34F: // Range
     {

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -85,7 +85,9 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
   case 0x19F: // Speedo
     {
       float speed = ( ((d[0]&0xf) << 8) + d[1] ) * 0.1; 
-      StandardMetrics.ms_v_pos_speed->SetValue(speed); // 
+      float odo   = ( (d[5] << 16) + (d[6] << 8) + (d[7]) ) * 0.1;
+      StandardMetrics.ms_v_pos_speed->SetValue(speed); // speed in km/h
+      StandardMetrics.ms_v_pos_odometer->SetValue(odo); // ODO km
       break;
     }
   case 0x203: // Wheel speeds
@@ -102,7 +104,7 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
     }
   case 0x205: // 12V battery voltage
     {
-      StandardMetrics.ms_v_bat_12v_voltage->SetValue(d[1]*0.1); // 
+      StandardMetrics.ms_v_bat_12v_voltage->SetValue(d[1]*0.1); // Volts
       break;
     }	
   case 0x33D: // Momentary power
@@ -110,7 +112,7 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
       StandardMetrics.ms_v_bat_power->SetValue(d[4]-100); // kW 
       break;
     }	
-    // case 0x34E: // Distance Today, Distance since reset
+    // case 0x34E: // Distance Today , Distance since reset, scale is 0.1 km
   case 0x34F: // Range
     {
       StandardMetrics.ms_v_bat_range_est->SetValue((float)d[7]); // Car's estimate on remainging range

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -78,7 +78,8 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
   case 0x105: // Motor RPM
     {
       int rpm = ((d[0]&0x3f) << 8) + d[1]; 
-      StandardMetrics.ms_v_mot_rpm->SetValue(rpm); // 
+      StandardMetrics.ms_v_mot_rpm->SetValue(rpm); // RPM
+      StandardMetrics.ms_v_env_throttle->SetValue(d[4]/2.50); // Drive pedal state [%]
       break;
     }
   case 0x19F: // Speedo

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -82,13 +82,23 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
       float fr_speed = ( ((d[2]&0xf) << 8) + d[3] ) * 0.0603504; 
       float rl_speed = ( ((d[4]&0xf) << 8) + d[5] ) * 0.0603504; 
       float rr_speed = ( ((d[5]&0xf) << 8) + d[7] ) * 0.0603504; 
-      StandardMetrics.ms_v_pos_speed->SetValue(fl_speed); // HV Voltage
+      float speed = (fl_speed + fr_speed + rl_speed + rr_speed) / 4; // Average of all four wheels :)
+      StandardMetrics.ms_v_pos_speed->SetValue(speed); // 
       ESP_LOGD(TAG, "Speeds: FL %3d, FR %3d, RL %3d, RR %3d", (int)fl_speed, (int)fr_speed, (int)rl_speed, (int)rr_speed);
       break;
     }
+  case 0x33D:
+    {
+      StandardMetrics.ms_v_bat_power->SetValue(d[4]-100); // Current power, direct watts, offset 100. 
+      ESP_LOGD(TAG, "POWER from %03x 8 %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
+      break;
+    }	
+    // case 0x34E: // Distance Today, Distance since reset
   case 0x34F: // Range
     {
-      StandardMetrics.ms_v_bat_range_est->SetValue((float)d[7]); // HV Voltage
+      StandardMetrics.ms_v_bat_range_est->SetValue((float)d[7]); // Car's estimate on remainging range
+      /* This is really an average, but let's move this when better is found*/
+      StandardMetrics.ms_v_bat_consumption->SetValue((float)d[1]*0.5/1.609344); // Consumption per distance
       ESP_LOGD(TAG, "Range from %03x 8 %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
       break;
     }

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -1,6 +1,6 @@
 /*
 ;    Project:       Open Vehicle Monitor System
-;    Date:          14th March 2017
+;    Date:          4th May 2020
 ;
 ;    Changes:
 ;    1.0  Initial release

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -75,6 +75,12 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
   uint8_t *d = p_frame->data.u8;
    
   switch (p_frame->MsgID) {
+  case 0x19F: // Speedo
+    {
+      float speed = ( ((d[0]&0xf) << 8) + d[1] ) * 0.1; 
+      StandardMetrics.ms_v_pos_speed->SetValue(speed); // 
+      break;
+    }
   case 0x203: // Wheel speeds
     {
       /* Using wheel speed for speedo meter, as I have not yet found a better number */
@@ -82,15 +88,14 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
       float fr_speed = ( ((d[2]&0xf) << 8) + d[3] ) * 0.0603504; 
       float rl_speed = ( ((d[4]&0xf) << 8) + d[5] ) * 0.0603504; 
       float rr_speed = ( ((d[5]&0xf) << 8) + d[7] ) * 0.0603504; 
-      float speed = (fl_speed + fr_speed + rl_speed + rr_speed) / 4; // Average of all four wheels :)
-      StandardMetrics.ms_v_pos_speed->SetValue(speed); // 
+      // Don't post it, as wheels may be spinning. 0x19F is the correct MsgID for speed
+      // StandardMetrics.ms_v_pos_speed->SetValue(fl_speed); // 
       ESP_LOGD(TAG, "Speeds: FL %3d, FR %3d, RL %3d, RR %3d", (int)fl_speed, (int)fr_speed, (int)rl_speed, (int)rr_speed);
       break;
     }
-  case 0x33D:
+  case 0x205: // 12V battery voltage
     {
-      StandardMetrics.ms_v_bat_power->SetValue(d[4]-100); // Current power, direct watts, offset 100. 
-      ESP_LOGD(TAG, "POWER from %03x 8 %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
+      StandardMetrics.ms_v_bat_12v_voltage->SetValue(d[1]*0.1); // 
       break;
     }	
     // case 0x34E: // Distance Today, Distance since reset

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
@@ -5,9 +5,7 @@
 ;    Changes:
 ;    1.0  Initial release
 ;
-;    (C) 2011       Michael Stegen / Stegen Electronics
-;    (C) 2011-2017  Mark Webb-Johnson
-;    (C) 2011        Sonny Chen @ EPRO/DX
+;    (C) 2020       Jarkko Ruoho
 ;
 ; Permission is hereby granted, free of charge, to any person obtaining a copy
 ; of this software and associated documentation files (the "Software"), to deal

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
@@ -1,0 +1,45 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th March 2017
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2017  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#ifndef __VEHICLE_MERCEDESB250E_H__
+#define __VEHICLE_MERCEDESB250E_H__
+
+#include "vehicle.h"
+
+using namespace std;
+
+class OvmsVehicleMercedesB250e : public OvmsVehicle
+  {
+  public:
+    OvmsVehicleMercedesB250e();
+    ~OvmsVehicleMercedesB250e();
+  };
+
+#endif //#ifndef __VEHICLE_MERCEDESB250E_H__

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
@@ -1,6 +1,6 @@
 /*
 ;    Project:       Open Vehicle Monitor System
-;    Date:          14th March 2017
+;    Date:          4th May 2020
 ;
 ;    Changes:
 ;    1.0  Initial release

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
@@ -40,6 +40,16 @@ class OvmsVehicleMercedesB250e : public OvmsVehicle
   public:
     OvmsVehicleMercedesB250e();
     ~OvmsVehicleMercedesB250e();
+
+  public:
+    void IncomingFrameCan1(CAN_frame_t* p_frame);
+
+  protected:
+    OvmsMetricFloat *mt_ed_eco_accel;             // eco score on acceleration over last 6 hours
+    OvmsMetricFloat *mt_ed_eco_const;             // eco score on constant driving over last 6 hours
+    OvmsMetricFloat *mt_ed_eco_coast;             // eco score on coasting over last 6 hours
+    OvmsMetricFloat *mt_ed_eco_score;             // eco score shown on dashboard over last 6 hours
+    
   };
 
 #endif //#ifndef __VEHICLE_MERCEDESB250E_H__

--- a/vehicle/OVMS.V3/main/Kconfig
+++ b/vehicle/OVMS.V3/main/Kconfig
@@ -372,11 +372,11 @@ config OVMS_VEHICLE_VWEUP
         Enable to include support for VW e-Up vehicle.
 
 config OVMS_VEHICLE_MERCEDESB250E
-    bool "Include support for base Mercedes-Benz B250E vehicle stub"
+    bool "Include support for Mercedes-Benz B250E (W242) vehicle"
     default n
     depends on OVMS
     help
-        Enable to include support for base NONE vehicle stub.
+        Enable to include support for Mercedes-Benz B250E (W242) vehicle.
 
 config OVMS_VEHICLE_RXTASK_STACK
     int "Stack size for vehicle RX task"

--- a/vehicle/OVMS.V3/main/Kconfig
+++ b/vehicle/OVMS.V3/main/Kconfig
@@ -371,6 +371,13 @@ config OVMS_VEHICLE_VWEUP
     help
         Enable to include support for VW e-Up vehicle.
 
+config OVMS_VEHICLE_MERCEDESB250E
+    bool "Include support for base Mercedes-Benz B250E vehicle stub"
+    default n
+    depends on OVMS
+    help
+        Enable to include support for base NONE vehicle stub.
+
 config OVMS_VEHICLE_RXTASK_STACK
     int "Stack size for vehicle RX task"
     default 6144


### PR DESCRIPTION
Passivel listener for CAN1.
Decodes only small set of messages, for example momentary power and ODO are found, but no SOC.
