### PR TITLE
Make some metrics persistent across warm reboots

### DIFF
--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -67,7 +67,7 @@ MetricsStandard::MetricsStandard()
   ms_v_type = new OvmsMetricString(MS_V_TYPE);
   ms_v_vin = new OvmsMetricString(MS_V_VIN);
 
-  ms_v_bat_soc = new OvmsMetricFloat(MS_V_BAT_SOC, SM_STALE_HIGH, Percentage);
+  ms_v_bat_soc = new OvmsMetricFloat(MS_V_BAT_SOC, SM_STALE_HIGH, Percentage, true);
   ms_v_bat_soh = new OvmsMetricFloat(MS_V_BAT_SOH, SM_STALE_HIGH, Percentage);
   ms_v_bat_cac = new OvmsMetricFloat(MS_V_BAT_CAC, SM_STALE_HIGH, AmpHours);
   ms_v_bat_health = new OvmsMetricString(MS_V_BAT_HEALTH, SM_STALE_HIGH);
@@ -136,11 +136,11 @@ MetricsStandard::MetricsStandard()
   ms_v_charge_duration_soc = new OvmsMetricInt(MS_V_CHARGE_DURATION_SOC, SM_STALE_MID, Minutes);
 
   ms_v_inv_temp = new OvmsMetricFloat(MS_V_INV_TEMP, SM_STALE_MID, Celcius);
-  ms_v_bat_temp = new OvmsMetricFloat(MS_V_BAT_TEMP, SM_STALE_MID, Celcius);
+  ms_v_bat_temp = new OvmsMetricFloat(MS_V_BAT_TEMP, SM_STALE_MID, Celcius, true);
   ms_v_mot_rpm = new OvmsMetricInt(MS_V_MOT_RPM, SM_STALE_MID);
-  ms_v_mot_temp = new OvmsMetricFloat(MS_V_MOT_TEMP, SM_STALE_MID, Celcius);
+  ms_v_mot_temp = new OvmsMetricFloat(MS_V_MOT_TEMP, SM_STALE_MID, Celcius, true);
   ms_v_charge_temp = new OvmsMetricFloat(MS_V_CHARGE_TEMP, SM_STALE_MID, Celcius);
-  ms_v_env_temp = new OvmsMetricFloat(MS_V_ENV_TEMP, SM_STALE_MID, Celcius);
+  ms_v_env_temp = new OvmsMetricFloat(MS_V_ENV_TEMP, SM_STALE_MID, Celcius, true);
   ms_v_env_cabintemp = new OvmsMetricFloat(MS_V_ENV_CABINTEMP, SM_STALE_MID, Celcius);
   ms_v_env_cabinfan = new OvmsMetricInt(MS_V_ENV_CABINFAN, SM_STALE_MID, Percentage);
   ms_v_env_cabinsetpoint = new OvmsMetricFloat(MS_V_ENV_CABINSETPOINT, SM_STALE_MID, Celcius);
@@ -188,17 +188,17 @@ MetricsStandard::MetricsStandard()
   ms_v_pos_speed = new OvmsMetricFloat(MS_V_POS_SPEED, SM_STALE_MID, Kph);
   ms_v_pos_acceleration = new OvmsMetricFloat(MS_V_POS_ACCELERATION, SM_STALE_MID, MetersPSS);
   ms_v_pos_gpsspeed = new OvmsMetricFloat(MS_V_POS_GPSSPEED, SM_STALE_MID, Kph);
-  ms_v_pos_odometer = new OvmsMetricFloat(MS_V_POS_ODOMETER, SM_STALE_MID, Kilometers);
+  ms_v_pos_odometer = new OvmsMetricFloat(MS_V_POS_ODOMETER, SM_STALE_MID, Kilometers, true);
   ms_v_pos_trip = new OvmsMetricFloat(MS_V_POS_TRIP, SM_STALE_MID, Kilometers);
 
-  ms_v_tpms_fl_t = new OvmsMetricFloat(MS_V_TPMS_FL_T, SM_STALE_MID, Celcius);
-  ms_v_tpms_fr_t = new OvmsMetricFloat(MS_V_TPMS_FR_T, SM_STALE_MID, Celcius);
-  ms_v_tpms_rr_t = new OvmsMetricFloat(MS_V_TPMS_RR_T, SM_STALE_MID, Celcius);
-  ms_v_tpms_rl_t = new OvmsMetricFloat(MS_V_TPMS_RL_T, SM_STALE_MID, Celcius);
-  ms_v_tpms_fl_p = new OvmsMetricFloat(MS_V_TPMS_FL_P, SM_STALE_MID, kPa);
-  ms_v_tpms_fr_p = new OvmsMetricFloat(MS_V_TPMS_FR_P, SM_STALE_MID, kPa);
-  ms_v_tpms_rr_p = new OvmsMetricFloat(MS_V_TPMS_RR_P, SM_STALE_MID, kPa);
-  ms_v_tpms_rl_p = new OvmsMetricFloat(MS_V_TPMS_RL_P, SM_STALE_MID, kPa);
+  ms_v_tpms_fl_t = new OvmsMetricFloat(MS_V_TPMS_FL_T, SM_STALE_MID, Celcius, true);
+  ms_v_tpms_fr_t = new OvmsMetricFloat(MS_V_TPMS_FR_T, SM_STALE_MID, Celcius, true);
+  ms_v_tpms_rr_t = new OvmsMetricFloat(MS_V_TPMS_RR_T, SM_STALE_MID, Celcius, true);
+  ms_v_tpms_rl_t = new OvmsMetricFloat(MS_V_TPMS_RL_T, SM_STALE_MID, Celcius, true);
+  ms_v_tpms_fl_p = new OvmsMetricFloat(MS_V_TPMS_FL_P, SM_STALE_MID, kPa, true);
+  ms_v_tpms_fr_p = new OvmsMetricFloat(MS_V_TPMS_FR_P, SM_STALE_MID, kPa, true);
+  ms_v_tpms_rr_p = new OvmsMetricFloat(MS_V_TPMS_RR_P, SM_STALE_MID, kPa, true);
+  ms_v_tpms_rl_p = new OvmsMetricFloat(MS_V_TPMS_RL_P, SM_STALE_MID, kPa, true);
   }
 
 MetricsStandard::~MetricsStandard()

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -119,7 +119,7 @@ extern float UnitConvert(metric_unit_t from, metric_unit_t to, float value);
 class OvmsMetric
   {
   public:
-    OvmsMetric(const char* name, uint16_t autostale=0, metric_unit_t units = Other);
+    OvmsMetric(const char* name, uint16_t autostale = 0, metric_unit_t units = Other, bool persist = false);
     virtual ~OvmsMetric();
 
   public:
@@ -160,7 +160,7 @@ class OvmsMetric
 class OvmsMetricBool : public OvmsMetric
   {
   public:
-    OvmsMetricBool(const char* name, uint16_t autostale=0, metric_unit_t units = Other);
+    OvmsMetricBool(const char* name, uint16_t autostale=0, metric_unit_t units = Other, bool persist = false);
     virtual ~OvmsMetricBool();
 
   public:
@@ -184,7 +184,7 @@ class OvmsMetricBool : public OvmsMetric
 class OvmsMetricInt : public OvmsMetric
   {
   public:
-    OvmsMetricInt(const char* name, uint16_t autostale=0, metric_unit_t units = Other);
+    OvmsMetricInt(const char* name, uint16_t autostale=0, metric_unit_t units = Other, bool persist = false);
     virtual ~OvmsMetricInt();
 
   public:
@@ -208,7 +208,7 @@ class OvmsMetricInt : public OvmsMetric
 class OvmsMetricFloat : public OvmsMetric
   {
   public:
-    OvmsMetricFloat(const char* name, uint16_t autostale=0, metric_unit_t units = Other);
+    OvmsMetricFloat(const char* name, uint16_t autostale=0, metric_unit_t units = Other, bool persist = false);
     virtual ~OvmsMetricFloat();
 
   public:
@@ -227,12 +227,13 @@ class OvmsMetricFloat : public OvmsMetric
 
   protected:
     float m_value;
+    float* m_valuep;
   };
 
 class OvmsMetricString : public OvmsMetric
   {
   public:
-    OvmsMetricString(const char* name, uint16_t autostale=0, metric_unit_t units = Other);
+    OvmsMetricString(const char* name, uint16_t autostale=0, metric_unit_t units = Other, bool persist = false);
     virtual ~OvmsMetricString();
 
   public:
@@ -257,8 +258,8 @@ template <size_t N, int startpos=1>
 class OvmsMetricBitset : public OvmsMetric
   {
   public:
-    OvmsMetricBitset(const char* name, uint16_t autostale=0, metric_unit_t units = Other)
-      : OvmsMetric(name, autostale, units)
+    OvmsMetricBitset(const char* name, uint16_t autostale=0, metric_unit_t units = Other, bool persist = false)
+      : OvmsMetric(name, autostale, units, persist)
       {
       }
     virtual ~OvmsMetricBitset()
@@ -370,8 +371,8 @@ template <typename ElemType>
 class OvmsMetricSet : public OvmsMetric
   {
   public:
-    OvmsMetricSet(const char* name, uint16_t autostale=0, metric_unit_t units = Other)
-      : OvmsMetric(name, autostale, units)
+    OvmsMetricSet(const char* name, uint16_t autostale=0, metric_unit_t units = Other, bool persist = false)
+      : OvmsMetric(name, autostale, units, persist)
       {
       }
     virtual ~OvmsMetricSet()
@@ -489,8 +490,8 @@ template
 class OvmsMetricVector : public OvmsMetric
   {
   public:
-    OvmsMetricVector(const char* name, uint16_t autostale=0, metric_unit_t units = Other)
-      : OvmsMetric(name, autostale, units)
+    OvmsMetricVector(const char* name, uint16_t autostale=0, metric_unit_t units = Other, bool persist = false)
+      : OvmsMetric(name, autostale, units, persist)
       {
       }
     virtual ~OvmsMetricVector()
@@ -687,12 +688,12 @@ class OvmsMetrics
     bool SetFloat(const char* metric, float value);
     OvmsMetric* Find(const char* metric);
 
-    OvmsMetricString *InitString(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other);
-    OvmsMetricInt *InitInt(const char* metric, uint16_t autostale=0, int value=0, metric_unit_t units = Other);
-    OvmsMetricBool *InitBool(const char* metric, uint16_t autostale=0, bool value=0, metric_unit_t units = Other);
-    OvmsMetricFloat *InitFloat(const char* metric, uint16_t autostale=0, float value=0, metric_unit_t units = Other);
+    OvmsMetricString *InitString(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other, bool persist = false);
+    OvmsMetricInt *InitInt(const char* metric, uint16_t autostale=0, int value=0, metric_unit_t units = Other, bool persist = false);
+    OvmsMetricBool *InitBool(const char* metric, uint16_t autostale=0, bool value=0, metric_unit_t units = Other, bool persist = false);
+    OvmsMetricFloat *InitFloat(const char* metric, uint16_t autostale=0, float value=0, metric_unit_t units = Other, bool persist = false);
     template <size_t N>
-    OvmsMetricBitset<N> *InitBitset(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other)
+    OvmsMetricBitset<N> *InitBitset(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other, bool persist = false)
       {
       OvmsMetricBitset<N> *m = (OvmsMetricBitset<N> *)Find(metric);
       if (m==NULL) m = new OvmsMetricBitset<N>(metric, autostale, units);
@@ -701,7 +702,7 @@ class OvmsMetrics
       return m;
       }
     template <typename ElemType>
-    OvmsMetricSet<ElemType> *InitSet(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other)
+    OvmsMetricSet<ElemType> *InitSet(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other, bool persist = false)
       {
       OvmsMetricSet<ElemType> *m = (OvmsMetricSet<ElemType> *)Find(metric);
       if (m==NULL) m = new OvmsMetricSet<ElemType>(metric, autostale, units);
@@ -710,7 +711,7 @@ class OvmsMetrics
       return m;
       }
     template <typename ElemType>
-    OvmsMetricVector<ElemType> *InitVector(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other)
+    OvmsMetricVector<ElemType> *InitVector(const char* metric, uint16_t autostale=0, const char* value=NULL, metric_unit_t units = Other, bool persist = false)
       {
       OvmsMetricVector<ElemType> *m = (OvmsMetricVector<ElemType> *)Find(metric);
       if (m==NULL) m = new OvmsMetricVector<ElemType>(metric, autostale, units);


### PR DESCRIPTION
Use the RTC_NOINIT_ATTR attribute to put some metrics in RTC slow memory
These persist across crashes, firmware updates, and warm reboots and
are zero'ed on cold reboots
This is only implemented for OvmsMetricFloat
Unrelated fix: puts() -> writer->puts() in metrics_list()