### PR TITLE
Persistent metrics improvements

### DIFF
--- a/docs/source/userguide/metrics.rst
+++ b/docs/source/userguide/metrics.rst
@@ -57,9 +57,15 @@ changes::
 
   OVMS# metrics ?
   list                 Show all metrics
+  persist              Show persistent metrics info
   set                  Set the value of a metric
   trace                METRIC trace framework
 
+Some metrics are presistent across warm reboots. This prevents
+values such as SOC from being lost when firmware is updated (or in
+the event of a crash). You can display these with ``metrics list
+-p`` and view general information about presistent metrics with
+``metrics persist``.
 
 ----------------
 Standard Metrics

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,8 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- #377 Make some metrics (e.g. v.b.soc) persistent across warm reboots
+  This includes crashes and firmware updates
 
 2020-05-31 MWJ  3.2.013 OTA release
 - TLS Trusted CA update (for addtrust/usertrust)

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -77,8 +77,8 @@ MetricsStandard::MetricsStandard()
   ms_v_bat_coulomb_recd = new OvmsMetricFloat(MS_V_BAT_COULOMB_RECD, SM_STALE_MID, AmpHours);
   ms_v_bat_power = new OvmsMetricFloat(MS_V_BAT_POWER, SM_STALE_MID, kW);
   ms_v_bat_consumption = new OvmsMetricFloat(MS_V_BAT_CONSUMPTION, SM_STALE_MID, WattHoursPK);
-  ms_v_bat_energy_used = new OvmsMetricFloat(MS_V_BAT_ENERGY_USED, SM_STALE_MID, kWh);
-  ms_v_bat_energy_recd = new OvmsMetricFloat(MS_V_BAT_ENERGY_RECD, SM_STALE_MID, kWh);
+  ms_v_bat_energy_used = new OvmsMetricFloat(MS_V_BAT_ENERGY_USED, SM_STALE_MID, kWh, true);
+  ms_v_bat_energy_recd = new OvmsMetricFloat(MS_V_BAT_ENERGY_RECD, SM_STALE_MID, kWh, true);
   ms_v_bat_range_full = new OvmsMetricFloat(MS_V_BAT_RANGE_FULL, SM_STALE_HIGH, Kilometers);
   ms_v_bat_range_ideal = new OvmsMetricFloat(MS_V_BAT_RANGE_IDEAL, SM_STALE_HIGH, Kilometers);
   ms_v_bat_range_est = new OvmsMetricFloat(MS_V_BAT_RANGE_EST, SM_STALE_HIGH, Kilometers);
@@ -135,13 +135,13 @@ MetricsStandard::MetricsStandard()
   ms_v_charge_duration_range = new OvmsMetricInt(MS_V_CHARGE_DURATION_RANGE, SM_STALE_MID, Minutes);
   ms_v_charge_duration_soc = new OvmsMetricInt(MS_V_CHARGE_DURATION_SOC, SM_STALE_MID, Minutes);
 
-  ms_v_inv_temp = new OvmsMetricFloat(MS_V_INV_TEMP, SM_STALE_MID, Celcius);
+  ms_v_inv_temp = new OvmsMetricFloat(MS_V_INV_TEMP, SM_STALE_MID, Celcius, true);
   ms_v_bat_temp = new OvmsMetricFloat(MS_V_BAT_TEMP, SM_STALE_MID, Celcius, true);
   ms_v_mot_rpm = new OvmsMetricInt(MS_V_MOT_RPM, SM_STALE_MID);
   ms_v_mot_temp = new OvmsMetricFloat(MS_V_MOT_TEMP, SM_STALE_MID, Celcius, true);
-  ms_v_charge_temp = new OvmsMetricFloat(MS_V_CHARGE_TEMP, SM_STALE_MID, Celcius);
+  ms_v_charge_temp = new OvmsMetricFloat(MS_V_CHARGE_TEMP, SM_STALE_MID, Celcius, true);
   ms_v_env_temp = new OvmsMetricFloat(MS_V_ENV_TEMP, SM_STALE_MID, Celcius, true);
-  ms_v_env_cabintemp = new OvmsMetricFloat(MS_V_ENV_CABINTEMP, SM_STALE_MID, Celcius);
+  ms_v_env_cabintemp = new OvmsMetricFloat(MS_V_ENV_CABINTEMP, SM_STALE_MID, Celcius, true);
   ms_v_env_cabinfan = new OvmsMetricInt(MS_V_ENV_CABINFAN, SM_STALE_MID, Percentage);
   ms_v_env_cabinsetpoint = new OvmsMetricFloat(MS_V_ENV_CABINSETPOINT, SM_STALE_MID, Celcius);
   ms_v_env_cabinintake = new OvmsMetricString(MS_V_ENV_CABININTAKE, SM_STALE_MID);

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -137,6 +137,7 @@ class OvmsMetric
     virtual uint32_t Age();
     virtual bool IsDefined();
     virtual bool IsFirstDefined();
+    virtual bool IsPersist();
     virtual bool IsStale();
     virtual void SetStale(bool stale);
     virtual void SetAutoStale(uint16_t seconds);
@@ -155,6 +156,7 @@ class OvmsMetric
     metric_unit_t m_units;
     metric_defined_t m_defined;
     bool m_stale;
+    bool m_persist;
   };
 
 class OvmsMetricBool : public OvmsMetric
@@ -224,6 +226,7 @@ class OvmsMetricFloat : public OvmsMetric
     void SetValue(std::string value);
     void SetValue(dbcNumber& value);
     void operator=(std::string value) { SetValue(value); }
+    virtual bool IsPersist();
 
   protected:
     float m_value;


### PR DESCRIPTION
Make some more metrics persistent as per Michael:
v.b.energy.used, v.b.energy.recd, v.c.temp, v.i.temp
Add v.e.cabintemp while we're at it
Check that persistent metric name fits in the field
Add -p to metrics_list() to limit output to just persistent metrics
and improve argument handling (e.g. "metrics list -vp v.p" works)
invalidate pmetrics by zero'ing magic instead of size ("metrics persist -r")
no need to increment pmetrics version since we changed the size
update changes.txt and add minimal documentation to the user guide