### PR TITLE
Reduce RTC persistent metrics reads of slow RAM

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -903,7 +903,7 @@ void OvmsMetricBool::SetValue(dbcNumber& value)
 OvmsMetricFloat::OvmsMetricFloat(const char* name, uint16_t autostale, metric_unit_t units, bool persist)
   : OvmsMetric(name, autostale, units, persist)
   {
-  m_value = 0;
+  m_value = 0.0;
   m_valuep = NULL;
   if (!persist)
     return;
@@ -927,12 +927,12 @@ OvmsMetricFloat::OvmsMetricFloat(const char* name, uint16_t autostale, metric_un
       ESP_LOGE(TAG, "persist name field too small for OvmsMetricFloat (%s)", name);
       return;
       }
-
     ++pmetrics.used;
     }
 
   m_valuep = &vp->value;
-  if (*m_valuep != 0.0)
+  m_value = *m_valuep;
+  if (m_value != 0.0)
     SetModified(true);
   ESP_LOGI(TAG, "persist %s = %s", name, AsUnitString("?", units).c_str());
   }
@@ -951,15 +951,10 @@ std::string OvmsMetricFloat::AsString(const char* defvalue, metric_unit_t units,
       ss.precision(precision); // Set desired precision
       ss << fixed;
       }
-    float pvalue;
-    if (m_valuep != NULL)
-      pvalue = *m_valuep;
-    else
-      pvalue = m_value;
     if ((units != Other)&&(units != m_units))
-      ss << UnitConvert(m_units,units,pvalue);
+      ss << UnitConvert(m_units,units,m_value);
     else
-      ss << pvalue;
+      ss << m_value;
     std::string s(ss.str());
     return s;
     }
@@ -981,15 +976,10 @@ float OvmsMetricFloat::AsFloat(const float defvalue, metric_unit_t units)
   {
   if (IsDefined())
     {
-    float pvalue;
-    if (m_valuep != NULL)
-      pvalue = *m_valuep;
-    else
-      pvalue = m_value;
     if ((units != Other)&&(units != m_units))
-      return UnitConvert(m_units,units,pvalue);
+      return UnitConvert(m_units,units,m_value);
     else
-      return pvalue;
+      return m_value;
     }
   else
     return defvalue;
@@ -1011,17 +1001,11 @@ void OvmsMetricFloat::SetValue(float value, metric_unit_t units)
   {
   float nvalue = value;
   if ((units != Other)&&(units != m_units)) nvalue=UnitConvert(units,m_units,value);
-  float pvalue;
-  if (m_valuep != NULL)
-    pvalue = *m_valuep;
-  else
-    pvalue = m_value;
-  if (pvalue != nvalue)
+  if (m_value != nvalue)
     {
+    m_value = nvalue;
     if (m_valuep != NULL)
-      *m_valuep = nvalue;
-    else
-      m_value = nvalue;
+      *m_valuep = m_value;
     SetModified(true);
     }
   else
@@ -1031,18 +1015,11 @@ void OvmsMetricFloat::SetValue(float value, metric_unit_t units)
 void OvmsMetricFloat::SetValue(std::string value)
   {
   float nvalue = atof(value.c_str());
-  float pvalue;
-  if (m_valuep != NULL)
-    pvalue = *m_valuep;
-  else
-    pvalue = m_value;
-  if (pvalue != nvalue)
+  if (m_value != nvalue)
     {
     m_value = nvalue;
     if (m_valuep != NULL)
-      *m_valuep = nvalue;
-    else
-      m_value = nvalue;
+      *m_valuep = m_value;
     SetModified(true);
     }
   else


### PR DESCRIPTION
Use the m_value field to cache it as suggested by Michael
(This actually cleans things up compared to pre-persistent metrics)