### PR TITLE
Faster Poller option when needed

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -122,10 +122,12 @@ class OvmsVehicle : public InternalRamAllocated
     canbus* m_can4;
 
   private:
+    bool m_only_one_poll_per_second;  // Poller sends only one poll per tick/second even when more polls are active for the current tick/second
     void VehicleTicker1(std::string event, void* data);
     void VehicleConfigChanged(std::string event, void* data);
     void PollerSend();
     void PollerReceive(CAN_frame_t* frame);
+    void IncomingPollReplyInternal(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain);
 
   protected:
     virtual void IncomingFrameCan1(CAN_frame_t* p_frame);
@@ -308,6 +310,7 @@ class OvmsVehicle : public InternalRamAllocated
   protected:
     void PollSetPidList(canbus* bus, const poll_pid_t* plist);
     void PollSetState(uint8_t state);
+    void PollSetState(uint8_t state, bool only_one_poll_per_second);
 
   // BMS helpers
   protected:


### PR DESCRIPTION
Currently the Poller sends a maximum of one poll per second/tick. Even when there are more than one poll to do in the particular second/tick.

Example for `OvmsVehicle::poll_pid_t vwup_polls[]`:        

    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_AC_U, {0, 0, 5}},
    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_AC_I, {0, 0, 5}},
    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_U, {0, 1, 5}},
    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_I, {0, 1, 5}},
    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_SOC, {0, 20, 20}},

The first 4 polls happen 1 second apart (taking 4 seconds in total) and the SOC poll comes in with a rough frequency of 42 seconds instead of 20.

I was expecting the first 4 polls go as fast as possible after each other and the SOC of course every 20 seconds.

My changes do exactly that but leaving the standard behaviour as is.

If active `PollerSend()` will be called immediately after the last incoming Poller reply was processed and no more data for this reply is expected.

If someone wants to active this in the vehicle-implementation just call `PollerSetState(state, false);`. So this behaviour can be conveniently changed with the Poller state.