### PR TITLE
fast-poller: take 2

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -124,6 +124,7 @@ class OvmsVehicle : public InternalRamAllocated
   private:
     void VehicleTicker1(std::string event, void* data);
     void VehicleConfigChanged(std::string event, void* data);
+    void PollerToNextEntry();
     void PollerSend(bool fromTicker);
     void PollerReceive(CAN_frame_t* frame);
     void IncomingPollReplyInternal(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain);
@@ -295,8 +296,7 @@ class OvmsVehicle : public InternalRamAllocated
     canbus*           m_poll_bus;             // Bus to poll on
     const poll_pid_t* m_poll_plist;           // Head of poll list
     const poll_pid_t* m_poll_plcur;           // Current position in poll list
-    const poll_pid_t* m_poll_plstart;         // Position the ticker started at
-    uint32_t          m_poll_ticker;          // Polling ticker
+    uint32_t          m_poll_ticker;          // Polling ticker: How many full cycles of list are done (max 3600 before reset)
     uint32_t          m_poll_moduleid_sent;   // ModuleID last sent
     uint32_t          m_poll_moduleid_low;    // Expected response moduleid low mark
     uint32_t          m_poll_moduleid_high;   // Expected response moduleid high mark


### PR DESCRIPTION
Here is my solution.

- With `PollerSetThrottling(0)` the poller does all polls for the current tick as fast as possible.
- `PollerSetThrottling(2)` splits all active polls for the tick into blocks of max(!) 2 and does one block per second.
- The Poller Tick gets increased every time the polls start from the top of the list.
- The Poller Tick must not equal the seconds passed. For example when the poller has to wait for a reply which even may time out.

**Above is tested** with 1) `PollerSetThrottling(0)`, 2) `PollerSetThrottling(1)` and 3) `PollerSetThrottling(2)` for the following poll lists:

a) One entry A with polltime=1
b) Two entries A, B with polltime=1 each
c) Three entries A, B, C with polltime=5 each
d) Three entries: A=5, B=10, C=10
e) with 2nd polltime entry of:

    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_U, {0, 1, 5}},
    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_I, {0, 1, 5}},
    // Same tick & order important of above 2: VWUP_BAT_MGMT_I calculates the power
    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_SOC, {0, 20, 20}},
    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_ENERGY_COUNTERS, {0, 20, 20}},

    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_CELL_MAX, {0, 20, 20}},
    {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_CELL_MIN, {0, 20, 20}},
    // Same tick & order important of above 2: VWUP_BAT_MGMT_CELL_MIN calculates the delta

    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIISESSION, VWUP_CHARGER_EXTDIAG, {0, 30, 30}},

    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_AC_U, {0, 0, 5}},
    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_AC_I, {0, 0, 5}},    
    // Same tick & order important of above 2: VWUP_CHARGER_AC_I calculates the AC power
    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_DC_U, {0, 0, 5}},
    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_DC_I, {0, 0, 5}},
    // Same tick & order important of above 2: VWUP_CHARGER_DC_I calculates the DC power
    // Same tick & order important of above 4: VWUP_CHARGER_DC_I calculates the power loss & efficiency

    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_POWER_EFF, {0, 5, 10}}, // 5 @ VWUP_ON to detect charging
    {VWUP_CHARGER_TX, VWUP_CHARGER_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_CHARGER_POWER_LOSS, {0, 0, 10}},

    {VWUP_MFD_TX, VWUP_MFD_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_MFD_ODOMETER, {0, 60, 60}},
    {0, 0, 0, 0, {0, 0, 0}}};

f) same as e) including wait timeout for two entries

**Results:**
1a), 2a), 3a): One poll each second
1b), 3b): Two polls every second
2b): One poll each second
1c): Polls A,B,C every 5 seconds
2c): 5th second: A. --- 6th: B. --- 7th: C. --- 8th: none. --- 9th none. --- 10th: A. ...
3c): 5th: A,B. --- 6th: C. --- 7th: none. --- 8th: none. --- 9th none. --- 10th: A,B. ...
...
1e): Every poll got executed in with the interval supplied (i.e. VWUP_BAT_MGMT_SOC every 20 seconds)

(Text is subject to typos, errors and fatigue)