### PR TITLE
NL: add obdrequest command by canbus and improve polling

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -969,6 +969,9 @@ OvmsVehicle::OvmsVehicle()
   m_poll_ml_offset = 0;
   m_poll_ml_frame = 0;
   m_poll_wait = 0;
+  m_poll_sequence_max = 1;
+  m_poll_sequence_cnt = 0;
+  m_poll_fc_septime = 25;       // response default timing: 25 milliseconds
 
   m_bms_voltages = NULL;
   m_bms_vmins = NULL;
@@ -1124,9 +1127,10 @@ void OvmsVehicle::RxTask()
       {
       if (!m_ready)
         continue;
-      if ((frame.origin == m_poll_bus)&&(m_poll_plist))
+      if (m_poll_wait && frame.origin == m_poll_bus && m_poll_plist)
         {
-        // This is intended for our poller
+        // This is a quick filter check to see if the frame is possibly intended for our poller.
+        // The filter will be checked again in PollerReceive() after locking the mutex.
         // ESP_LOGI(TAG, "Poller Rx candidate ID=%03x (expecting %03x-%03x)",frame.MsgID,m_poll_moduleid_low,m_poll_moduleid_high);
         if ((frame.MsgID >= m_poll_moduleid_low)&&(frame.MsgID <= m_poll_moduleid_high))
           {
@@ -1158,6 +1162,10 @@ void OvmsVehicle::IncomingFrameCan4(CAN_frame_t* p_frame)
   }
 
 void OvmsVehicle::IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain)
+  {
+  }
+
+void OvmsVehicle::IncomingPollError(canbus* bus, uint16_t type, uint16_t pid, uint16_t code)
   {
   }
 
@@ -1216,7 +1224,7 @@ void OvmsVehicle::VehicleTicker1(std::string event, void* data)
 
   m_ticker++;
 
-  PollerSend();
+  PollerSend(true);
 
   Ticker1(m_ticker);
   if ((m_ticker % 10) == 0) Ticker10(m_ticker);
@@ -2010,10 +2018,12 @@ OvmsVehicle::vehicle_mode_t OvmsVehicle::VehicleModeKey(const std::string code)
 
 void OvmsVehicle::PollSetPidList(canbus* bus, const poll_pid_t* plist)
   {
-  OvmsMutexLock lock(&m_poll_mutex);
+  OvmsRecMutexLock lock(&m_poll_mutex);
   m_poll_bus = bus;
   m_poll_plist = plist;
   m_poll_ticker = 0;
+  m_poll_sequence_cnt = 0;
+  m_poll_wait = 0;
   m_poll_plcur = NULL;
   }
 
@@ -2021,41 +2031,59 @@ void OvmsVehicle::PollSetState(uint8_t state)
   {
   if ((state < VEHICLE_POLL_NSTATES)&&(state != m_poll_state))
     {
-    OvmsMutexLock lock(&m_poll_mutex);
+    OvmsRecMutexLock lock(&m_poll_mutex);
     m_poll_state = state;
     m_poll_ticker = 0;
+    m_poll_sequence_cnt = 0;
+    m_poll_wait = 0;
     m_poll_plcur = NULL;
     }
   }
 
-void OvmsVehicle::PollerSend()
+/**
+ * PollSetResponseSeparationTime: configure ISO TP multi frame response timing
+ *  See: https://en.wikipedia.org/wiki/ISO_15765-2
+ *  
+ *  @param septime
+ *    Separation Time (ST), the minimum delay time between frames. Default: 25 milliseconds
+ *    ST values up to 127 (0x7F) specify the minimum number of milliseconds to delay between frames,
+ *    while values in the range 241 (0xF1) to 249 (0xF9) specify delays increasing from
+ *    100 to 900 microseconds.
+ *  
+ *  The configuration is kept unchanged over calls to PollSetPidList() or PollSetState().
+ */
+void OvmsVehicle::PollSetResponseSeparationTime(uint8_t septime)
   {
-  OvmsMutexLock lock(&m_poll_mutex);
-  if (!m_poll_bus || !m_poll_plist) return;
+  assert (septime <= 127 || (septime >= 241 && septime <= 249));
+  OvmsRecMutexLock lock(&m_poll_mutex);
+  m_poll_fc_septime = septime;
+  }
+
+void OvmsVehicle::PollerSend(bool fromTicker)
+  {
+  OvmsRecMutexLock lock(&m_poll_mutex);
+
+  // Don't do anything with no bus, no list or an empty list
+  if (!m_poll_bus || !m_poll_plist || m_poll_plist->txmoduleid == 0) return;
+
   if (m_poll_plcur == NULL) m_poll_plcur = m_poll_plist;
+
+  // ESP_LOGD(TAG, "PollerSend(%d): entry at[type=%02X, pid=%X], ticker=%u, wait=%u, cnt=%u/%u",
+  //          fromTicker, m_poll_plcur->type, m_poll_plcur->pid,
+  //          m_poll_ticker, m_poll_wait, m_poll_sequence_cnt, m_poll_sequence_max);
+
+  if (fromTicker) 
+    {
+    // Timer ticker call: reset throttling counter, check response timeout
+    m_poll_sequence_cnt = 0;
+    if (m_poll_wait > 0) m_poll_wait--;
+    }
+  if (m_poll_wait > 0) return;
 
   while (m_poll_plcur->txmoduleid != 0)
     {
-    // there are remaining poll replays from last poll. we wait for it.
-    if (m_poll_ml_remain > 7)
-      {
-      if (m_poll_wait)
-        {
-        // ESP_LOGD(TAG,"wait last Polling for %02x: there are remaining poll replays", m_poll_plcur->pid);
-        m_poll_wait = 0;
-        m_poll_ml_remain = 0;
-        return;
-        }
-      else
-        {
-        // ESP_LOGD(TAG,"wait Polling for %02x: there are remaining poll replays", m_poll_plcur->pid);
-        m_poll_wait = 1;
-        return;
-        }
-      }
-    m_poll_wait = 0;
-    if ((m_poll_plcur->polltime[m_poll_state] > 0)&&
-        ((m_poll_ticker % m_poll_plcur->polltime[m_poll_state] ) == 0))
+    if ((m_poll_plcur->polltime[m_poll_state] > 0) &&
+        ((m_poll_ticker % m_poll_plcur->polltime[m_poll_state]) == 0))
       {
       // We need to poll this one...
       m_poll_type = m_poll_plcur->type;
@@ -2075,212 +2103,267 @@ void OvmsVehicle::PollerSend()
         m_poll_moduleid_high = 0x7ef;
         }
 
-      // ESP_LOGD(TAG, "Polling for %d/%02x (expecting %03x/%03x-%03x)",
-      //   m_poll_type,m_poll_pid,m_poll_moduleid_sent,m_poll_moduleid_low,m_poll_moduleid_high);
+      ESP_LOGD(TAG, "PollerSend(%d): send [type=%02X, pid=%X], expecting %03x/%03x-%03x",
+               fromTicker, m_poll_type, m_poll_pid, m_poll_moduleid_sent, m_poll_moduleid_low, m_poll_moduleid_high);
+      
       CAN_frame_t txframe;
       memset(&txframe,0,sizeof(txframe));
       txframe.origin = m_poll_bus;
       txframe.MsgID = m_poll_moduleid_sent;
       txframe.FIR.B.FF = CAN_frame_std;
       txframe.FIR.B.DLC = 8;
+      
       switch (m_poll_plcur->type)
         {
-        case VEHICLE_POLL_TYPE_OBDIICURRENT:
-        case VEHICLE_POLL_TYPE_OBDIIFREEZE:
-        case VEHICLE_POLL_TYPE_OBDIISESSION:
-          // 8 bit PID request for single frame response:
-          txframe.data.u8[0] = 0x02;
-          txframe.data.u8[1] = m_poll_type;
-          txframe.data.u8[2] = m_poll_pid;
-          break;
-        case VEHICLE_POLL_TYPE_OBDIIVEHICLE:
-        case VEHICLE_POLL_TYPE_OBDIIGROUP:
-        case VEHICLE_POLL_TYPE_OBDII_1A:
-          // 8 bit PID request for multi frame response:
-          m_poll_ml_remain = 0;
-          txframe.data.u8[0] = 0x02;
-          txframe.data.u8[1] = m_poll_type;
-          txframe.data.u8[2] = m_poll_pid;
-          break;
+        // 16 bit PID requests:
         case VEHICLE_POLL_TYPE_OBDIIEXTENDED:
-          // 16 bit PID request:
-          m_poll_ml_remain = 0;
-          txframe.data.u8[0] = 0x03;
-          txframe.data.u8[1] = m_poll_type; //VEHICLE_POLL_TYPE_OBDIIEXTENDED;    // Get extended PID
+          txframe.data.u8[0] = (ISOTP_FT_SINGLE << 4) + 3;
+          txframe.data.u8[1] = m_poll_type;
           txframe.data.u8[2] = m_poll_pid >> 8;
           txframe.data.u8[3] = m_poll_pid & 0xff;
           break;
+
+        // 8 bit PID requests:
+        default:
+          txframe.data.u8[0] = (ISOTP_FT_SINGLE << 4) + 2;
+          txframe.data.u8[1] = m_poll_type;
+          txframe.data.u8[2] = m_poll_pid;
+          break;
         }
+      
       m_poll_bus->Write(&txframe);
+      m_poll_ml_frame = 0;
+      m_poll_ml_offset = 0;
+      m_poll_ml_remain = 0;
+      m_poll_wait = 2;
       m_poll_plcur++;
+      m_poll_sequence_cnt++;
+
       return;
       }
+
+    // Poll entry is not due, check next
     m_poll_plcur++;
     }
 
+  // Completed checking all poll entries for the current m_poll_ticker
+  // ESP_LOGD(TAG, "PollerSend(%d): cycle complete for ticker=%u", fromTicker, m_poll_ticker);
   m_poll_plcur = m_poll_plist;
   m_poll_ticker++;
   if (m_poll_ticker > 3600) m_poll_ticker -= 3600;
   }
 
+
 void OvmsVehicle::PollerReceive(CAN_frame_t* frame)
   {
-  // ESP_LOGI(TAG, "Receive Poll Response for %d/%02x",m_poll_type,m_poll_pid);
-  switch (m_poll_type)
+  OvmsRecMutexLock lock(&m_poll_mutex);
+  char *hexdump = NULL;
+
+  // After locking the mutex, check again for poll expectance match:
+  if (!m_poll_wait || !m_poll_plist || frame->origin != m_poll_bus ||
+      frame->MsgID < m_poll_moduleid_low || frame->MsgID > m_poll_moduleid_high)
     {
-    case VEHICLE_POLL_TYPE_OBDIICURRENT:
-    case VEHICLE_POLL_TYPE_OBDIIFREEZE:
-    case VEHICLE_POLL_TYPE_OBDIISESSION:
-      // 8 bit PID single frame response:
-      if ((frame->data.u8[1] == 0x40+m_poll_type)&&
-          (frame->data.u8[2] == m_poll_pid))
-        {
-        m_poll_ml_frame = 0;
-        IncomingPollReply(frame->origin, m_poll_type, m_poll_pid, &frame->data.u8[3], 5, 0);
-        return;
-        }
+    ESP_LOGD(TAG, "PollerReceive[%03X]: dropping expired poll response", frame->MsgID);
+    return;
+    }
+
+
+  // 
+  // Get & validate ISO-TP meta data
+  // 
+
+  uint8_t  tp_frametype;          // ISO-TP frame type (0…3)
+  uint8_t  tp_frameindex;         // TP cyclic frame index (0…15)
+  uint16_t tp_len;                // TP remaining payload length including this frame (0…4095)
+  uint8_t* tp_data;               // TP frame data section address
+  uint8_t  tp_datalen;            // TP frame data section length (0…7)
+
+  tp_frametype = frame->data.u8[0] >> 4;
+
+  switch (tp_frametype)
+    {
+    case ISOTP_FT_SINGLE:
+      tp_frameindex = 0;
+      tp_len = frame->data.u8[0] & 0x0f;
+      tp_data = &frame->data.u8[1];
+      tp_datalen = tp_len;
       break;
-    case VEHICLE_POLL_TYPE_OBDIIVEHICLE:
-    case VEHICLE_POLL_TYPE_OBDIIGROUP:
-    case VEHICLE_POLL_TYPE_OBDII_1A:
-      // 8 bit PID multiple frame response:
-      if (((frame->data.u8[0]>>4) == 0x1)&&
-          (frame->data.u8[2] == 0x40+m_poll_type)&&
-          (frame->data.u8[3] == m_poll_pid))
-        {
-        // First frame is 4 bytes header (2 ISO-TP, 2 OBDII), 4 bytes data:
-        // [first=1,lenH] [lenL] [type+40] [pid] [data0] [data1] [data2] [data3]
-        // Note that the value of 'len' includes the OBDII type and pid bytes,
-        // but we don't count these in the data we pass to IncomingPollReply.
-        //
-        // First frame; send flow control frame:
-        CAN_frame_t txframe;
-        memset(&txframe,0,sizeof(txframe));
-        txframe.origin = frame->origin;
-        txframe.FIR.B.FF = CAN_frame_std;
-        txframe.FIR.B.DLC = 8;
-
-        if (m_poll_moduleid_sent == 0x7df)
-          {
-          // broadcast request: derive module ID from response ID:
-          // (Note: this only works for the SAE standard ID scheme)
-          txframe.MsgID = frame->MsgID - 8;
-          }
-        else
-          {
-          // use known module ID:
-          txframe.MsgID = m_poll_moduleid_sent;
-          }
-
-        txframe.data.u8[0] = 0x30; // flow control frame type
-        txframe.data.u8[1] = 0x00; // request all frames available
-        txframe.data.u8[2] = 0x19; // with 25ms send interval
-        txframe.Write();
-
-        // prepare frame processing, first frame contains first 4 bytes:
-        m_poll_ml_remain = (((uint16_t)(frame->data.u8[0]&0x0f))<<8) + frame->data.u8[1] - 2 - 4;
-        m_poll_ml_offset = 4;
-        m_poll_ml_frame = 0;
-
-        // ESP_LOGI(TAG, "Poll ML first frame (frame=%d, remain=%d)",m_poll_ml_frame,m_poll_ml_remain);
-        IncomingPollReply(frame->origin, m_poll_type, m_poll_pid, &frame->data.u8[4], 4, m_poll_ml_remain);
-        return;
-        }
-      else if (((frame->data.u8[0]>>4)==0x2)&&(m_poll_ml_remain>0))
-        {
-        // Consecutive frame (1 control + 7 data bytes)
-        uint16_t len;
-        if (m_poll_ml_remain>7)
-          {
-          m_poll_ml_remain -= 7;
-          m_poll_ml_offset += 7;
-          len = 7;
-          }
-        else
-          {
-          len = m_poll_ml_remain;
-          m_poll_ml_offset += m_poll_ml_remain;
-          m_poll_ml_remain = 0;
-          }
-        m_poll_ml_frame++;
-        // ESP_LOGI(TAG, "Poll ML subsequent frame (frame=%d, remain=%d)",m_poll_ml_frame,m_poll_ml_remain);
-        IncomingPollReply(frame->origin, m_poll_type, m_poll_pid, &frame->data.u8[1], len, m_poll_ml_remain);
-        return;
-        }
+    case ISOTP_FT_FIRST:
+      tp_frameindex = 0;
+      tp_len = (frame->data.u8[0] & 0x0f) << 8 | frame->data.u8[1];
+      tp_data = &frame->data.u8[2];
+      tp_datalen = (tp_len > 6) ? 6 : tp_len;
       break;
-    case VEHICLE_POLL_TYPE_OBDIIEXTENDED:
-      // 16 bit PID response:
-      if (((frame->data.u8[0]>>4) == 0x1)&&
-          (frame->data.u8[2] == 0x40+m_poll_type)&&
-          ((frame->data.u8[4]+(((uint16_t) frame->data.u8[3]) << 8))  == m_poll_pid))
-        {
-        // First frame is 4 bytes header (2 ISO-TP, 2 OBDII), 4 bytes data:
-        // [first=1,lenH] [lenL] [type+40] [pid] [data0] [data1] [data2] [data3]
-        // Note that the value of 'len' includes the OBDII type and pid bytes,
-        // but we don't count these in the data we pass to IncomingPollReply.
-        //
-        // First frame; send flow control frame:
-        CAN_frame_t txframe;
-        memset(&txframe,0,sizeof(txframe));
-        txframe.origin = frame->origin;
-        txframe.FIR.B.FF = CAN_frame_std; //CAN_frame_ext?
-        txframe.FIR.B.DLC = 8;
-
-        if (m_poll_moduleid_sent == 0x7df)
-          {
-          // broadcast request: derive module ID from response ID:
-          // (Note: this only works for the SAE standard ID scheme)
-          txframe.MsgID = frame->MsgID - 8;
-          }
-        else
-          {
-          // use known module ID:
-          txframe.MsgID = m_poll_moduleid_sent;
-          }
-
-        txframe.data.u8[0] = 0x30; // flow control frame type
-        txframe.data.u8[1] = 0x00; // request all frames available
-        txframe.data.u8[2] = 0x19; // with 25ms send interval
-        txframe.Write();
-
-        // prepare frame processing, first frame contains first 4 bytes:
-        m_poll_ml_remain = (((uint16_t)(frame->data.u8[0]&0x0f))<<8) + frame->data.u8[1] - 3;
-        m_poll_ml_offset = 3;
-        m_poll_ml_frame = 0;
-
-        //ESP_LOGD(TAG, "Poll ML first frame (frame=%d, remain=%d)",m_poll_ml_frame,m_poll_ml_remain);
-        IncomingPollReply(frame->origin, m_poll_type, m_poll_pid, &frame->data.u8[4], 4, m_poll_ml_remain);
-        return;
-        }
-      else if (((frame->data.u8[0]>>4)==0x2)&&(m_poll_ml_remain>0))
-        {
-        // Consecutive frame (1 control + 7 data bytes)
-        uint16_t len;
-        if (m_poll_ml_remain>7)
-          {
-          m_poll_ml_remain -= 7;
-          m_poll_ml_offset += 7;
-          len = 7;
-          }
-        else
-          {
-          len = m_poll_ml_remain;
-          m_poll_ml_offset += m_poll_ml_remain;
-          m_poll_ml_remain = 0;
-          }
-        m_poll_ml_frame++;
-        //ESP_LOGD(TAG, "Poll ML subsequent frame (frame=%d, remain=%d)",m_poll_ml_frame,m_poll_ml_remain);
-        IncomingPollReply(frame->origin, m_poll_type, m_poll_pid, &frame->data.u8[1], len, m_poll_ml_remain);
-        return;
-        }
-      else if ((frame->data.u8[1] == 0x62)&&
-               ((frame->data.u8[3]+(((uint16_t) frame->data.u8[2]) << 8)) == m_poll_pid))
-        {
-        IncomingPollReply(frame->origin, m_poll_type, m_poll_pid, &frame->data.u8[4], 4, 0);
-        }
+    case ISOTP_FT_CONSECUTIVE:
+      tp_frameindex = frame->data.u8[0] & 0x0f;
+      tp_len = m_poll_ml_remain;
+      tp_data = &frame->data.u8[1];
+      tp_datalen = (tp_len > 7) ? 7 : tp_len;
       break;
+    default:
+      {
+      // This is most likely an indication there is a non ISO-TP device sending
+      // in our expected RX ID range, so we log the frame and abort:
+      FormatHexDump(&hexdump, (const char*)frame->data.u8, 8);
+      ESP_LOGW(TAG, "PollerReceive[%03X]: ignoring unknown/invalid ISO TP frame: %s",
+               frame->MsgID, hexdump ? hexdump : "-");
+      if (hexdump) free(hexdump);
+      return;
+      }
+    }
+
+  // Check frame index:
+  if (tp_frametype == ISOTP_FT_CONSECUTIVE)
+    {
+    if (m_poll_ml_remain == 0 || tp_frameindex != (m_poll_ml_frame & 0x0f))
+      {
+      FormatHexDump(&hexdump, (const char*)frame->data.u8, 8);
+      ESP_LOGW(TAG, "PollerReceive[%03X]: unexpected/out of sequence ISO TP frame (%d vs %d), aborting poll %02X(%X): %s",
+              frame->MsgID, tp_frameindex, m_poll_ml_frame & 0x0f, m_poll_type, m_poll_pid,
+              hexdump ? hexdump : "-");
+      if (hexdump) free(hexdump);
+      m_poll_moduleid_low = m_poll_moduleid_high = 0; // ignore further frames
+      m_poll_wait = 2; // give the bus time to let remaining frames pass
+      return;
+      }
+    }
+
+
+  // 
+  // Get & validate OBD/UDS meta data
+  // 
+
+  uint8_t  response_type = 0;         // OBD/UDS response type tag (expected: 0x40 + request type)
+  uint16_t response_pid = 0;          // OBD/UDS response PID (expected: request PID)
+  uint8_t* response_data = NULL;      // OBD/UDS frame payload address
+  uint16_t response_datalen = 0;      // OBD/UDS frame payload length (0…7)
+  uint8_t  error_type = 0;            // OBD/UDS error response service type (expected: request type)
+  uint8_t  error_code = 0;            // OBD/UDS error response code (see ISO 14229 Annex A.1)
+
+  if (tp_frametype == ISOTP_FT_CONSECUTIVE)
+    {
+    response_type = 0x40+m_poll_type;
+    response_pid = m_poll_pid;
+    response_data = tp_data;
+    response_datalen = tp_datalen;
+    }
+  else // ISOTP_FT_FIRST || ISOTP_FT_SINGLE
+    {
+    response_type = tp_data[0];
+    switch (response_type)
+      {
+      // Negative response code:
+      case UDS_RESP_TYPE_NRC:
+        error_type = tp_data[1];
+        error_code = tp_data[2];
+        break;
+
+      // 16 bit PID requests:
+      case 0x40+VEHICLE_POLL_TYPE_OBDIIEXTENDED:
+        response_pid = tp_data[1] << 8 | tp_data[2];
+        response_data = &tp_data[3];
+        response_datalen = tp_datalen - 3;
+        break;
+
+      // 8 bit PID requests:
+      default:
+        response_pid = tp_data[1];
+        response_data = &tp_data[2];
+        response_datalen = tp_datalen - 2;
+        break;
+      }
+    }
+
+
+  // 
+  // Process OBD/UDS payload
+  // 
+
+  if (response_type == UDS_RESP_TYPE_NRC && error_type == m_poll_type)
+    {
+    // Negative Response Code, forward to application:
+    m_poll_ml_remain = 0;
+    ESP_LOGD(TAG, "PollerReceive[%03X]: process OBD/UDS error %02X(%X) code=%02X",
+             frame->MsgID, m_poll_type, m_poll_pid, error_code);
+    IncomingPollError(frame->origin, m_poll_type, m_poll_pid, error_code);
+    }
+  else if (response_type == 0x40+m_poll_type && response_pid == m_poll_pid)
+    {
+    // Normal matching poll response, forward to application:
+    m_poll_ml_remain = tp_len - tp_datalen;
+    ESP_LOGD(TAG, "PollerReceive[%03X]: process OBD/UDS response %02X(%X) frm=%u len=%u off=%u rem=%u",
+             frame->MsgID, m_poll_type, m_poll_pid,
+             m_poll_ml_frame, response_datalen, m_poll_ml_offset, m_poll_ml_remain);
+    IncomingPollReply(frame->origin, m_poll_type, m_poll_pid, response_data, response_datalen, m_poll_ml_remain);
+    }
+  else
+    {
+    // This is most likely a late response to a previous poll, log & skip:
+    FormatHexDump(&hexdump, (const char*)frame->data.u8, 8);
+    ESP_LOGW(TAG, "PollerReceive[%03X]: OBD/UDS response type/PID mismatch, got %02X(%X) vs %02X(%X) => ignoring: %s",
+             frame->MsgID, response_type, response_pid, 0x40+m_poll_type, m_poll_pid, hexdump ? hexdump : "-");
+    if (hexdump) free(hexdump);
+    return;
+    }
+
+
+  // Do we expect more data?
+  if (m_poll_ml_remain)
+    {
+    if (tp_frametype == ISOTP_FT_FIRST)
+      {
+      // First frame; send flow control frame:
+      CAN_frame_t txframe;
+      memset(&txframe,0,sizeof(txframe));
+      txframe.origin = frame->origin;
+      txframe.FIR.B.FF = CAN_frame_std;
+      txframe.FIR.B.DLC = 8;
+
+      if (m_poll_moduleid_sent == 0x7df)
+        {
+        // broadcast request: derive module ID from response ID:
+        // (Note: this only works for the SAE standard ID scheme)
+        txframe.MsgID = frame->MsgID - 8;
+        }
+      else
+        {
+        // use known module ID:
+        txframe.MsgID = m_poll_moduleid_sent;
+        }
+
+      txframe.data.u8[0] = 0x30;                // flow control frame type
+      txframe.data.u8[1] = 0x00;                // request all frames available
+      txframe.data.u8[2] = m_poll_fc_septime;   // with configured separation timing (default 25 ms)
+      txframe.Write();
+      m_poll_ml_frame = 1;
+      }
+    else
+      {
+      m_poll_ml_frame++;
+      }
+
+    m_poll_ml_offset += response_datalen; // next frame application payload offset
+    m_poll_wait = 2;
+    }
+  else
+    {
+    // Request response complete:
+    m_poll_wait = 0;
+    }
+
+
+  // Immediately send the next poll for this tick if…
+  // - we are not waiting for another frame
+  // - the poll was no broadcast (with potential further responses from other devices)
+  // - poll throttling is unlimited or limit isn't reached yet
+  if (m_poll_wait == 0 &&
+      m_poll_moduleid_sent != 0x7df &&
+      (!m_poll_sequence_max || m_poll_sequence_cnt < m_poll_sequence_max))
+    {
+    PollerSend(false);
     }
   }
+
 
 /**
  * SetFeature: V2 compatibility config wrapper

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -45,19 +45,36 @@
 using namespace std;
 struct DashboardConfig;
 
-// Polling types supported:
+
+// ISO TP:
+//  (see https://en.wikipedia.org/wiki/ISO_15765-2)
+
+#define ISOTP_FT_SINGLE                 0
+#define ISOTP_FT_FIRST                  1
+#define ISOTP_FT_CONSECUTIVE            2
+#define ISOTP_FT_FLOWCTRL               3
+
+// OBD2/UDS Polling types supported:
 //  (see https://en.wikipedia.org/wiki/OBD-II_PIDs
 //   and https://en.wikipedia.org/wiki/Unified_Diagnostic_Services)
 
 #define VEHICLE_POLL_TYPE_NONE          0x00
+
+// OBD (ISO 15031) service identifiers supported:
 #define VEHICLE_POLL_TYPE_OBDIICURRENT  0x01 // Mode 01 "current data"
 #define VEHICLE_POLL_TYPE_OBDIIFREEZE   0x02 // Mode 02 "freeze frame data"
 #define VEHICLE_POLL_TYPE_OBDIIVEHICLE  0x09 // Mode 09 "vehicle information"
+
+// UDS (ISO 14229) & custom service identifiers supported:
 #define VEHICLE_POLL_TYPE_OBDIISESSION  0x10 // UDS: Diagnostic Session Control
-#define VEHICLE_POLL_TYPE_OBDII_1A  			0x1A // Mode 1A
+#define VEHICLE_POLL_TYPE_OBDII_1A      0x1A // Mode 1A
 #define VEHICLE_POLL_TYPE_OBDIIGROUP    0x21 // enhanced data by 8 bit PID
 #define VEHICLE_POLL_TYPE_OBDIIEXTENDED 0x22 // enhanced data by 16 bit PID
 
+// OBD/UDS Negative Response Code
+#define UDS_RESP_TYPE_NRC               0x7F  // see ISO 14229 Annex A.1
+
+// Number of polling states supported
 #define VEHICLE_POLL_NSTATES            4
 
 
@@ -124,7 +141,7 @@ class OvmsVehicle : public InternalRamAllocated
   private:
     void VehicleTicker1(std::string event, void* data);
     void VehicleConfigChanged(std::string event, void* data);
-    void PollerSend();
+    void PollerSend(bool fromTicker);
     void PollerReceive(CAN_frame_t* frame);
 
   protected:
@@ -133,6 +150,7 @@ class OvmsVehicle : public InternalRamAllocated
     virtual void IncomingFrameCan3(CAN_frame_t* p_frame);
     virtual void IncomingFrameCan4(CAN_frame_t* p_frame);
     virtual void IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain);
+    virtual void IncomingPollError(canbus* bus, uint16_t type, uint16_t pid, uint16_t code);
 
   protected:
     int m_minsoc;            // The minimum SOC level before alert
@@ -289,7 +307,7 @@ class OvmsVehicle : public InternalRamAllocated
       } poll_pid_t;
 
   protected:
-    OvmsMutex         m_poll_mutex;           // Concurrency protection
+    OvmsRecMutex      m_poll_mutex;           // Concurrency protection for recursive calls
     uint8_t           m_poll_state;           // Current poll state
     canbus*           m_poll_bus;             // Bus to poll on
     const poll_pid_t* m_poll_plist;           // Head of poll list
@@ -300,14 +318,29 @@ class OvmsVehicle : public InternalRamAllocated
     uint32_t          m_poll_moduleid_high;   // Expected response moduleid high mark
     uint16_t          m_poll_type;            // Expected type
     uint16_t          m_poll_pid;             // Expected PID
-    uint16_t          m_poll_ml_remain;       // Bytes remainign for ML poll
+    uint16_t          m_poll_ml_remain;       // Bytes remaining for ML poll
     uint16_t          m_poll_ml_offset;       // Offset of ML poll
     uint16_t          m_poll_ml_frame;        // Frame number for ML poll
-    uint16_t          m_poll_wait;            // Wait for remaining poll replays
+    uint8_t           m_poll_wait;            // Wait counter for a reply from a sent poll or bytes remaining.
+                                              // Gets set = 2 when a poll is sent OR when bytes are remaining after receiving.
+                                              // Gets set = 0 when a poll is received.
+                                              // Gets decremented with every second/tick in PollerSend().
+                                              // PollerSend() aborts when > 0.
+                                              // Why set = 2: When a poll gets send just before the next ticker occurs
+                                              //              PollerSend() decrements to 1 and doesn't send the next poll.
+                                              //              Only when the reply doesn't get in until the next ticker occurs
+                                              //              PollserSend() decrements to 0 and abandons the outstanding reply (=timeout)
+
+  private:
+    uint8_t           m_poll_sequence_max;    // Polls allowed to be sent in sequence per time tick (second), default 1, 0 = no limit
+    uint8_t           m_poll_sequence_cnt;    // Polls already sent in the current time tick (second)
+    uint8_t           m_poll_fc_septime;      // Flow control separation time for multi frame responses
 
   protected:
     void PollSetPidList(canbus* bus, const poll_pid_t* plist);
     void PollSetState(uint8_t state);
+    void PollSetThrottling(uint8_t sequence_max) { m_poll_sequence_max = sequence_max; }
+    void PollSetResponseSeparationTime(uint8_t septime);
 
   // BMS helpers
   protected:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -40,25 +40,37 @@ static const char *TAG = "v-nissanleaf";
 #include "ovms_metrics.h"
 #include "metrics_standard.h"
 #include "ovms_webserver.h"
+#include "ovms_command.h"
+#include "ovms_config.h"
 
-#define MAX_POLL_DATA_LEN 196
+#define MAX_POLL_DATA_LEN         196
+#define BMS_TXID                  0x79B
+#define BMS_RXID                  0x7BB
+#define CHARGER_TXID              0x797
+#define CHARGER_RXID              0x79a
+#define BROADCAST_TXID            0x7df
+#define BROADCAST_RXID            0x0
+
+#define VIN_PID                   0x81
+#define QC_COUNT_PID              0x1203
+#define L1L2_COUNT_PID            0x1205
 
 enum poll_states
   {
   POLLSTATE_OFF,      //- car is off
   POLLSTATE_ON,       //- car is on
-  POLLSTATE_RUNNING,  //- car is driving
+  POLLSTATE_RUNNING,  //- car is in drive/reverse
   POLLSTATE_CHARGING  //- car is charging
   };
 
 static const OvmsVehicle::poll_pid_t obdii_polls[] =
   {
-    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {  0, 30, 0, 0 } }, // VIN [19]
-    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1203, {  0, 30, 0, 0 } }, // QC [4]
-    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1205, {  0, 30, 0, 0 } }, // L0/L1/L2 [4]
-    { 0x79b, 0x7bb, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 0, 60 } }, // bat [39/41]
-    { 0x79b, 0x7bb, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 0, 60 } }, // battery voltages [196]
-    { 0x79b, 0x7bb, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {  0, 300, 0, 300 } }, // battery temperatures [14]
+//    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {  0, 30, 0, 0 } }, // VIN [19]
+//    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1203, {  0, 30, 0, 0 } }, // QC [4]
+//    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1205, {  0, 30, 0, 0 } }, // L0/L1/L2 [4]
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 0, 60 } },   // bat [39/41]
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 0, 60 } },   // battery voltages [196]
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {  0, 300, 0, 300 } }, // battery temperatures [14]
     { 0, 0, 0x00, 0x00, { 0, 0, 0, 0 } }
   };
 
@@ -92,7 +104,20 @@ enum charge_duration_index
   CHARGE_DURATION_RANGE_L0,
   };
 
+OvmsVehicleNissanLeaf* OvmsVehicleNissanLeaf::GetInstance(OvmsWriter* writer /*=NULL*/)
+  {
+    OvmsVehicleNissanLeaf* nl = (OvmsVehicleNissanLeaf*) MyVehicleFactory.ActiveVehicle();
+    string type = StdMetrics.ms_v_type->AsString();
+    if (!nl || type != "NL") {
+      if (writer)
+        writer->puts("Error: Nissan Leaf vehicle module not selected");
+      return NULL;
+    }
+    return nl;
+  }
+
 OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
+  : nl_obd_rxwait(1,1)
   {
   ESP_LOGI(TAG, "Nissan Leaf v3.0 vehicle module");
 
@@ -133,14 +158,16 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   m_climate_remotecool = MyMetrics.InitBool("xnl.cc.remotecool", SM_STALE_MIN, false);
   MyMetrics.InitBool("v.e.on", SM_STALE_MIN, false);
   MyMetrics.InitBool("v.e.awake", SM_STALE_MID, false);
+  MyMetrics.InitBool("v.e.locked", SM_STALE_MID, false);
   MyMetrics.InitBool("v.vin", SM_STALE_NONE, "");
   MyMetrics.InitString("v.c.state",SM_STALE_MID,"stopped");
   m_gen1_charger = false;
 
   RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
   RegisterCanBus(2,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
-  PollSetPidList(m_can1,obdii_polls);
   PollSetState(POLLSTATE_OFF);
+  PollSetPidList(m_can1,obdii_polls);
+
 
   MyConfig.RegisterParam("xnl", "Nissan Leaf", true, true);
   ConfigChanged(NULL);
@@ -151,6 +178,9 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
 
   m_remoteCommandTimer = xTimerCreate("Nissan Leaf Remote Command", 100 / portTICK_PERIOD_MS, pdTRUE, this, remoteCommandTimer);
   m_ccDisableTimer = xTimerCreate("Nissan Leaf CC Disable", 1000 / portTICK_PERIOD_MS, pdFALSE, this, ccDisableTimer);
+
+  //load custom shell commands
+  CommandInit();
 
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -163,6 +193,25 @@ OvmsVehicleNissanLeaf::~OvmsVehicleNissanLeaf()
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
   WebDeInit();
 #endif
+  }
+
+void OvmsVehicleNissanLeaf::CommandInit()
+  {
+  cmd_xnl = MyCommandApp.RegisterCommand("xnl","Nissan Leaf framework");
+
+  OvmsCommand* obd = cmd_xnl->RegisterCommand("obd", "OBD2 tools");
+  OvmsCommand* cmd_can1 = obd->RegisterCommand("can1", "Send OBD2 request, output response to EV can bus");
+  cmd_can1->RegisterCommand("device", "Send OBD2 request to an ECU",shell_obd_request,
+    "<txid> <rxid> <request>\n"
+    "Where <request> includes mode (01, 02, 09, 10, 1A, 21 or 22) and pid.\n"
+    "Example: 79B 7BB 2101", 3, 3);
+  cmd_can1->RegisterCommand("broadcast", "Send OBD2 request as broadcast", shell_obd_request, "<request>", 1, 1);
+  OvmsCommand* cmd_can2 = obd->RegisterCommand("can2", "Send to CAR can bus");
+  cmd_can2->RegisterCommand("device", "Send OBD2 request to a device", shell_obd_request,
+    "<txid> <rxid> <request>\n"
+    "Where <request> includes mode (01, 02, 09, 10, 1A, 21 or 22) and pid.\n"
+    "Example: 79B 7BB 2101", 3, 3);
+  cmd_can2->RegisterCommand("broadcast", "Send OBD2 request as broadcast", shell_obd_request, "<request>", 1, 1);
   }
 
 void OvmsVehicleNissanLeaf::ConfigChanged(OvmsConfigParam* param)
@@ -184,6 +233,7 @@ void OvmsVehicleNissanLeaf::ConfigChanged(OvmsConfigParam* param)
 
   //TODO nl_enable_write = MyConfig.GetParamValueBool("xnl", "canwrite", false);
   m_enable_write = MyConfig.GetParamValueBool("xnl", "canwrite", false);
+  if (!m_enable_write) PollSetState(POLLSTATE_OFF);
   }
 
 
@@ -196,7 +246,6 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_car_on(bool isOn)
     {
     // Log once that car is being turned on
     ESP_LOGI(TAG,"CAR IS ON");
-    PollSetBus(m_can2);
     if (m_enable_write) PollSetState(POLLSTATE_ON);
     // Reset trip values
     StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
@@ -256,7 +305,6 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_charger_status(ChargerStatus stat
       StdMetrics.ms_v_charge_mode->SetValue(fast_charge ? "performance" : "standard");
       StandardMetrics.ms_v_charge_substate->SetValue("onrequest");
       StandardMetrics.ms_v_charge_state->SetValue("charging");
-      PollSetBus(m_can1);
       if (m_enable_write) PollSetState(POLLSTATE_CHARGING);
       // TODO only use battery current for Quick Charging, for regular charging
       // we should return AC line current and voltage, not battery
@@ -313,16 +361,121 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_charger_status(ChargerStatus stat
 
 int OvmsVehicleNissanLeaf::GetNotifyChargeStateDelay(const char* state)
   {
-    if (StandardMetrics.ms_m_monotonic->AsInt() < 10)
-      return 0; //avoid notify on boot triggered by setting delay
-    else return 5; //allow time for charger to handshake
+  if (StandardMetrics.ms_m_monotonic->AsInt() < 10)
+    return 0; //avoid notify on boot triggered by setting delay
+  else return 5; //allow time for charger to handshake
   }
 
-// Use to switch can bus to poll without resetting poll ticker
-void OvmsVehicleNissanLeaf::PollSetBus(canbus* bus)
+void OvmsVehicleNissanLeaf::shell_obd_request(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
-  OvmsMutexLock lock(&m_poll_mutex);
-  m_poll_bus = bus;
+    OvmsVehicleNissanLeaf* nl = GetInstance(writer);
+    const char* strbus = cmd->GetParent()->GetName();
+    if (!nl)
+      return;
+    if (!MyConfig.GetParamValueBool("xnl", "canwrite", false)) {
+        writer->puts("ERROR: canwrite not enabled");
+        return;
+      }
+
+    uint16_t txid = 0, rxid = 0;
+    uint32_t req = 0;
+    uint8_t bus = 2; // default to CAR can
+    string response;
+
+    // parse args:
+    string device = cmd->GetName();
+    if (device == "device") {
+      if (argc < 3) {
+        writer->puts("ERROR: too few args, need: txid rxid request");
+        return;
+      }
+      txid = strtol(argv[0], NULL, 16);
+      rxid = strtol(argv[1], NULL, 16);
+      req = strtol(argv[2], NULL, 16);
+      bus = (strcmp(strbus,"can1") == 0 ? 1 : 2);
+    } else {
+      if (argc < 1) {
+        writer->puts("ERROR: too few args, need: request");
+        return;
+      }
+      req = strtol(argv[0], NULL, 16);
+      if (device == "broadcast") {
+        txid = BROADCAST_TXID;
+        rxid = BROADCAST_RXID;
+      }
+    }
+
+    // validate request:
+    uint8_t mode = (req <= 0xffff) ? ((req & 0xff00) >> 8) : ((req & 0xff0000) >> 16);
+    if (mode != 0x01 && mode != 0x02 && mode != 0x09 &&
+        mode != 0x10 && mode != 0x1A && mode != 0x21 && mode != 0x22) {
+      writer->puts("ERROR: mode must be one of: 01, 02, 09, 10, 1A, 21 or 22");
+      return;
+    } else if (req > 0xffffff) {
+      writer->puts("ERROR: PID must be 8 or 16 bit");
+      return;
+    }
+
+    // execute request:
+    if (!nl->ObdRequest(txid, rxid, req, response, 3000, bus)) {
+      if (bus == 1) writer->puts("ERROR: timeout waiting for response on can1");
+      if (bus == 2) writer->puts("ERROR: timeout waiting for response on can2");
+      return;
+    }
+
+    // output response as hex dump:
+    writer->puts("Response:");
+    char *buf = NULL;
+    size_t rlen = response.size(), offset = 0;
+    do {
+      rlen = FormatHexDump(&buf, response.data() + offset, rlen, 16);
+      offset += 16;
+      writer->puts(buf ? buf : "-");
+    } while (rlen);
+    if (buf)
+      free(buf);
+  }
+
+bool OvmsVehicleNissanLeaf::ObdRequest(uint16_t txid, uint16_t rxid, uint32_t request, string& response, int timeout_ms /*=3000*/, uint8_t bus)
+  {
+  OvmsMutexLock lock(&nl_obd_request);
+  uint8_t  curbus = (m_poll_bus == m_can1 ? 1 : 2);
+  canbus*  reqbus = (bus == 1 ? m_can1 : m_can2);
+  // prepare single poll:
+  OvmsVehicle::poll_pid_t poll[] = {
+    { txid, rxid, 0, 0, { 1, 1, 1, 1 } },
+    { 0, 0, 0, 0, { 0, 0, 0, 0 } }
+  };
+  if (request < 0x10000) {
+    poll[0].type = (request & 0xff00) >> 8;
+    poll[0].pid = request & 0xff;
+  } else {
+    poll[0].type = (request & 0xff0000) >> 16;
+    poll[0].pid = request & 0xffff;
+  }
+
+  // stop default polling:
+  PollSetPidList((curbus == 1 ? m_can1 : m_can2), NULL);
+  vTaskDelay(pdMS_TO_TICKS(100));
+
+  // clear rx semaphore, start single poll:
+  nl_obd_rxwait.Take(0);
+  nl_obd_rxbuf.clear();
+  PollSetPidList(reqbus, poll);
+
+  // wait for response:
+  bool rxok = nl_obd_rxwait.Take(pdMS_TO_TICKS(timeout_ms));
+  if (rxok == pdTRUE) {
+    response = nl_obd_rxbuf;
+    nl_obd_rxbuf.clear();
+    }
+
+  // restore default polling:
+  nl_obd_rxwait.Give();
+  vTaskDelay(pdMS_TO_TICKS(100));
+  PollSetPidList((curbus == 1 ? m_can1 : m_can2), obdii_polls);
+
+  return (rxok == pdTRUE);
   }
 
 void OvmsVehicleNissanLeaf::PollReply_Battery(uint8_t reply_data[], uint16_t reply_len)
@@ -498,55 +651,72 @@ void OvmsVehicleNissanLeaf::PollReply_VIN(uint8_t reply_data[], uint16_t reply_l
   }
 
 // Reassemble all pieces of a multi-frame reply.
-void OvmsVehicleNissanLeaf::IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t remain)
+void OvmsVehicleNissanLeaf::IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain)
   {
-  static int last_pid = -1;
-  static int last_remain = -1;
-  static uint8_t buf[MAX_POLL_DATA_LEN];
-  static int bufpos = 0;
+  string& rxbuf = nl_obd_rxbuf;
 
-  int i;
-  if ( pid != last_pid || remain >= last_remain )
-    {
+  // init / fill rx buffer:
+  if (m_poll_ml_frame == 0) {
+    rxbuf.clear();
+    rxbuf.reserve(length + mlremain);
+  }
+  rxbuf.append((char*)data, length);
+  if (mlremain)
+    return;
+
+  //static int last_pid = -1;
+  //static int last_remain = -1;
+  static uint8_t buf[MAX_POLL_DATA_LEN];
+  //static int bufpos = 0;
+  memcpy(buf, rxbuf.c_str(), rxbuf.size());
+  //int i;
+  //if ( pid != last_pid || remain >= last_remain )
+  //  {
     // must be a new reply, so reset to the beginning
-    last_pid=pid;
-    last_remain=remain;
-    bufpos=0;
-    }
-  for (i=0; i<length; i++)
-    {
-    if ( bufpos < sizeof(buf) ) buf[bufpos++] = data[i];
-    }
-  if (remain==0)
-    {
-    uint32_t id_pid = m_poll_moduleid_low<<16 | pid;
+  //  last_pid=pid;
+  //  last_remain=remain;
+  //  bufpos=0;
+  //  }
+  //for (i=0; i<length; i++)
+  //  {
+  //  if ( bufpos < sizeof(buf) ) buf[bufpos++] = data[i];
+  //  }
+  //if (remain==0)
+  //  {
+  uint32_t id_pid = m_poll_moduleid_low<<16 | pid;
     switch (id_pid)
       {
       case 0x7bb0001: // battery
-        PollReply_Battery(buf, bufpos);
+        PollReply_Battery(buf, rxbuf.size());
         break;
       case 0x7bb0002:
-        PollReply_BMS_Volt(buf, bufpos);
+        PollReply_BMS_Volt(buf, rxbuf.size());
         break;
       case 0x7bb0004:
-        PollReply_BMS_Temp(buf, bufpos);
+        PollReply_BMS_Temp(buf, rxbuf.size());
         break;
       case 0x79a1203: // QC
-        PollReply_QC(buf, bufpos);
+        PollReply_QC(buf, rxbuf.size());
         break;
       case 0x79a1205: // L0/L1/L2
-        PollReply_L0L1L2(buf, bufpos);
+        PollReply_L0L1L2(buf, rxbuf.size());
         break;
       case 0x79a0081: // VIN
-        PollReply_VIN(buf, bufpos);
+        PollReply_VIN(buf, rxbuf.size());
         break;
       default:
-        ESP_LOGI(TAG, "IncomingPollReply: unknown reply module|pid=%#x len=%d", id_pid, bufpos);
+        ESP_LOGI(TAG, "IncomingPollReply: unknown reply module|pid=%#x len=%d", id_pid, rxbuf.size());
         break;
       }
-    last_pid=-1;
-    last_remain=-1;
-    bufpos=0;
+    //last_pid=-1;
+    //last_remain=-1;
+    //bufpos=0;
+    //}
+    // single poll?
+    if (!nl_obd_rxwait.IsAvail()) {
+      // yes: stop poller & signal response
+      PollSetPidList(m_poll_bus, NULL);
+      nl_obd_rxwait.Give();
     }
   }
 
@@ -1190,15 +1360,13 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         case 1: // accessory
         case 2: // on (not ready to drive)
           StandardMetrics.ms_v_env_awake->SetValue(true);
-          PollSetBus(m_can2);
-          if (m_enable_write) PollSetState(POLLSTATE_ON);
           break;
         case 3: // ready to drive, is triggered on unlock
           StandardMetrics.ms_v_env_awake->SetValue(true);
           if (StandardMetrics.ms_v_env_footbrake->AsFloat() > 0) //check footbrake to avoid false positive
-          {
-          vehicle_nissanleaf_car_on(true);
-          }
+            {
+            vehicle_nissanleaf_car_on(true);
+            }
           break;
         }
 
@@ -1351,12 +1519,42 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
     // the core framework?
     // perhaps interested code should be able to subscribe to "onChange" and
     // "onStale" events for each metric?
+    ESP_LOGD(TAG, "Poll state: %d", m_poll_state);
     if (StandardMetrics.ms_v_env_awake->AsBool() && StandardMetrics.ms_v_env_awake->IsStale())
       {
       StandardMetrics.ms_v_env_awake->SetValue(false);
       }
   }
 
+void OvmsVehicleNissanLeaf::Ticker60(uint32_t ticker)
+  {
+  if (m_enable_write && StandardMetrics.ms_v_env_awake->AsBool())
+    {
+    string response;
+    ESP_LOGD(TAG, "Obd request for VIN, QC & L1L2 counts");
+    if (StandardMetrics.ms_v_vin->AsString() == "")
+      {
+      if (!this->ObdRequest(CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP<<8 | VIN_PID, response, 3000, 2)) {
+        ESP_LOGD(TAG, "Obd request sent: txid=%x rxid=%x req=%x", CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP<<8 | VIN_PID);
+        ESP_LOGI(TAG, "Vin request poll timed out");
+        }
+      }
+    if (m_charge_count_qc->AsInt() == 0)
+      {
+      if (!this->ObdRequest(CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED<<16 | QC_COUNT_PID, response, 3000, 2)) {
+        ESP_LOGD(TAG, "Obd request sent: txid=%x rxid=%x req=%x", CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED<<16 | QC_COUNT_PID);
+        ESP_LOGI(TAG, "QC count request poll timed out");
+        }
+      }
+    if (m_charge_count_l0l1l2->AsInt() == 0)
+      {
+      if (!this->ObdRequest(CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED<<16 | L1L2_COUNT_PID, response, 3000, 2)) {
+        ESP_LOGD(TAG, "Obd request sent: txid=%x rxid=%x req=%x", CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED<<16 | L1L2_COUNT_PID);
+        ESP_LOGI(TAG, "L1L2 count request poll timed out");
+        }
+      }
+    }
+  }
 /**
  * Update derived energy metrics while driving
  * Called once per second from Ticker1

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -48,14 +48,14 @@ enum poll_states
   POLLSTATE_OFF,      //- car is off
   POLLSTATE_ON,       //- car is on
   POLLSTATE_RUNNING,  //- car is driving
-  POLLSTATE_CHARGING //- car is charging
+  POLLSTATE_CHARGING  //- car is charging
   };
 
 static const OvmsVehicle::poll_pid_t obdii_polls[] =
   {
-    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {  0, 999, 0, 0 } }, // VIN [19]
-    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1203, {  0, 999, 0, 0 } }, // QC [4]
-    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1205, {  0, 999, 0, 0 } }, // L0/L1/L2 [4]
+    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {  0, 30, 0, 0 } }, // VIN [19]
+    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1203, {  0, 30, 0, 0 } }, // QC [4]
+    { 0x797, 0x79a, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x1205, {  0, 30, 0, 0 } }, // L0/L1/L2 [4]
     { 0x79b, 0x7bb, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 0, 60 } }, // bat [39/41]
     { 0x79b, 0x7bb, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 0, 60 } }, // battery voltages [196]
     { 0x79b, 0x7bb, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {  0, 300, 0, 300 } }, // battery temperatures [14]
@@ -193,6 +193,7 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_car_on(bool isOn)
     {
     // Log once that car is being turned on
     ESP_LOGI(TAG,"CAR IS ON");
+    PollSetBus(m_can2);
     PollSetState(POLLSTATE_ON);
     // Reset trip values
     StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
@@ -205,7 +206,10 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_car_on(bool isOn)
     // Log once that car is being turned off
     ESP_LOGI(TAG,"CAR IS OFF");
     //StandardMetrics.ms_v_env_awake->SetValue(false);
-    PollSetState(POLLSTATE_OFF);
+    if (StandardMetrics.ms_v_charge_state->AsString()  != "charging")
+      {
+      PollSetState(POLLSTATE_OFF);
+      }
     }
 
   // Always set this value to prevent it from going stale
@@ -221,7 +225,7 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_car_on(bool isOn)
 //
 void OvmsVehicleNissanLeaf::vehicle_nissanleaf_charger_status(ChargerStatus status)
   {
-  bool fast_charge;
+  bool fast_charge  = false;
   switch (status)
     {
     case CHARGER_STATUS_IDLE:
@@ -236,6 +240,7 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_charger_status(ChargerStatus stat
       StandardMetrics.ms_v_charge_state->SetValue("stopped");
       break;
     case CHARGER_STATUS_QUICK_CHARGING:
+      fast_charge = true;
     case CHARGER_STATUS_CHARGING:
       if (!StandardMetrics.ms_v_charge_inprogress->AsBool())
         {
@@ -244,10 +249,11 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_charger_status(ChargerStatus stat
         }
       StandardMetrics.ms_v_door_chargeport->SetValue(true); //see 0x35d, can't use as only open signal
       StandardMetrics.ms_v_charge_inprogress->SetValue(true);
-      fast_charge = StandardMetrics.ms_v_charge_type->AsString() == "chademo";
+      StandardMetrics.ms_v_charge_type->SetValue(fast_charge ? "chademo" : "type1");
       StdMetrics.ms_v_charge_mode->SetValue(fast_charge ? "performance" : "standard");
       StandardMetrics.ms_v_charge_substate->SetValue("onrequest");
       StandardMetrics.ms_v_charge_state->SetValue("charging");
+      PollSetBus(m_can1);
       PollSetState(POLLSTATE_CHARGING);
       // TODO only use battery current for Quick Charging, for regular charging
       // we should return AC line current and voltage, not battery
@@ -307,6 +313,13 @@ int OvmsVehicleNissanLeaf::GetNotifyChargeStateDelay(const char* state)
     if (StandardMetrics.ms_m_monotonic->AsInt() < 10)
       return 0; //avoid notify on boot triggered by setting delay
     else return 5; //allow time for charger to handshake
+  }
+
+// Use to switch can bus to poll without resetting poll ticker
+void OvmsVehicleNissanLeaf::PollSetBus(canbus* bus)
+  {
+  OvmsMutexLock lock(&m_poll_mutex);
+  m_poll_bus = bus;
   }
 
 void OvmsVehicleNissanLeaf::PollReply_Battery(uint8_t reply_data[], uint16_t reply_len)
@@ -376,7 +389,10 @@ void OvmsVehicleNissanLeaf::PollReply_BMS_Volt(uint8_t reply_data[], uint16_t re
   for(i=0; i<96; i++)
     {
     int millivolt = reply_data[i*2] << 8 | reply_data[i*2+1];
-    BmsSetCellVoltage(i, millivolt / 1000.0);
+    if (millivolt < 5000) //ignore invalid readings
+      {
+      BmsSetCellVoltage(i, millivolt / 1000.0);
+      }
     }
   }
 
@@ -473,8 +489,9 @@ void OvmsVehicleNissanLeaf::PollReply_VIN(uint8_t reply_data[], uint16_t reply_l
   //  < 0x79a 61 81
   // [ 0..16] 53 4a 4e 46 41 41 5a 45 30 55 3X 3X 3X 3X 3X 3X 3X
   // [17..18] 00 00
-
-  StandardMetrics.ms_v_vin->SetValue((char*)reply_data);
+  char buf[19];
+  strncpy(buf,(char*)reply_data,reply_len);
+  StandardMetrics.ms_v_vin->SetValue(buf); //(char*)reply_data
   }
 
 // Reassemble all pieces of a multi-frame reply.
@@ -651,28 +668,25 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       //  {
         // can_databuffer[6] is the J1772 pilot current, 0.5A per bit
         // TODO enum?
-      float current_limit = d[6] / 2.0f;
-      StandardMetrics.ms_v_charge_climit->SetValue(current_limit);
-      if (current_limit > 0)
-        {
-        StandardMetrics.ms_v_charge_type->SetValue("type1");
-        }
+      StandardMetrics.ms_v_charge_climit->SetValue(d[6] / 2.0f);
+      StandardMetrics.ms_v_charge_current->SetValue(d[1] / 2.0f);
       //d[3] ramps from 0 to 0xB3 (179) but can sit at 1 due to capacitance?? set >90 to ensure valid signal
       //use to set pilot signal
-      StandardMetrics.ms_v_charge_voltage->SetValue(d[3]);
-      if (d[3] > 90)
+      //d[4] appears to be chademo charge voltage
+      StandardMetrics.ms_v_charge_voltage->SetValue(d[4] > d[3] ? d[4] : d[3]);
+      if (d[3] > 90 || d[4] > 90)
         {
-          StandardMetrics.ms_v_charge_pilot->SetValue(true);
-          StandardMetrics.ms_v_charge_current->SetValue(d[1]/2.0f); //AC charger current
+        StandardMetrics.ms_v_charge_pilot->SetValue(true);
         }
       else
         {
-          StandardMetrics.ms_v_charge_pilot->SetValue(false);
+        StandardMetrics.ms_v_charge_pilot->SetValue(false);
         }
       //  }
       switch (d[5])
         {
         case 0x80:
+        case 0x82:
           vehicle_nissanleaf_charger_status(CHARGER_STATUS_IDLE);
           break;
         case 0x83:
@@ -681,10 +695,18 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         case 0x84:
           vehicle_nissanleaf_charger_status(CHARGER_STATUS_FINISHED);
           break;
-        case 0x88:
-          vehicle_nissanleaf_charger_status(CHARGER_STATUS_CHARGING);
+        case 0x88: // on evse power loss car still reports 0x88
+          if (StandardMetrics.ms_v_charge_pilot->AsBool())
+            {
+            vehicle_nissanleaf_charger_status(CHARGER_STATUS_CHARGING);
+            }
+          else
+            {
+            vehicle_nissanleaf_charger_status(CHARGER_STATUS_FINISHED);
+            }
           break;
         case 0x90: //this state appears just before 0x88 and after evse removed (prepare/finish)
+        case 0x92:
           vehicle_nissanleaf_charger_status(CHARGER_STATUS_IDLE);
           break;
         case 0x98:
@@ -970,10 +992,10 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         {
         // Quick Charging
         // TODO enum?
-        StandardMetrics.ms_v_charge_type->SetValue("chademo");
+        //StandardMetrics.ms_v_charge_type->SetValue("chademo");
         StandardMetrics.ms_v_charge_climit->SetValue(120);
         StandardMetrics.ms_v_charge_pilot->SetValue(true);
-        StandardMetrics.ms_v_door_chargeport->SetValue(true);
+        //StandardMetrics.ms_v_door_chargeport->SetValue(true);
         }
       else
         {
@@ -984,7 +1006,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_charge_climit->SetValue(current_limit);
         if (current_limit > 0 && current_limit <= 32)
           {
-          StandardMetrics.ms_v_charge_type->SetValue("type1");
+          //StandardMetrics.ms_v_charge_type->SetValue("type1");
           StandardMetrics.ms_v_charge_pilot->SetValue(true);
           }
         }
@@ -1161,18 +1183,20 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         {
         case 0: // off
           vehicle_nissanleaf_car_on(false);
+          break;
         case 1: // accessory
-          //vehicle_nissanleaf_car_on(false);
-          StandardMetrics.ms_v_env_awake->SetValue(true);
         case 2: // on (not ready to drive)
-          //vehicle_nissanleaf_car_on(false);
           StandardMetrics.ms_v_env_awake->SetValue(true);
+          PollSetBus(m_can2);
+          PollSetState(POLLSTATE_ON);
+          break;
         case 3: // ready to drive, is triggered on unlock
           StandardMetrics.ms_v_env_awake->SetValue(true);
           if (StandardMetrics.ms_v_env_footbrake->AsFloat() > 0) //check footbrake to avoid false positive
           {
           vehicle_nissanleaf_car_on(true);
           }
+          break;
         }
 
       break;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -176,6 +176,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     float m_cum_energy_recd_wh; 					// Cumulated energy (in wh) recovered  within 1 second ticker interval
     float m_cum_energy_charge_wh;					// Cumulated energy (in wh) charged within 10 second ticker interval
     bool m_gen1_charger;					        // True if using original charger and 0x5bf messages, false if using 0x390 messages
+    bool m_enable_write;                  // Enable/disable can write (polling and commands)
   };
 
 #endif //#ifndef __VEHICLE_NISSANLEAF_H__

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -139,6 +139,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     void PollReply_VIN(uint8_t reply_data[], uint16_t reply_len);
     void PollReply_BMS_Volt(uint8_t reply_data[], uint16_t reply_len);
     void PollReply_BMS_Temp(uint8_t reply_data[], uint16_t reply_len);
+    void PollSetBus(canbus* bus);
 
     TimerHandle_t m_remoteCommandTimer;
     TimerHandle_t m_ccDisableTimer;

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.cpp
@@ -26,7 +26,7 @@
 #include "ovms_log.h"
 static const char *TAG = "v-twizy";
 
-#define VERSION "1.9.0"
+#define VERSION "1.10.0"
 
 #include <stdio.h>
 #include <string>

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.h
@@ -93,6 +93,7 @@ class OvmsVehicleRenaultTwizy : public OvmsVehicle
     void CanResponder(const CAN_frame_t* p_frame);
     void IncomingFrameCan1(CAN_frame_t* p_frame);
     void IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain);
+    void IncomingPollError(canbus* bus, uint16_t type, uint16_t pid, uint16_t code);
     void Ticker1(uint32_t ticker);
     void Ticker10(uint32_t ticker);
     void ConfigChanged(OvmsConfigParam* param);
@@ -498,7 +499,7 @@ class OvmsVehicleRenaultTwizy : public OvmsVehicle
     void ObdInit();
     void ObdTicker1();
     void ObdTicker10();
-    bool ObdRequest(uint16_t txid, uint16_t rxid, uint32_t request, string& response, int timeout_ms=3000);
+    int ObdRequest(uint16_t txid, uint16_t rxid, uint32_t request, string& response, int timeout_ms=3000);
 
   public:
     // Shell commands:
@@ -514,6 +515,7 @@ class OvmsVehicleRenaultTwizy : public OvmsVehicle
 
   protected:
     string              twizy_obd_rxbuf;
+    uint16_t            twizy_obd_rxerr;
     OvmsMutex           twizy_obd_request;
     OvmsSemaphore       twizy_obd_rxwait;
 

--- a/vehicle/OVMS.V3/production/fasttech/fasttech.skus.txt
+++ b/vehicle/OVMS.V3/production/fasttech/fasttech.skus.txt
@@ -12,3 +12,4 @@
 9658635,Kia Soul OBD-II to DB9 Data Cable for OVMS
 9665972,OVMS Data Cable for Early Teslas
 9728447,OVMS K-line Option Expansion Board Module
+9730443,OVMS Data Cable for Later Tesla Model S/X


### PR DESCRIPTION
Hi Michael,
Appreciate if you can review the changes I have made to the `ObdRequest` function to handle requests to either can bus, and that I'm using the semaphore and mutexes appropriately.

Also the shell command call to `ObdRequest` is working well but I cannot understand why the same function is not working from `Ticker60` (no TX/RX frames appear on the can bus before the timeout is logged), if you can let me know where I've gone wrong that would be great ;)