### PR TITLE
OTA: Change to use NetHttp and therefore support TLS.

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -10,6 +10,7 @@ Open Vehicle Monitor System v3 - Change log
 - VW e-UP T26A: add climate control and charging detection
 - New vehicle: VW e-Up via OBD-II Port (VWUP.OBD)
 - New vehicle: MG ZS EV via OBD-II Port (MGEV)
+- Add support for TLS OTA update and change to default
 
 2020-09-02 MWJ  3.2.015  OTA release
 - Notify: add explicit channel exclusion config syntax

--- a/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
+++ b/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
@@ -417,7 +417,7 @@ void ota_flash_http(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int arg
     std::string tag = MyConfig.GetParamValue("ota","tag");
     url = MyConfig.GetParamValue("ota","server");
     if (url.empty())
-      url = "api.openvehicles.com/firmware/ota";
+      url = "https://api.openvehicles.com/firmware/ota";
 #ifdef CONFIG_OVMS_HW_BASE_3_0
     url.append("/v3.0/");
 #endif //#ifdef CONFIG_OVMS_HW_BASE_3_0
@@ -690,7 +690,7 @@ void OvmsOTA::GetStatus(ota_info& info, bool check_update /*=true*/)
       std::string tag = MyConfig.GetParamValue("ota","tag");
       std::string url = MyConfig.GetParamValue("ota","server");
       if (url.empty())
-        url = "api.openvehicles.com/firmware/ota";
+        url = "https://api.openvehicles.com/firmware/ota";
 #ifdef CONFIG_OVMS_HW_BASE_3_0
       url.append("/v3.0/");
 #endif //#ifdef CONFIG_OVMS_HW_BASE_3_0
@@ -853,7 +853,7 @@ bool OvmsOTA::AutoFlash(bool force)
   std::string tag = MyConfig.GetParamValue("ota","tag");
   std::string url = MyConfig.GetParamValue("ota","server");
   if (url.empty())
-    url = "api.openvehicles.com/firmware/ota";
+    url = "https://api.openvehicles.com/firmware/ota";
 #ifdef CONFIG_OVMS_HW_BASE_3_0
   url.append("/v3.0/");
 #endif //#ifdef CONFIG_OVMS_HW_BASE_3_0

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -2167,12 +2167,6 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
     tag = c.getvar("tag");
 
     if (action.substr(0,3) == "set") {
-
-      if (startsWith(server, "https:")) {
-        error = true;
-        output += "<p>Sorry, https not yet supported!</p>";
-      }
-
       info.partition_boot = c.getvar("boot_old");
       std::string partition_boot = c.getvar("boot");
       if (partition_boot != info.partition_boot) {
@@ -2291,8 +2285,8 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
     "<p>Automatic updates are normally only done if a wifi connection is available at the time. Before allowing updates via modem, be aware a single firmware image has a size of around 3 MB, which may lead to additional costs on your data plan.</p>");
   c.print(
     "<datalist id=\"server-list\">"
-      "<option value=\"api.openvehicles.com/firmware/ota\">"
-      "<option value=\"ovms.dexters-web.de/firmware/ota\">"
+      "<option value=\"https://api.openvehicles.com/firmware/ota\">"
+      "<option value=\"https://ovms.dexters-web.de/firmware/ota\">"
     "</datalist>"
     "<datalist id=\"tag-list\">"
       "<option value=\"main\">"
@@ -2301,7 +2295,7 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
     "</datalist>"
     );
   c.input_text("Update server", "server", server.c_str(), "Specify or select from list (clear to see all options)",
-    "<p>Default is <code>api.openvehicles.com/firmware/ota</code>. Note: currently only http is supported.</p>",
+    "<p>Default is <code>https://api.openvehicles.com/firmware/ota</code>.</p>",
     "list=\"server-list\"");
   c.input_text("Version tag", "tag", tag.c_str(), "Specify or select from list (clear to see all options)",
     "<p>Default is <code>main</code> for standard releases. Use <code>eap</code> (early access program) for stable or <code>edge</code> for bleeding edge developer builds.</p>",

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_init.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_init.cpp
@@ -747,7 +747,7 @@ std::string OvmsWebServer::CfgInit3(PageEntry_t& p, PageContext_t& c, std::strin
   if (server.empty())
     server = MyConfig.GetParamValue("ota", "server");
   if (server.empty())
-    server = "api.openvehicles.com/firmware/ota";
+    server = "https://api.openvehicles.com/firmware/ota";
 
   MyOTA.GetStatus(info, true);
 
@@ -842,9 +842,9 @@ std::string OvmsWebServer::CfgInit3(PageEntry_t& p, PageContext_t& c, std::strin
   c.form_start(p.uri);
   c.input_radio_start("Update server", "server");
   c.input_radio_option("server", "Asia-Pacific (openvehicles.com)",
-    "api.openvehicles.com/firmware/ota" , server == "api.openvehicles.com/firmware/ota");
+    "https://api.openvehicles.com/firmware/ota" , server == "https://api.openvehicles.com/firmware/ota");
   c.input_radio_option("server", "Europe (dexters-web.de)",
-    "ovms.dexters-web.de/firmware/ota", server == "ovms.dexters-web.de/firmware/ota");
+    "https://ovms.dexters-web.de/firmware/ota", server == "https://ovms.dexters-web.de/firmware/ota");
   c.input_radio_end();
   c.print(
     "<div class=\"form-group\">"


### PR DESCRIPTION
This removes the old HTTP client and uses the newer Mongoose HTTP client which then allows for HTTPS updates (and changelogs).

Despite adding TLS support to the update, the binary size increase is very small.

I considered whether it was worth moving the implementations out of the downloaders from `ovms_ota.cpp`, I welcome comments on the implementation.  In addition, I had to do a fair amount of fudging in my `WaitForCompletion` function to allow it to execute as part of a request.