### PR TITLE
MG: Fix SoC polling when the car is running

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
@@ -108,7 +108,8 @@ void OvmsVehicleMgEv::IncomingPollFrame(CAN_frame_t* frame)
                 ESP_LOGV(TAG, "Got response from gateway, wake up complete");
                 m_wakeState = Tester;
                 // If we are currently unlocked, then send to BCM
-                if (StandardMetrics.ms_v_env_locked->AsBool() == false)
+                if (StandardMetrics.ms_v_env_locked->AsBool() == false &&
+                    monotonictime - StandardMetrics.ms_v_env_locked->LastModified() <= 2)
                 {
                     SendKeepAliveTo(frame->origin, bcmId);
                 }

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -87,8 +87,8 @@ void OvmsVehicleMgEv::IncomingBmsPoll(uint16_t pid, uint8_t* data, uint8_t lengt
                         StandardMetrics.ms_v_charge_state->SetValue("topoff");
                     }
                 }
-                // SoC is 3% - 97%, so we need to scale it
-                StandardMetrics.ms_v_bat_soc->SetValue(((soc * 103.0) / 97.0) - 3.0);
+                // SoC is 7% - 97%, so we need to scale it
+                StandardMetrics.ms_v_bat_soc->SetValue(((soc * 107.0) / 97.0) - 7.0);
             }
             break;
         case bmsStatusPid:

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -175,10 +175,14 @@ void OvmsVehicleMgEv::SoftwareVersions(
 void OvmsVehicleMgEv::SoftwareVersions(OvmsWriter* writer)
 {
     constexpr uint32_t ecus[] = {
-        bmsId, dcdcId, vcuId, atcId, bcmId, gwmId, tpmsId, pepsId, 0x761u, 0x760u
+        bmsId, dcdcId, vcuId, atcId, bcmId, gwmId, tpmsId, pepsId, 0x761u, 0x760u, 0x784u,
+        0x750u, 0x776u, 0x771u, 0x782u, 0x734u, 0x733u, 0x732u, 0x730u, 0x723u, 0x721u,
+        0x720u, 0x711u
     };
     const char *names[] = {
-        "BMS", "DCDC", "VCU", "ATC", "BCM", "GWM", "TPMS", "PEPS", "ICE", "IPK"
+        "BMS", "DCDC", "VCU", "ATC", "BCM", "GWM", "TPMS", "PEPS", "ICE", "IPK", "EVCC",
+        "ATC", "PLC", "SCU", "TC", "FDR", "FVCM", "RDRA", "SRM", "EPB", "EPS",
+        "ABS", "TBOX"
     };
     constexpr uint32_t ecuCount = sizeof(ecus) / sizeof(ecus[0]);
 


### PR DESCRIPTION
The PEPS module reports that the car is locked when it is running (even if it isn't).  Therefore revert the logic to check if the car is on first before checking if it's locked.  However, this requires us to be a bit more careful about when we poll the BCM to avoid alarms.