### PR TITLE
VWUP.T26: Fixed some minor bugs.

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
@@ -136,7 +136,8 @@ ID	Conversion	     Unit    Function
 527	(d5/2)-50	     °C      Outdoor temperature     	         	
 531	d0 00		             Headlights off
 52D	d0 +255 if d1 41     km	     Calculated range		     
-470	d1 1,2,4,8,20,10     Integer Status doors, trunk, hood		     
+381     d0 02			     Status doors locked
+470	d1 1,2,4,8,20,10     Integer Doors, trunk, hood opened or closed	
 3E1	d4		     Integer Blower speed? (57,66,7D,98,BB,DE,FA)
 575	d0 00 to 0F 	     Integer Key position		         	
 569	b07			     "AC"-LED

--- a/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
@@ -142,7 +142,7 @@ ID	Conversion	     Unit    Function
 569	b07			     "AC"-LED
 69C	d1/10+10	     °C      temperature setpoint for remote AC
 				     (only in message D2 <d1> 00 1E 1E 0A 00 00)
-61C	d2 00 or 01	     bool    Charging detection				
+61C	d2 00,01,06	     bool    Charging detection				
 43D	d1 01 or 11		     TX: Working or sleeping in the ring     	
 5A7	d1 16			     TX: OCU AC blocking signal
 5A9	all 00			     TX: OCU heartbeat

--- a/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
@@ -142,7 +142,7 @@ ID	Conversion	     Unit    Function
 569	b07			     "AC"-LED
 69C	d1/10+10	     °C      temperature setpoint for remote AC
 				     (only in message D2 <d1> 00 1E 1E 0A 00 00)
-61C	d2 00,01,06	     bool    Charging detection				
+61C	d2 < 07		     bool    Charging detection				
 43D	d1 01 or 11		     TX: Working or sleeping in the ring     	
 5A7	d1 16			     TX: OCU AC blocking signal
 5A9	all 00			     TX: OCU heartbeat

--- a/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
@@ -135,7 +135,7 @@ ID	Conversion	     Unit    Function
 3E3	(d2-100)/2           °C      Cabin temperature      	         	
 527	(d5/2)-50	     °C      Outdoor temperature     	         	
 531	d0 00		             Headlights off
-52D	d0		     km	     Calculated range		     
+52D	d0 +255 if d1 41     km	     Calculated range		     
 470	d1 1,2,4,8,20,10     Integer Status doors, trunk, hood		     
 3E1	d4		     Integer Blower speed? (57,66,7D,98,BB,DE,FA)
 575	d0 00 to 0F 	     Integer Key position		         	

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
@@ -101,6 +101,8 @@
 ;
 ;    0.4.1  Corrected estimated range
 ;
+;    0.4.2  Corrected locked status, cabin temperature
+:
 ;    (C) 2020       Chris van der Meijden
 ;
 ;    Big thanx to sharkcow, Dimitrie78, E-Imo, Dexter and 'der kleine Nik'.
@@ -109,7 +111,7 @@
 #include "ovms_log.h"
 static const char *TAG = "v-vweup-t26";
 
-#define VERSION "0.4.1"
+#define VERSION "0.4.2"
 
 #include <stdio.h>
 #include "pcp.h"
@@ -350,7 +352,7 @@ void OvmsVehicleVWeUpT26::IncomingFrameCan3(CAN_frame_t *p_frame)
         break;
 
     case 0x381: // Vehicle locked
-        if (d[0] > 0)
+        if (d[0] == 0x02)
         {
              StandardMetrics.ms_v_env_locked->SetValue(true);
         }
@@ -361,9 +363,12 @@ void OvmsVehicleVWeUpT26::IncomingFrameCan3(CAN_frame_t *p_frame)
         break;
 
     case 0x3E3: // Cabin temperature
-        StandardMetrics.ms_v_env_cabintemp->SetValue((d[2]-100)/2);
-        // Set PEM inv temp to support older app version with cabin temp workaround display
-        StandardMetrics.ms_v_inv_temp->SetValue((d[2] - 100) / 2);
+        if (d[2] != 0xFF)
+        {
+           StandardMetrics.ms_v_env_cabintemp->SetValue((d[2]-100)/2);
+           // Set PEM inv temp to support older app version with cabin temp workaround display
+           StandardMetrics.ms_v_inv_temp->SetValue((d[2] - 100) / 2);
+        }
         break;
 
     case 0x470: // Doors

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
@@ -31,7 +31,7 @@
 
 /*
 ;    Subproject:    Integration of support for the VW e-UP
-;    Date:          23rd September 2020
+;    Date:          28th September 2020
 ;
 ;    Changes:
 ;    0.1.0  Initial code
@@ -97,6 +97,8 @@
 ;
 ;    0.3.9  Corrected estimated range
 ;
+;    0.4.0  Implemnted ICCB charging detection
+;
 ;    (C) 2020       Chris van der Meijden
 ;
 ;    Big thanx to sharkcow, Dimitrie78, E-Imo, Dexter and 'der kleine Nik'.
@@ -105,7 +107,7 @@
 #include "ovms_log.h"
 static const char *TAG = "v-vweup-t26";
 
-#define VERSION "0.3.9"
+#define VERSION "0.4.0"
 
 #include <stdio.h>
 #include "pcp.h"
@@ -395,7 +397,8 @@ void OvmsVehicleVWeUpT26::IncomingFrameCan3(CAN_frame_t *p_frame)
 
     case 0x61C: // Charge detection
       cd_count++;
-      if ((d[2] == 0x00) || (d[2] == 0x01)) {
+      if ((d[2] == 0x00) || (d[2] == 0x01 || d[2] == 0x06)) {
+         // 06 is ICCB
          isCharging = true;
       } else {
          isCharging = false;

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
@@ -31,7 +31,7 @@
 
 /*
 ;    Subproject:    Integration of support for the VW e-UP
-;    Date:          28th September 2020
+;    Date:          29th September 2020
 ;
 ;    Changes:
 ;    0.1.0  Initial code
@@ -99,6 +99,8 @@
 ;
 ;    0.4.0  Implemnted ICCB charging detection
 ;
+;    0.4.1  Corrected estimated range
+;
 ;    (C) 2020       Chris van der Meijden
 ;
 ;    Big thanx to sharkcow, Dimitrie78, E-Imo, Dexter and 'der kleine Nik'.
@@ -107,7 +109,7 @@
 #include "ovms_log.h"
 static const char *TAG = "v-vweup-t26";
 
-#define VERSION "0.4.0"
+#define VERSION "0.4.1"
 
 #include <stdio.h>
 #include "pcp.h"
@@ -279,8 +281,9 @@ void OvmsVehicleVWeUpT26::IncomingFrameCan3(CAN_frame_t *p_frame)
 
     case 0x52D: // KM range left (estimated).
         if (d[0] != 0xFE) {
-           if (d[0] > 0x06) {
-              if (d[0] < 0x08) d[0] = 0x00;
+           if (d[1] == 0x41) {
+              StandardMetrics.ms_v_bat_range_est->SetValue(d[0] + 255);
+           } else {
               StandardMetrics.ms_v_bat_range_est->SetValue(d[0]);
            }
         }

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/t26_eup.cpp
@@ -397,8 +397,7 @@ void OvmsVehicleVWeUpT26::IncomingFrameCan3(CAN_frame_t *p_frame)
 
     case 0x61C: // Charge detection
       cd_count++;
-      if ((d[2] == 0x00) || (d[2] == 0x01 || d[2] == 0x06)) {
-         // 06 is ICCB
+      if (d[2] < 0x07) {
          isCharging = true;
       } else {
          isCharging = false;


### PR DESCRIPTION
Fixed ICCB detection, wrong values on estimated range, wrong values on cabin temperature and wrong locked/unlocked status when the doors were opened.
