### PR TITLE
MG: Handle charging in a more dignified way

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
@@ -75,11 +75,18 @@ void OvmsVehicleMgEv::IncomingPollFrame(CAN_frame_t* frame)
 {
     if (frame->MsgID == 0x70au)
     {
-        ESP_LOGI(
+        ESP_LOGV(
             TAG, "Wake up message (length %d): %02x %02x %02x %02x %02x %02x %02x",
             frame->FIR.B.DLC, frame->data.u8[0], frame->data.u8[1], frame->data.u8[2],
             frame->data.u8[3], frame->data.u8[4], frame->data.u8[5], frame->data.u8[6]
         );
+        if (m_wakeState == Off)
+        {
+            // If we get a 70a and the CAN is off, then we'll need to wake the CAN
+            ESP_LOGI(TAG, "Wake state from %d to %d", Off, Diagnostic);
+            m_wakeState = Diagnostic;
+            m_wakeTicker = monotonictime;
+        }
     }
 
     uint8_t frameType = frame->data.u8[0] >> 4;

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -168,8 +168,8 @@ void OvmsVehicleMgEv::IncomingBmsPoll(
                         StandardMetrics.ms_v_charge_state->SetValue("topoff");
                     }
                 }
-                // SoC is 7% - 97%, so we need to scale it
-                StandardMetrics.ms_v_bat_soc->SetValue(((soc * 107.0) / 97.0) - 7.0);
+                // SoC is 6% - 97%, so we need to scale it
+                StandardMetrics.ms_v_bat_soc->SetValue(((soc * 106.0) / 97.0) - 6.0);
             }
             break;
         case bmsStatusPid:

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_vcu.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_vcu.cpp
@@ -65,7 +65,11 @@ void OvmsVehicleMgEv::IncomingVcuPoll(
         case vcuIgnitionStatePid:
             // Aux only is 1, but we'll say it's on when the ignition is too
             StandardMetrics.ms_v_env_aux12v->SetValue(data[0] != 0);
-            StandardMetrics.ms_v_env_on->SetValue(data[0] == 2);
+            if (StandardMetrics.ms_v_env_on->AsBool() != (data[0] == 2))
+            {
+                // Only set on change so we can see when it was turned on
+                StandardMetrics.ms_v_env_on->SetValue(data[0] == 2);
+            }
             break;
         case vcuVinPid:
             HandleVinMessage(data, length, remain);

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -95,8 +95,8 @@ const OvmsVehicle::poll_pid_t obdii_polls[] =
 // The number of seconds without receiving a CAN packet before assuming it's asleep
 constexpr uint32_t ASLEEP_TIMEOUT = 5u;
 
-// The number of seconds without a CAN TX error before we assume in zombie mode
-constexpr uint32_t ZOMBIE_TIMEOUT = 10u;
+// The number of seconds trying to wake from zombie before giving up
+constexpr uint32_t ZOMBIE_TIMEOUT = 30u;
 
 // The number of seconds since the last time the wake state changed before assuming
 // zombie mode

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -102,6 +102,10 @@ constexpr uint32_t ZOMBIE_TIMEOUT = 10u;
 // zombie mode
 constexpr uint32_t TRANSITION_TIMEOUT = 25u;
 
+/// The number of seconds the car has to be unlocked for before transitioning from session
+/// keep alive to TP keep alive
+constexpr uint32_t UNLOCKED_CHARGING_TIMEOUT = 5u;
+
 }  // anon namespace
 
 OvmsVehicleMgEv::OvmsVehicleMgEv()
@@ -379,6 +383,12 @@ void OvmsVehicleMgEv::DeterminePollState(canbus* currentBus, bool wokenUp, uint3
     {
         PollSetState(PollStateCharging);
         if (m_wakeState == Off || m_wakeState == Awake)
+        {
+            m_wakeState = Tester;
+            m_wakeTicker = ticker;
+        }
+        if (m_wakeState == Diagnostic && !StandardMetrics.ms_v_env_locked->AsBool() &&
+                ticker - m_wakeTicker > UNLOCKED_CHARGING_TIMEOUT)
         {
             m_wakeState = Tester;
             m_wakeTicker = ticker;

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
@@ -145,10 +145,6 @@ class OvmsVehicleMgEv : public OvmsVehicle
     uint32_t m_rxPacketTicker;
     /// The last number of packets received on the CAN
     uint32_t m_rxPackets;
-    /// The last ticker that we saw a TX error on
-    uint32_t m_txErrorsTicker;
-    /// The last number of TX errors on the CAN
-    uint32_t m_txErrors;
     /// The current state of the CAN to the gateway
     WakeState m_wakeState;
     /// The ticker time the wake state was changed


### PR DESCRIPTION
We currently cause the charger port to be locked when the car is unlocked and detect zombie mode in a way that is dependant on the CAN hardware.  This resolves those issues.