### PR TITLE
MG: 12v protection

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
@@ -84,8 +84,7 @@ void OvmsVehicleMgEv::IncomingPollFrame(CAN_frame_t* frame)
         {
             // If we get a 70a and the CAN is off, then we'll need to wake the CAN
             ESP_LOGI(TAG, "Wake state from %d to %d", Off, Diagnostic);
-            m_wakeState = Diagnostic;
-            m_wakeTicker = monotonictime;
+            AttemptDiagnostic();
         }
     }
 

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
@@ -80,7 +80,8 @@ void OvmsVehicleMgEv::IncomingPollFrame(CAN_frame_t* frame)
             frame->FIR.B.DLC, frame->data.u8[0], frame->data.u8[1], frame->data.u8[2],
             frame->data.u8[3], frame->data.u8[4], frame->data.u8[5], frame->data.u8[6]
         );
-        if (m_wakeState == Off)
+        // If we were off, or woken by this message then wake up
+        if (m_wakeState == Off || (m_wakeState == Awake && monotonictime == m_wakeTicker))
         {
             // If we get a 70a and the CAN is off, then we'll need to wake the CAN
             ESP_LOGI(TAG, "Wake state from %d to %d", Off, Diagnostic);

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -106,6 +106,9 @@ constexpr uint32_t TRANSITION_TIMEOUT = 25u;
 /// keep alive to TP keep alive
 constexpr uint32_t UNLOCKED_CHARGING_TIMEOUT = 5u;
 
+/// Maximum number of times to try and wake the car to find it wasn't charging or on
+constexpr uint16_t DIAG_ATTEMPTS = 3u;
+
 }  // anon namespace
 
 OvmsVehicleMgEv::OvmsVehicleMgEv()
@@ -138,6 +141,7 @@ OvmsVehicleMgEv::OvmsVehicleMgEv()
     // Assume the CAN is off to start with
     m_wakeState = Off;
     m_wakeTicker = 0u;
+    m_diagCount = 0u;
 
     // Create the timer for zombie mode, but no need to start it yet
     m_zombieTimer = xTimerCreate(
@@ -335,8 +339,7 @@ bool OvmsVehicleMgEv::HasWoken(canbus* currentBus, uint32_t ticker)
         if (m_wakeState == Tester)
         {
             ESP_LOGD(TAG, "Car not responding while sending TP, sending diagnostic");
-            m_wakeState = Diagnostic;
-            m_wakeTicker = monotonictime;
+            AttemptDiagnostic();
         }
         else if (m_wakeState != Waking && m_wakeState != Off &&
                 (m_wakeState != Diagnostic || monotonictime - m_wakeTicker > ZOMBIE_TIMEOUT))
@@ -349,10 +352,24 @@ bool OvmsVehicleMgEv::HasWoken(canbus* currentBus, uint32_t ticker)
     return wokenUp;
 }
 
+void OvmsVehicleMgEv::AttemptDiagnostic()
+{
+    if (m_diagCount > DIAG_ATTEMPTS)
+    {
+        ESP_LOGE(TAG, "Woken the car too many times without success, not trying again");
+        m_wakeState = Off;
+        return;
+    }
+    ++m_diagCount;
+    m_wakeState = Diagnostic;
+    m_wakeTicker = monotonictime;
+}
+
 void OvmsVehicleMgEv::DeterminePollState(canbus* currentBus, bool wokenUp, uint32_t ticker)
 {
     if (StandardMetrics.ms_v_charge_inprogress->AsBool())
     {
+        m_diagCount = 0u;
         PollSetState(PollStateCharging);
         if (m_wakeState == Off || m_wakeState == Awake)
         {
@@ -371,6 +388,7 @@ void OvmsVehicleMgEv::DeterminePollState(canbus* currentBus, bool wokenUp, uint3
         if (StandardMetrics.ms_v_env_on->AsBool() &&
                 monotonictime - StandardMetrics.ms_v_env_on->LastModified() >= 5)
         {
+            m_diagCount = 0u;
             PollSetState(PollStateRunning);
         }
         else if (StandardMetrics.ms_v_env_locked->AsBool())

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -92,15 +92,15 @@ const OvmsVehicle::poll_pid_t obdii_polls[] =
     { 0, 0, 0x00, 0x00, { 0, 0, 0, 0 }, 0 }
 };
 
-// The number of seconds without receiving a CAN packet before assuming it's asleep
+/// The number of seconds without receiving a CAN packet before assuming it's asleep
 constexpr uint32_t ASLEEP_TIMEOUT = 5u;
 
-// The number of seconds trying to wake from zombie before giving up
+/// The number of seconds trying to wake from zombie before giving up
 constexpr uint32_t ZOMBIE_TIMEOUT = 30u;
 
-// The number of seconds since the last time the wake state changed before assuming
-// zombie mode
-constexpr uint32_t TRANSITION_TIMEOUT = 25u;
+/// The number of seconds trying to keep awake without success before allowing it to
+/// go to sleep
+constexpr uint32_t TRANSITION_TIMEOUT = 50u;
 
 /// The number of seconds the car has to be unlocked for before transitioning from session
 /// keep alive to TP keep alive

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -363,13 +363,6 @@ void OvmsVehicleMgEv::AttemptDiagnostic()
         m_wakeState = Off;
         return;
     }
-    // Check against the threshold rather than ms_v_env_charging12v to catch before the
-    // ticker loop executes
-    if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() < CHARGING_THRESHOLD)
-    {
-        ESP_LOGI(TAG, "12v doesn't appear to be charging, not going to attempt to wake");
-        return;
-    }
     ++m_diagCount;
     m_wakeState = Diagnostic;
     m_wakeTicker = monotonictime;
@@ -433,6 +426,13 @@ void OvmsVehicleMgEv::ZombieTimer()
     if (currentBus == nullptr)
     {
         // Polling is disabled, so there's nothing to do here
+        return;
+    }
+    if (!StandardMetrics.ms_v_env_charging12v->AsBool())
+    {
+        // Don't wake the car if the 12v isn't charging because that can only end in a
+        // dead battery
+        ESP_LOGV(TAG, "Not sending SO as 12v is not charging.");
         return;
     }
     // Send Diagnostic Session Control (0x10, 0x02).

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
@@ -92,6 +92,8 @@ class OvmsVehicleMgEv : public OvmsVehicle
     void SendAlarmSensitive(canbus* currentBus);
     bool SendKeepAliveTo(canbus* currentBus, uint16_t id);
 
+    void AttemptDiagnostic();
+
     void NotifyVehicleIdling() override;
 
     // mg_poll_bms.cpp
@@ -149,6 +151,8 @@ class OvmsVehicleMgEv : public OvmsVehicle
     WakeState m_wakeState;
     /// The ticker time the wake state was changed
     uint32_t m_wakeTicker;
+    /// A count of the number of times we've woken the car to find it wasn't charging
+    uint16_t m_diagCount;
     /// A timer used to send the zombie keep alive frame which is required every 250ms
     TimerHandle_t m_zombieTimer;
     /// The command registered when the car is made to query the software versions of the


### PR DESCRIPTION
Additional protection to avoid the 12v from draining.  Does not appear to always be able to detect a delayed charge anymore, but will not deplete the 12v battery, so better for a stable release.