### PR TITLE
Net: Support for connection timeout in NetConns.

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_netconns.h
+++ b/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_netconns.h
@@ -57,7 +57,7 @@ class OvmsNetTcpClient: public OvmsMongooseWrapper
     virtual void Mongoose(struct mg_connection *nc, int ev, void *ev_data);
 
   public:
-    bool Connect(std::string dest, struct mg_connect_opts opts);
+    bool Connect(std::string dest, struct mg_connect_opts opts, double timeout = 0.0);
     void Disconnect();
     size_t SendData(uint8_t *data, size_t length);
     bool IsConnected();

--- a/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.cpp
+++ b/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.cpp
@@ -56,7 +56,7 @@ OvmsNetHttpAsyncClient::~OvmsNetHttpAsyncClient()
     }
   }
 
-bool OvmsNetHttpAsyncClient::Request(std::string url, const char* method)
+bool OvmsNetHttpAsyncClient::Request(std::string url, const char* method, double timeout)
   {
   m_url = url;
   m_method = method;
@@ -114,7 +114,7 @@ bool OvmsNetHttpAsyncClient::Request(std::string url, const char* method)
     }
 
   m_httpstate = NetHttpConnecting;
-  return Connect(m_dest, opts);
+  return Connect(m_dest, opts, timeout);
   }
 
 int OvmsNetHttpAsyncClient::ResponseCode()

--- a/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.h
+++ b/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.h
@@ -54,7 +54,7 @@ class OvmsNetHttpAsyncClient: public OvmsNetTcpClient
       };
 
   public:
-    bool Request(std::string url, const char* method = "GET");
+    bool Request(std::string url, const char* method = "GET", double timeout = 0.0);
     int ResponseCode();
     size_t BodySize();
     OvmsNetHttpAsyncClient::NetHttpState GetState();


### PR DESCRIPTION
This adds support for connection timeouts (and fixes a race condition with the user data) but I don't think this class is actually used by anything.  Perhaps it should simply be removed?