### PR TITLE
fix cabintemp, add battery heater metric

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
@@ -74,17 +74,19 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   bool socnewcar;
   bool sohnewcar;
   std::string modelyear;
+  std::string cabintempoffset;
   std::string maxgids;
   std::string newcarah;
 
   if (c.method == "POST") {
     // process form submission:
-    modelyear = c.getvar("modelyear");
-    maxgids   = c.getvar("maxgids");
-    newcarah  = c.getvar("newcarah");
-    socnewcar = (c.getvar("socnewcar") == "yes");
-    sohnewcar = (c.getvar("sohnewcar") == "yes");
-    canwrite  = (c.getvar("canwrite") == "yes");
+    modelyear       = c.getvar("modelyear");
+    cabintempoffset = c.getvar("cabintempoffset");
+    maxgids         = c.getvar("maxgids");
+    newcarah        = c.getvar("newcarah");
+    socnewcar       = (c.getvar("socnewcar") == "yes");
+    sohnewcar       = (c.getvar("sohnewcar") == "yes");
+    canwrite        = (c.getvar("canwrite") == "yes");
 
     // check:
     if (!modelyear.empty()) {
@@ -92,10 +94,15 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
       if (n < 2011)
         error += "<li data-input=\"modelyear\">Model year must be &ge; 2011</li>";
     }
+    
+    if (cabintempoffset.empty()) {
+      error += "<li data-input=\"cabintempoffset\">Cabin Temperature Offset can not be empty</li>";
+    }
 
     if (error == "") {
       // store:
       MyConfig.SetParamValue("xnl", "modelyear", modelyear);
+      MyConfig.SetParamValue("xnl", "cabintempoffset", cabintempoffset);
       MyConfig.SetParamValue("xnl", "maxGids",   maxgids);
       MyConfig.SetParamValue("xnl", "newCarAh",  newcarah);
       MyConfig.SetParamValueBool("xnl", "soc.newcar", socnewcar);
@@ -116,12 +123,13 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   }
   else {
     // read configuration:
-    modelyear = MyConfig.GetParamValue("xnl", "modelyear", STR(DEFAULT_MODEL_YEAR));
-    maxgids   = MyConfig.GetParamValue("xnl", "maxGids", STR(GEN_1_NEW_CAR_GIDS));
-    newcarah  = MyConfig.GetParamValue("xnl", "newCarAh", STR(GEN_1_NEW_CAR_AH));
-    socnewcar = MyConfig.GetParamValueBool("xnl", "soc.newcar", false);
-    sohnewcar = MyConfig.GetParamValueBool("xnl", "soh.newcar", false);
-    canwrite  = MyConfig.GetParamValueBool("xnl", "canwrite", false);
+    modelyear       = MyConfig.GetParamValue("xnl", "modelyear", STR(DEFAULT_MODEL_YEAR));
+    cabintempoffset = MyConfig.GetParamValue("xnl", "cabintempoffset", STR(DEFAULT_CABINTEMP_OFFSET));
+    maxgids         = MyConfig.GetParamValue("xnl", "maxGids", STR(GEN_1_NEW_CAR_GIDS));
+    newcarah        = MyConfig.GetParamValue("xnl", "newCarAh", STR(GEN_1_NEW_CAR_AH));
+    socnewcar       = MyConfig.GetParamValueBool("xnl", "soc.newcar", false);
+    sohnewcar       = MyConfig.GetParamValueBool("xnl", "soh.newcar", false);
+    canwrite        = MyConfig.GetParamValueBool("xnl", "canwrite", false);
 
     c.head(200);
   }
@@ -155,6 +163,9 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input("number", "Model year", "modelyear", modelyear.c_str(), "Default: " STR(DEFAULT_MODEL_YEAR),
     "<p>This determines the format of CAN write messages as it differs slightly between model years.</p>",
     "min=\"2011\" step=\"1\"", "");
+  c.input("number", "Cabin Temperature Offset", "cabintempoffset", cabintempoffset.c_str(), "Default: " STR(DEFAULT_CABINTEMP_OFFSET),
+    "<p>This allows to adjust the cabin temperature sensor readings in celcius.</p>",
+    "step=\"0.1\"", "");
   c.fieldset_end();
 
   c.print("<hr>");

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -138,7 +138,7 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   m_battery_energy_capacity = MyMetrics.InitFloat("xnl.v.b.e.capacity", SM_STALE_HIGH, 0, kWh);
   m_battery_energy_available = MyMetrics.InitFloat("xnl.v.b.e.available", SM_STALE_HIGH, 0, kWh);
   m_battery_type = MyMetrics.InitInt("xnl.v.b.type", SM_STALE_HIGH, 0); // auto-detect version and size by can traffic
-  m_battery_heaterpresent = MyMetrics.InitBool("v.b.heaterpresent", SM_STALE_HIGH, false);
+  m_battery_heaterpresent = MyMetrics.InitBool("xnl.v.b.heaterpresent", SM_STALE_HIGH, false);
   m_charge_duration = MyMetrics.InitVector<int>("xnl.v.c.duration", SM_STALE_HIGH, 0, Minutes);
   // note vector strings are not handled by ovms_metrics.h and cause web errors loading ev.data in ovms.js
   // this will need to be resolved before reinstating metrics

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1264,8 +1264,10 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         {
         StandardMetrics.ms_v_bat_temp->SetValue(d[2] / 2 - 40);
         }
-      // Battery Heater existance as reported by the LBC. Frame 4, bit 0.
-      if ( d[4] )
+      /* Battery Heater existance as reported by the LBC. 
+       * Frame 4, bit 0. Note this should only work on AZE0. 
+       */
+      if ( d[4] && MyConfig.GetParamValueInt("xnl", "modelyear", DEFAULT_MODEL_YEAR) >= 2013 )
         {
         m_battery_heaterpresent->SetValue(d[4] & 0x01);
         }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -138,6 +138,7 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   m_battery_energy_capacity = MyMetrics.InitFloat("xnl.v.b.e.capacity", SM_STALE_HIGH, 0, kWh);
   m_battery_energy_available = MyMetrics.InitFloat("xnl.v.b.e.available", SM_STALE_HIGH, 0, kWh);
   m_battery_type = MyMetrics.InitInt("xnl.v.b.type", SM_STALE_HIGH, 0); // auto-detect version and size by can traffic
+  m_battery_heaterpresent = MyMetrics.InitBool("v.b.heaterpresent", SM_STALE_HIGH, false);
   m_charge_duration = MyMetrics.InitVector<int>("xnl.v.c.duration", SM_STALE_HIGH, 0, Minutes);
   // note vector strings are not handled by ovms_metrics.h and cause web errors loading ev.data in ovms.js
   // this will need to be resolved before reinstating metrics
@@ -1006,9 +1007,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
 
       bool hvac_calculated = false;
 
-      int model_year = MyConfig.GetParamValueInt("xnl", "modelyear", DEFAULT_MODEL_YEAR);
-
-      if (model_year < 2013)
+      if (MyConfig.GetParamValueInt("xnl", "modelyear", DEFAULT_MODEL_YEAR) < 2013)
       // leaving this legacy (mostly) code part until someone tests the new logic in <2013 cars.
       {
         // this might be a bit field? So far these 6 values indicate HVAC on
@@ -1076,10 +1075,11 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
     case 0x54f:
       /* Climate control's measurement of temperature inside the car.
        * Appears to be in Fahrenheit. Unsure why the check for 20? 
+       * mjk: seeems like off by 6 celcius on 2013 models, so added cabintempoffset that can be set in GUI.
        */
       if (d[0] != 20)
         {
-        StandardMetrics.ms_v_env_cabintemp->SetValue(5.0 / 9.0 * (d[0] - 32));
+        StandardMetrics.ms_v_env_cabintemp->SetValue((5.0 / 9.0 * (d[0] - 32)) + MyConfig.GetParamValueFloat("xnl", "cabintempoffset", DEFAULT_CABINTEMP_OFFSET));
         // StandardMetrics.ms_v_env_cabintemp->SetValue(d[0] / 2.0 - 14);
         }
       break;
@@ -1263,6 +1263,11 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       if ( (d[0]>>6) == 1 )
         {
         StandardMetrics.ms_v_bat_temp->SetValue(d[2] / 2 - 40);
+        }
+      // Battery Heater existance as reported by the LBC. Frame 4, bit 0.
+      if ( d[4] )
+        {
+        m_battery_heaterpresent->SetValue(d[4] & 0x01);
         }
       break;
     }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -42,6 +42,7 @@
 #include "nl_types.h"
 
 #define DEFAULT_MODEL_YEAR 2012
+#define DEFAULT_CABINTEMP_OFFSET .0
 #define GEN_1_NEW_CAR_GIDS 281
 #define GEN_1_NEW_CAR_AH 66
 #define GEN_1_KM_PER_KWH 7.1
@@ -164,6 +165,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     OvmsMetricFloat *m_battery_energy_capacity;
     OvmsMetricFloat *m_battery_energy_available;
     OvmsMetricInt *m_battery_type;
+    OvmsMetricBool *m_battery_heaterpresent;
     OvmsMetricVector<int> *m_charge_duration;
     OvmsMetricVector<string> *m_charge_duration_label;
     OvmsMetricInt *m_quick_charge;


### PR DESCRIPTION
- Cabin temperature readings seem to differ between cars. Added configurable offset in NL Features GUI.
- Added battery heater present (yes/no) metric as discussed in #311 `v.b.heaterpresent                        yes`