### PR TITLE
NL: improved climate settings >2015

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1067,8 +1067,8 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_env_heating->SetValue(heating);
         StandardMetrics.ms_v_env_cooling->SetValue(cooling);
         // The following 2 values work only when climate control is activated while connected to charger.
-        m_climate_remoteheat->SetValue((d[1] & 0x0B) && heating); // needs confirming
-        m_climate_remotecool->SetValue((d[1] & 0x0A) && cooling);
+        m_climate_remoteheat->SetValue((d[1] & 0x0B) == 0x0B && heating); // needs confirming
+        m_climate_remotecool->SetValue((d[1] & 0x0A) == 0x0A && cooling);
         m_climate_auto->SetValue(d[1] & 0x02);
         
         hvac_calculated =  (d[1] != 0x08); 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1071,7 +1071,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         m_climate_remotecool->SetValue((d[1] & 0x0A) == 0x0A && cooling);
         m_climate_auto->SetValue(d[1] & 0x02);
         
-        hvac_calculated =  (d[1] != 0x08); 
+        hvac_calculated =  (d[1] != 0x08 && d[1] != 0x04); 
         // if climate control is off set fan speed to 0 as can bus value seems to be fan speed setpoint
         if (!hvac_calculated) m_climate_fan_speed->SetValue(0);
       }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1067,8 +1067,8 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_env_heating->SetValue(heating);
         StandardMetrics.ms_v_env_cooling->SetValue(cooling);
         // The following 2 values work only when climate control is activated while connected to charger.
-        m_climate_remoteheat->SetValue((d[1] & 0x0B) == 0x0B && heating); // needs confirming
-        m_climate_remotecool->SetValue((d[1] & 0x0A) == 0x0A && cooling);
+        m_climate_remoteheat->SetValue(!StandardMetrics.ms_v_env_on->AsBool() && heating);
+        m_climate_remotecool->SetValue(!StandardMetrics.ms_v_env_on->AsBool() && cooling);
         m_climate_auto->SetValue(d[1] & 0x02);
         
         hvac_calculated =  (d[1] != 0x08 && d[1] != 0x04); 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -181,6 +181,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     OvmsMetricInt *m_climate_fan_speed;
     OvmsMetricInt *m_climate_fan_speed_limit;
     OvmsMetricFloat *m_climate_setpoint;
+    OvmsMetricBool *m_climate_auto;
 
 
     float m_cum_energy_used_wh;				    // Cumulated energy (in wh) used within 1 second ticker interval


### PR DESCRIPTION
Hi @mjkapkan, please try this on your 2013. I have looked at the d[1] byte to separate out the various climate control functions as follows: a7 .... a0
a7 = 0
a6 = 1 for fan
a4,a5 = 1 for cooling
a2,a3 = unsure but if byte is 0x08 or 0x04 climate control is off 
a1 = 1 for auto hvac mode
a0 = 1 for heating
fan speed d[4] reports even when climate control is off, so this needs to be set to zero from hvac status. I have gone back to hvac status reporting as on when ventilating, heating or cooling as climate control is on when d[1] is not 0x08 or 0x04.