### PR TITLE
Fix typo in sendlivedata2abrp

### DIFF
--- a/plugin/abrp/sendlivedata2abrp.js
+++ b/plugin/abrp/sendlivedata2abrp.js
@@ -11,7 +11,7 @@
  * Enable:
  *  - install at above path
  *  - add to /store/scripts/ovmsmain.js:
- *                 abrp = require("sendlivedata2arbp");
+ *                 abrp = require("sendlivedata2abrp");
  *  - script reload
  *
  * Usage:


### PR DESCRIPTION
Fix a small typo that took a while to diagnose why the module wasn't being found.