### PR TITLE
bugfix in obd only mode, add charging metrics

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
@@ -134,6 +134,7 @@ v.c.12v.voltage               OBD        12.3V                    Output voltage
 v.c.charging                  T26        true                     Is vehicle charging (true = "Vehicle CHARGING" state. v.e.on=false if this is true)
 v.c.current 	              OBD        1.25A 	                  Momentary charger output current
 v.c.efficiency                OBD        91.3 %                   Charging efficiency calculated by v.b.power and v.c.power
+v.c.kwh                       OBD        2.6969kWh                Energy sum for running charge
 v.c.mode                      T26        standard                 standard, range, performance, storage
 v.c.pilot                     T26        no                       Pilot signal present
 v.c.power                     OBD        7.345 kW                 Input power of charger

--- a/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst
@@ -58,9 +58,9 @@ By default, both connections are activated.
 
 For more details on the two connection types, please see the corresponding projects:
 
-Comfort CAN (T26): `https://github.com/devmarxx/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup/docs/index.rst <https://github.com/devmarxx/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup/docs/index_t26.rst>`_ 
+Comfort CAN (T26): `https://github.com/devmarxx/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup/docs/index_t26.rst <https://github.com/devmarxx/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup/docs/index_t26.rst>`_ 
 
-OBD2: `https://github.com/SokoFromNZ/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup_obd/docs/index.rst <https://github.com/SokoFromNZ/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup_obd/docs/index_obd.rst>`_ 
+OBD2: `https://github.com/SokoFromNZ/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup_obd/docs/index_obd.rst <https://github.com/SokoFromNZ/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_vweup_obd/docs/index_obd.rst>`_ 
 
 The initial code is shamelessly copied from the original projects for the Comfort CAN by Chris van der Meijden and for the OBD2 port by SokoFromNZ.
 

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.h
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.h
@@ -187,6 +187,7 @@ class OvmsVehicleVWeUp : public OvmsVehicle
     float OdoStart;
     float EnergyRecdStart;
     float EnergyUsedStart;
+    float EnergyChargedStart;
 
   // --------------------------------------------------------------------------
   // OBD2 subsystem

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -204,7 +204,7 @@ void OvmsVehicleVWeUp::OBDCheckCarState()
             StandardMetrics.ms_v_charge_inprogress->SetValue(true);
             EnergyChargedStart = StandardMetrics.ms_v_bat_energy_recd_total->AsFloat();
             ESP_LOGD(TAG,"Charge Start Counter: %f",EnergyChargedStart);
-            PollSetState(VWUP_CHARGING);
+            PollSetState(VWEUP_CHARGING);
             TimeOffRequested = 0;
         }
         return;
@@ -218,7 +218,7 @@ void OvmsVehicleVWeUp::OBDCheckCarState()
         {
             ESP_LOGI(TAG, "Setting car state to ON");
             StandardMetrics.ms_v_env_on->SetValue(true);
-            PollSetState(VWUP_ON);
+            PollSetState(VWEUP_ON);
             TimeOffRequested = 0;
             OdoStart = StandardMetrics.ms_v_pos_odometer->AsFloat();
             EnergyRecdStart = StandardMetrics.ms_v_bat_energy_recd_total->AsFloat();
@@ -250,7 +250,7 @@ void OvmsVehicleVWeUp::OBDCheckCarState()
     StandardMetrics.ms_v_env_on->SetValue(false);
 //    StandardMetrics.ms_v_charge_voltage->SetValue(0);
 //    StandardMetrics.ms_v_charge_current->SetValue(0);
-    PollSetState(VWUP_OFF);
+    PollSetState(VWEUP_OFF);
 }
 
 void OvmsVehicleVWeUp::IncomingPollReply(canbus *bus, uint16_t type, uint16_t pid, uint8_t *data, uint8_t length, uint16_t mlremain)

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -46,7 +46,7 @@ static const char *TAG = "v-vweup";
 
 const OvmsVehicle::poll_pid_t vweup_polls[] = {
     // Note: poller ticker cycles at 3600 seconds = max period
-    // { txid, rxid, type, pid, { period_off, period_drive, period_charge }, bus, protocol }
+    // { txid, rxid, type, pid, { VWEUP_OFF, VWEUP_ON, VWEUP_CHARGING }, bus, protocol }
 
     {VWUP_BAT_MGMT_TX, VWUP_BAT_MGMT_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BAT_MGMT_U, {0, 1, 5}, 1, ISOTP_STD},
 //  Moved to ObdInit:    
@@ -72,6 +72,7 @@ const OvmsVehicle::poll_pid_t vweup_polls[] = {
 
     {VWUP_MFD_TX, VWUP_MFD_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_MFD_ODOMETER, {0, 60, 60}, 1, ISOTP_STD},
 
+//    {VWUP_BRK_TX, VWUP_BRK_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_BRK_TPMS, {0, 5, 5}, 1, ISOTP_STD},
 //    {VWUP_MOT_ELEC_TX, VWUP_MOT_ELEC_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_MOT_ELEC_TEMP_AMB, {0, 5, 0}, 1, ISOTP_STD},
     {VWUP_MFD_TX, VWUP_MFD_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_MFD_SERV_RANGE, {0, 60, 60}, 1, ISOTP_STD},
     {VWUP_MFD_TX, VWUP_MFD_RX, VEHICLE_POLL_TYPE_OBDIIEXTENDED, VWUP_MFD_SERV_TIME, {0, 60, 60}, 1, ISOTP_STD},
@@ -201,6 +202,8 @@ void OvmsVehicleVWeUp::OBDCheckCarState()
             ESP_LOGI(TAG, "Setting car state to CHARGING");
             StandardMetrics.ms_v_env_on->SetValue(false);
             StandardMetrics.ms_v_charge_inprogress->SetValue(true);
+            EnergyChargedStart = StandardMetrics.ms_v_bat_energy_recd_total->AsFloat();
+            ESP_LOGD(TAG,"Charge Start Counter: %f",EnergyChargedStart);
             PollSetState(VWUP_CHARGING);
             TimeOffRequested = 0;
         }
@@ -328,7 +331,10 @@ void OvmsVehicleVWeUp::IncomingPollReply(canbus *bus, uint16_t type, uint16_t pi
         if (PollReply.FromInt32("VWUP_BAT_MGMT_ENERGY_COUNTERS_RECD", value, 8))
         {
             StandardMetrics.ms_v_bat_energy_recd_total->SetValue(value / ((0xFFFFFFFF / 2.0f) / 250200.0f));
-            StandardMetrics.ms_v_bat_energy_recd->SetValue(StandardMetrics.ms_v_bat_energy_recd_total->AsFloat()-EnergyRecdStart); // so far we don't know where to get energy recovered on trip directly...
+            if (StandardMetrics.ms_v_env_on)
+                StandardMetrics.ms_v_bat_energy_recd->SetValue(StandardMetrics.ms_v_bat_energy_recd_total->AsFloat()-EnergyRecdStart); // so far we don't know where to get energy recovered on trip directly...
+            else
+                StandardMetrics.ms_v_charge_kwh->SetValue(StandardMetrics.ms_v_bat_energy_recd_total->AsFloat()-EnergyChargedStart); 
             VALUE_LOG(TAG, "VWUP_BAT_MGMT_ENERGY_COUNTERS_RECD=%f => %f", value, StandardMetrics.ms_v_bat_energy_recd_total->AsFloat());
         }
         if (PollReply.FromInt32("VWUP_BAT_MGMT_ENERGY_COUNTERS_USED", value, 12))


### PR DESCRIPTION
Thanks for taking care of migrating the namespaces on the previous PR :)
Sorry to request another pull already, but I just found a stupid typo that causes the detection of the car state to loop when in obd-only mode :(