### PR TITLE
VWeUP/T26: Enhanched temp range for cabin pre-heating (16-30)

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.cpp
@@ -182,16 +182,16 @@ bool OvmsVehicleVWeUp::SetFeature(int key, const char *value)
         return true;
     case 21:
         // check:
-        if (strlen(value) == 0) value = "21";
+        if (strlen(value) == 0) value = "22";
         for (i = 0; i < strlen(value); i++) {
            if (isdigit(value[i]) == false) {
-             value = "21";
+             value = "22";
              break;
            }
         }
         n = atoi(value);
-        if (n < 18) value = "18";
-        if (n > 23) value = "23";
+        if (n < 16) value = "16";
+        if (n > 30) value = "30";
         MyConfig.SetParamValue("xvu", "cc_temp", value);
         return true;
     default:

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
@@ -103,11 +103,15 @@
 ;
 ;    0.4.2  Corrected locked status, cabin temperature
 :
-;    0.4.2  Added "feature" parameters for model year and cabin temperature setting
+;    0.4.4  Added "feature" parameters for model year and cabin temperature setting
 ;
-;    0.4.3  Respond to vehicle turning climate control off
+;    0.4.5  Respond to vehicle turning climate control off
 ;
-;    (C) 2020       Chris van der Meijden
+;    0.4.6  Moved to unified ODB/T26 code
+;
+;    0.4.7  Corrected cabin temperature selection
+;
+;    (C) 2021       Chris van der Meijden
 ;
 ;    Big thanx to sharkcow, Dimitrie78, E-Imo, Dexter and 'der kleine Nik'.
 */
@@ -154,7 +158,7 @@ void OvmsVehicleVWeUp::T26Init()
     ocu_wait = false;
     vweup_cc_on = false;
     vweup_cc_turning_on = false;
-    vweup_cc_temp_int = 21;
+    vweup_cc_temp_int = 22;
     fas_counter_on = 0;
     fas_counter_off = 0;
     signal_ok = false;
@@ -845,6 +849,25 @@ void OvmsVehicleVWeUp::CCOn()
     data[5] = 0x01;
     data[6] = 0x6E; // This is the target temperature. T = 10 + d6/10
 
+
+    if (vweup_cc_temp_int == 16)
+    {
+        data[6] = 0x3C;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 16");
+    }
+    if (vweup_cc_temp_int == 17)
+    {
+        data[6] = 0x46;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 17");
+    }
+    if (vweup_cc_temp_int == 18)
+    {
+        data[6] = 0x50;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 18");
+    }
     if (vweup_cc_temp_int == 19)
     {
         data[6] = 0x5A;
@@ -874,6 +897,48 @@ void OvmsVehicleVWeUp::CCOn()
         data[6] = 0x82;
         if (dev_mode)
             ESP_LOGI(TAG, "Cabin temperature set: 23");
+    }
+    if (vweup_cc_temp_int == 24)
+    {
+        data[6] = 0x8C;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 24");
+    }
+    if (vweup_cc_temp_int == 25)
+    {
+        data[6] = 0x96;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 25");
+    }
+    if (vweup_cc_temp_int == 26)
+    {
+        data[6] = 0xA0;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 26");
+    }
+    if (vweup_cc_temp_int == 27)
+    {
+        data[6] = 0xAA;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 27");
+    }
+    if (vweup_cc_temp_int == 28)
+    {
+        data[6] = 0xB4;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 28");
+    }
+    if (vweup_cc_temp_int == 29)
+    {
+        data[6] = 0xBE;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 29");
+    }
+    if (vweup_cc_temp_int == 30)
+    {
+        data[6] = 0xC8;
+        if (dev_mode)
+            ESP_LOGI(TAG, "Cabin temperature set: 30");
     }
 
     data[7] = 0x00;

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_web.cpp
@@ -194,17 +194,26 @@ void OvmsVehicleVWeUp::WebCfgClimate(PageEntry_t &p, PageContext_t &c)
   c.panel_start("primary", "VW e-Up climate control configuration");
   c.form_start(p.uri);
 
-  c.print("<br>This page offers remote climate configuration.<br>The target temperature for the cabin can be set here.<br><br>");
+  c.print("<br>This page offers remote climate configuration.<br><br>The target temperature for the cabin can be set here (16 to 30 degrees Celcius).<br><br><br>");
 
   c.fieldset_start("Climate control");
 
   c.input_select_start("Cabin target temperature", "cc_temp");
+  c.input_select_option("16", "16", cc_temp == "16");
+  c.input_select_option("17", "17", cc_temp == "17");
   c.input_select_option("18", "18", cc_temp == "18");
   c.input_select_option("19", "19", cc_temp == "19");
   c.input_select_option("20", "20", cc_temp == "20");
   c.input_select_option("21", "21", cc_temp == "21");
   c.input_select_option("22", "22", cc_temp == "22");
   c.input_select_option("23", "23", cc_temp == "23");
+  c.input_select_option("24", "24", cc_temp == "24");
+  c.input_select_option("25", "25", cc_temp == "25");
+  c.input_select_option("26", "26", cc_temp == "26");
+  c.input_select_option("27", "27", cc_temp == "27");
+  c.input_select_option("28", "28", cc_temp == "28");
+  c.input_select_option("29", "29", cc_temp == "29");
+  c.input_select_option("30", "30", cc_temp == "30");
   c.input_select_end();
 
   c.print("<br><br>This parameter can also be set in the app under FEATURES 21.<hr>");


### PR DESCRIPTION
The temperature range VW uses for the pre-heating cabin temperature is 16 to 30 degrees celcius.

We had set the temperatures between 18 and 23. This is now corrected to 16 - 30.
