### PR TITLE
Round v.b.consumption so as to avoid the tiny numbers that result from the moving average calculation

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -776,12 +776,11 @@ void OvmsVehicle::NotifyBmsAlerts()
 // Override if your vehicle provides more detail.
 void OvmsVehicle::CalculateEfficiency()
   {
-  float consumption = 0, efficiency;
+  float consumption = 0;
   if (StdMetrics.ms_v_pos_speed->AsFloat() >= 5)
     consumption = StdMetrics.ms_v_bat_power->AsFloat(0, Watts) / StdMetrics.ms_v_pos_speed->AsFloat();
-  efficiency = (StdMetrics.ms_v_bat_consumption->AsFloat() * 4 + consumption) / 5;
-  if (efficiency < 1.0) efficiency = 0;     // Avoid the very tiny numbers we get after being stopped for a while
-  StdMetrics.ms_v_bat_consumption->SetValue(efficiency);
+  StdMetrics.ms_v_bat_consumption->SetValue(
+    TRUNCPREC((StdMetrics.ms_v_bat_consumption->AsFloat() * 4 + consumption) / 5, 1));
   }
 
 OvmsVehicle::vehicle_command_t OvmsVehicle::CommandSetChargeMode(vehicle_mode_t mode)

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -776,10 +776,12 @@ void OvmsVehicle::NotifyBmsAlerts()
 // Override if your vehicle provides more detail.
 void OvmsVehicle::CalculateEfficiency()
   {
-  float consumption = 0;
+  float consumption = 0, efficiency;
   if (StdMetrics.ms_v_pos_speed->AsFloat() >= 5)
     consumption = StdMetrics.ms_v_bat_power->AsFloat(0, Watts) / StdMetrics.ms_v_pos_speed->AsFloat();
-  StdMetrics.ms_v_bat_consumption->SetValue((StdMetrics.ms_v_bat_consumption->AsFloat() * 4 + consumption) / 5);
+  efficiency = (StdMetrics.ms_v_bat_consumption->AsFloat() * 4 + consumption) / 5;
+  if (efficiency < 1.0) efficiency = 0;     // Avoid the very tiny numbers we get after being stopped for a while
+  StdMetrics.ms_v_bat_consumption->SetValue(efficiency);
   }
 
 OvmsVehicle::vehicle_command_t OvmsVehicle::CommandSetChargeMode(vehicle_mode_t mode)


### PR DESCRIPTION
Due to the use of a smoothed average, when v.b.power goes to zero the smoothed average v.b.consumption only tends to zero and eventually gives crazy numbers like 1e-45.

This change just chops the v.b.consumption down to 0 once it falls below 1.