### PR TITLE
Change sm_v_bat_voltage to SM_STALE_HIGH

### DIFF
--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -72,7 +72,7 @@ MetricsStandard::MetricsStandard()
   ms_v_bat_soh = new OvmsMetricFloat(MS_V_BAT_SOH, SM_STALE_HIGH, Percentage);
   ms_v_bat_cac = new OvmsMetricFloat(MS_V_BAT_CAC, SM_STALE_HIGH, AmpHours);
   ms_v_bat_health = new OvmsMetricString(MS_V_BAT_HEALTH, SM_STALE_HIGH);
-  ms_v_bat_voltage = new OvmsMetricFloat(MS_V_BAT_VOLTAGE, SM_STALE_MID, Volts);
+  ms_v_bat_voltage = new OvmsMetricFloat(MS_V_BAT_VOLTAGE, SM_STALE_HIGH, Volts);
   ms_v_bat_current = new OvmsMetricFloat(MS_V_BAT_CURRENT, SM_STALE_MID, Amps);
   ms_v_bat_coulomb_used = new OvmsMetricFloat(MS_V_BAT_COULOMB_USED, SM_STALE_MID, AmpHours);
   ms_v_bat_coulomb_used_total = new OvmsMetricFloat(MS_V_BAT_COULOMB_USED_TOTAL, SM_STALE_MID, AmpHours);


### PR DESCRIPTION
Metric ms_v_bat_soh uses "stale-threshold" SM_STALE_HIGH.
ms_v_bat_voltage is a closely related metric, but was SM_STALE_MID.

This means that when your car is asleep the voltage metric expires but the soh does not.

This impacts the dashboard.

For me it makes since that of the SOH is SM_STALE_HIGH then the voltage should also be HIGH since the SOH fundamentally is derived from the pack voltage.