### PR TITLE
VWUP: T26 - Brought back 12v processing from version 0.1.2

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
@@ -352,6 +352,10 @@ void OvmsVehicleVWeUp::IncomingFrameCan3(CAN_frame_t *p_frame)
       }
       break;
 
+    case 0x571: // 12 Volt
+      StandardMetrics.ms_v_bat_12v_voltage->SetValue(5 + (0.05 * d[0]));
+      break;
+
     case 0x61C: // Charge detection
       cd_count++;
       if (d[2] < 0x07) {


### PR DESCRIPTION
Changed:
vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp