### PR TITLE
VWeUP/OBD: add service notifications

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -797,7 +797,7 @@ void OvmsVehicleVWeUp::IncomingPollReply(canbus *bus, uint16_t type, uint16_t pi
         // Send notification?
         int threshold = MyConfig.GetParamValueInt("xvu", "serv_warn_range", 5000);
         int old_value = StdMetrics.ms_v_env_service_range->AsInt();
-        if (old_value > threshold && value <= threshold && value > 0) {
+        if (old_value > threshold && value <= threshold && value > 0) { // excluding 0 seems to be necessary for now
           MyNotify.NotifyStringf("info", "Service", "Service range left: %d km!", value);
         }         
         StdMetrics.ms_v_env_service_range->SetValue(value);
@@ -809,7 +809,7 @@ void OvmsVehicleVWeUp::IncomingPollReply(canbus *bus, uint16_t type, uint16_t pi
         // Send notification?
         int threshold = MyConfig.GetParamValueInt("xvu", "serv_warn_time", 30);
         int old_value = StdMetrics.ms_v_env_service_time->AsInt();
-        if (old_value > threshold && value <= threshold && value > 0) {
+        if (old_value > threshold && value <= threshold && value > 0) { // excluding 0 seems to be necessary for now
           MyNotify.NotifyStringf("info", "Service", "Service time left: %d days!", value);
         }         
         ServiceDays -> SetValue(value);

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -794,12 +794,24 @@ void OvmsVehicleVWeUp::IncomingPollReply(canbus *bus, uint16_t type, uint16_t pi
 
     case VWUP_MFD_SERV_RANGE:
       if (PollReply.FromUint16("VWUP_MFD_SERV_RANGE", value)) {
+        // Send notification?
+        int threshold = MyConfig.GetParamValueInt("xvu", "serv_warn_range", 5000);
+        int old_value = StdMetrics.ms_v_env_service_range->AsInt();
+        if (old_value > threshold && value <= threshold && value > 0) {
+          MyNotify.NotifyStringf("info", "Service", "Service range left: %d km!", value);
+        }         
         StdMetrics.ms_v_env_service_range->SetValue(value);
         VALUE_LOG(TAG, "VWUP_MFD_SERV_RANGE=%f => %f", value, StdMetrics.ms_v_env_service_range->AsFloat());
       }
       break;
     case VWUP_MFD_SERV_TIME:
       if (PollReply.FromUint16("VWUP_MFD_SERV_TIME", value)) {
+        // Send notification?
+        int threshold = MyConfig.GetParamValueInt("xvu", "serv_warn_time", 30);
+        int old_value = StdMetrics.ms_v_env_service_time->AsInt();
+        if (old_value > threshold && value <= threshold && value > 0) {
+          MyNotify.NotifyStringf("info", "Service", "Service time left: %d days!", value);
+        }         
         ServiceDays -> SetValue(value);
         StdMetrics.ms_v_env_service_time->SetValue(StdMetrics.ms_m_timeutc->AsInt() + value * 86400);
         VALUE_LOG(TAG, "VWUP_MFD_SERV_TIME=%f => %f", value, StdMetrics.ms_v_env_service_time->AsFloat());


### PR DESCRIPTION
workaround to exclude values of 0 seems to be necessary (haven't found the cause yet)