### PR TITLE
Early I-MiEV support

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.cpp
@@ -239,13 +239,13 @@ void OvmsVehicleMitsubishi::IncomingFrameCan1(CAN_frame_t* p_frame)
 
   switch ( p_frame->MsgID )
     {
-      case 0x012: // Key status (early iMIEV)
+      case 0x012://freq10 // Key status (early iMIEV)
       {
         (d[2] == 4) ? vehicle_mitsubishi_car_on(true) : vehicle_mitsubishi_car_on(false);
       break;
       }
       
-      case 0x101: //freq10 //Key status (later iMIEV)
+      case 0x101://freq10 //Key status (later iMIEV)
       {
         (d[0] == 4) ? vehicle_mitsubishi_car_on(true) : vehicle_mitsubishi_car_on(false);
       break;
@@ -691,7 +691,7 @@ void OvmsVehicleMitsubishi::IncomingFrameCan1(CAN_frame_t* p_frame)
     {
       //Pid index 0-3
       int pid_index = (p_frame->MsgID) - 1761;
-      //cmu index 1-12
+      //cmu index 1-12: ignore high order nybble which appears to sometimes contain other status bits
       int cmu_id = d[0] & 0x0f;
       //
       double temp1 = d[1] - 50.0;


### PR DESCRIPTION
These are a couple of changes I've made locally to improve support for my early 2010 i-MiEV. Specifically:

1.  I have found that the battery cell information in the 0x6e? CAN sentences was being misinterpreted, because the index byte 1 sometimes has a bit in the high order nybble set. I don't know what this bit indicates, but it breaks the battery monitoring so I've taken the simple expedient of masking it out. This might apply to later i-MIEVs too. 
2. The ignition status is carried in a 0x012 sentence rather than the 0x101 sentence on later vehicles. I've made the simplifying assumption that both sentences won't be seen in the one vehicle. 

The changes should be compatible with existing vehicles as far as I can see. 