### PR TITLE
Only initialise v.e.on in module startup if it currently has no value.

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.cpp
@@ -279,8 +279,10 @@ OvmsVehicleBMWi3::OvmsVehicleBMWi3()
     PollSetState(pollerstate);
     mt_i3_pollermode->SetValue(pollerstate);
     mt_i3_obdisalive->SetValue(false);
-    StdMetrics.ms_v_env_awake->SetValue(false);
-    StdMetrics.ms_v_env_on->SetValue(false);
+    if (!StdMetrics.ms_v_env_awake->AsBool())
+        StdMetrics.ms_v_env_awake->SetValue(false);
+    if (!StdMetrics.ms_v_env_on->AsBool())
+        StdMetrics.ms_v_env_on->SetValue(false);
     PollSetThrottling(50);
     PollSetResponseSeparationTime(5);
 }


### PR DESCRIPTION
this avoids overwriting the value now saved through persistence.

Did the same for v.e.awake though not sure it it is persisted.
Harmless if it is not.