### PR TITLE
Minimal fix for ESP32 V3 can bus: turn off BRP_DIV if we're V2 or higher

### DIFF
--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -349,7 +349,13 @@ void esp32can::InitController()
   MODULE_ESP32CAN->BTR1.B.SAM=0x1;
 
   // Enable all interrupts except arbitration loss (can be ignored):
-  MODULE_ESP32CAN->IER.U = 0xff - __CAN_IRQ_ARB_LOST;
+  uint32_t ier = 0xff & ~__CAN_IRQ_ARB_LOST;
+  // Turn off BRP_DIV if we're V2 or higher
+  esp_chip_info_t chip;
+  esp_chip_info(&chip);
+  if (chip.revision >= 2)
+      ier &= ~__CAN_IER_BRP_DIV;
+  MODULE_ESP32CAN->IER.U = ier;
 
   // No acceptance filtering, as we want to fetch all messages
   MODULE_ESP32CAN->MBX_CTRL.ACC.CODE[0] = 0;

--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can_regdef.h
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can_regdef.h
@@ -90,6 +90,12 @@ typedef enum
   __CAN_IRQ_BUS_ERR=            BIT(7),             // IR.7 Bus Error Interrupt
   } ESP32CAN_IRQ_t;
 
+/* 
+ * Setting this interrupt enable register bit with ESP32 revision
+ * 2 and higher divides the Baud Rate Prescaler (BRP) by 2.
+ */
+#define __CAN_IER_BRP_DIV __CAN_IRQ_WAKEUP
+
 /** \brief OCMODE options. */
 typedef enum
   {


### PR DESCRIPTION
Starting with revision 2, the function of bit 4 of the interrupt enable register changes from "enable wakeup interrupt" to "divide BRP by 2". The OVMS SJA1000 code enables "all interrupts except arbitration loss" which was causing can baud rates to be half of what they were set to.

Reported by Thomas Heuer who referenced:

- [https://www.esp32.com/viewtopic.php?t=15581#p59670](https://www.esp32.com/viewtopic.php?t=15581#p59670)