### PR TITLE
Flags cleanup: Add usage strings and detect/report invalid flags

### DIFF
--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -251,8 +251,15 @@ void wifi_scan(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, co
     }
 
   bool json = false;
-  if (argc >= 1 && strcmp(argv[0], "-j") == 0)
+  if (argc > 0)
+    {
+    if (strcmp(argv[0], "-j") != 0)
+      {
+      cmd->PutUsage(writer);
+      return;
+      }
     json = true;
+    }
 
   me->Scan(writer, json);
   }

--- a/vehicle/OVMS.V3/main/ovms_command.h
+++ b/vehicle/OVMS.V3/main/ovms_command.h
@@ -257,9 +257,9 @@ class OvmsCommand : public ExternalRamAllocated
     OvmsCommand* FindCommand(const char* name);
     bool IsSecure() { return m_secure; }
     void Display(OvmsWriter* writer, int level);
+    void PutUsage(OvmsWriter* writer);
 
   private:
-    void PutUsage(OvmsWriter* writer);
     void ExpandUsage(const char* templ, OvmsWriter* writer, std::string& result);
 
   protected:

--- a/vehicle/OVMS.V3/main/ovms_events.cpp
+++ b/vehicle/OVMS.V3/main/ovms_events.cpp
@@ -146,8 +146,15 @@ void event_raise(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
 
   for (int i=0; i<argc; i++)
     {
-    if (argv[i][0]=='-' && argv[i][1]=='d')
+    if (argv[i][0] == '-')
+      {
+      if (argv[i][1] != 'd')
+        {
+        cmd->PutUsage(writer);
+        return;
+        }
       delay_ms = atol(argv[i]+2);
+      }
     else
       event = argv[i];
     }

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -164,6 +164,7 @@ class OvmsMetric
     virtual bool IsFirstDefined();
     virtual bool IsPersistent();
     virtual bool IsStale();
+    virtual bool IsString() { return false; };
     virtual bool IsFresh();
     virtual void RefreshPersist();
     virtual void SetStale(bool stale);
@@ -280,6 +281,7 @@ class OvmsMetricString : public OvmsMetric
 #endif
     bool SetValue(std::string value);
     void operator=(std::string value) { SetValue(value); }
+    virtual bool IsString() { return true; };
 
   protected:
     OvmsMutex m_mutex;

--- a/vehicle/OVMS.V3/main/ovms_module.cpp
+++ b/vehicle/OVMS.V3/main/ovms_module.cpp
@@ -971,8 +971,13 @@ bool module_factory_reset_yesno(OvmsWriter* writer, void* ctx, char ch)
 
 static void module_factory_reset(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
-  if (argc == 1 && strcmp(argv[0], "-noconfirm") == 0)
+  if (argc > 0)
     {
+    if (strcmp(argv[0], "-noconfirm") != 0)
+      {
+      cmd->PutUsage(writer);
+      return;
+      }
     module_perform_factoryreset(writer);
     }
   else

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -215,7 +215,50 @@ std::string json_encode(const src_string text)
         break;
       }
     }
-	return buf;
+  return buf;
+  }
+
+/**
+ * display_encode: encode string displaying unprintablel characters
+ * Emulates (linux) "cat -t" semantics
+ */
+template <class src_string>
+std::string display_encode(const src_string text)
+  {
+  std::string buf;
+  buf.reserve(text.size() + (text.size() >> 3));
+  for (int i = 0; i < text.size(); i++)
+    {
+    char ch = text[i];
+    if (!isascii(ch))
+      {
+      buf += "M-";
+      ch = toascii(ch);
+      }
+    if (ch == '\177')
+      {
+      buf += "^?";
+      continue;
+      }
+    if (ch == '\t')
+      {
+      buf += "^I";
+      continue;
+      }
+    if (ch == '\n')
+      {
+      // deviation from "cat -t"
+      buf += "^J";
+      continue;
+      }
+    if (!isprint(ch))
+      {
+      ch = ch ^ 0x40;
+      buf += "^";
+      }
+    buf += ch;
+    }
+  return buf;
   }
 
 

--- a/vehicle/OVMS.V3/main/ovms_vfs.cpp
+++ b/vehicle/OVMS.V3/main/ovms_vfs.cpp
@@ -141,7 +141,16 @@ void vfs_head(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
   for (int i=0; i<argc; i++)
     {
     if (argv[i][0] == '-')
-      nrlines = atoi(argv[i]+1);
+      {
+      char* ep;
+      int32_t v = strtol(argv[i] + 1, &ep, 10);
+      if (*ep != '\0')
+        {
+        cmd->PutUsage(writer);
+        return;
+        }
+      nrlines = v;
+      }
     else
       filename = argv[i];
     }
@@ -350,7 +359,16 @@ class VfsTailCommand : public OvmsCommandTask
       for (int i=0; i<argc; i++)
         {
         if (argv[i][0] == '-')
-          nrlines = atoi(argv[i]+1);
+          {
+          char* ep;
+          int32_t v = strtol(argv[i] + 1, &ep, 10);
+          if (*ep != '\0')
+            {
+            cmd->PutUsage(writer);
+            return OCS_Error;
+            }
+          nrlines = v;
+          }
         else
           filename = argv[i];
         }


### PR DESCRIPTION
Rename the -S flag to -c (show [c]ommand) for "metrics list" and add flags usage strings for it and "metrics persist". Add -t flag to display to display string metrics with semantics similar to linux "cat -t" which can be helpful when looking at metric strings with
unprintable characters.

Fix "metrics list" to search for at most one metric substring; previously the code would apply up to two "show only" arguments.

Add OvmsMetric::IsString().

Make OvmsCommand::PutUsage() public.

Check for invalid flags for "wifi scan", "event raise", "module factory reset", "vfs head", and "vfs tail".

Includes feedback and many suggestions from Michael and Stephen.