### PR TITLE
CAN: First attempt at porting the first of four espressif TWAI/CAN errata fixes

### DIFF
--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -209,15 +209,29 @@ static IRAM_ATTR void ESP32CAN_isr(void *pvParameters)
       xQueueSendFromISR(MyCan.m_rxqueue, &msg, &task_woken);
       }
 
-    // Errata workaround: CONFIG_TWAI_ERRATA_FIX_BUS_OFF_REC
+    // Errata workaround: TWAI_ERRATA_FIX_BUS_OFF_REC
+    //
+    // Add SW workaround for REC change during bus-off
+    //
+    // When the bus-off condition is reached, the REC should be
+    // reset to 0 and frozen (via LOM) by the driver's ISR. However
+    // on the ESP32, there is an edge case where the REC will
+    // increase before the driver's ISR can respond in time (e.g.,
+    // due to the rapid occurrence of bus errors), thus causing the
+    // REC to be non-zero after bus-off. A non-zero REC can prevent
+    // bus-off recovery as the bus-off recovery condition is that
+    // both TEC and REC become Enabling this option will add a
+    // workaround in the driver to forcibly reset REC to zero on
+    // reaching bus-off.
+
     // "Force REC to 0 by re-triggering bus-off (by setting TEC to 0 then 255)"
     if ((interrupt & __CAN_IRQ_ERR_WARNING) != 0)
       {
       uint32_t status = MODULE_ESP32CAN->SR.U;
       if ((status & __CAN_STS_BUS_OFF) != 0 && (status & __CAN_STS_ERR_WARNING) != 0)
         {
-        // Explicitly enter reset mode
-        MODULE_ESP32CAN->MOD.B.RM = 1;
+        // Freeze TEC/REC by entering listen only mode
+        MODULE_ESP32CAN->MOD.B.LOM = 1;
 
         // Re-trigger bus-off
         MODULE_ESP32CAN->TXERR.B.TXERR = 0;
@@ -226,8 +240,8 @@ static IRAM_ATTR void ESP32CAN_isr(void *pvParameters)
         // Exit reset mode
         MODULE_ESP32CAN->MOD.B.RM = 0;
 
-        // Clear the re-triggered bus-off interrupt
-        interrupt = MODULE_ESP32CAN->IR.U & 0xff;
+        // Clear the re-triggered bus-off interrupt, collect any new bits
+        interrupt |= MODULE_ESP32CAN->IR.U & 0xff;
         }
       }
 

--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -177,19 +177,6 @@ static IRAM_ATTR void ESP32CAN_isr(void *pvParameters)
   while ((interrupt = MODULE_ESP32CAN->IR.U & 0xff) != 0)
     {
     me->m_status.interrupts++;
-    // Errata workaround: CONFIG_TWAI_ERRATA_FIX_BUS_OFF_REC
-    // "Force REC to 0 by re-triggering bus-off (by setting TEC to 0 then 255)"
-    if ((interrupt & __CAN_IRQ_ERR_WARNING) != 0)
-      {
-      uint32_t status = MODULE_ESP32CAN->SR.U;
-      if ((status & __CAN_STS_BUS_OFF) != 0 && (status & __CAN_STS_ERR_WARNING) != 0)
-        {
-        MODULE_ESP32CAN->TXERR.B.TXERR = 0;
-        MODULE_ESP32CAN->TXERR.B.TXERR = 0xff;
-        // Clear the re-triggered bus-off interrupt
-        interrupt = MODULE_ESP32CAN->IR.U & 0xff;
-        }
-      }
 
     // Handle RX frame(s) available & FIFO overflow interrupts:
     if ((interrupt & (__CAN_IRQ_RX|__CAN_IRQ_DATA_OVERRUN)) != 0)
@@ -220,6 +207,28 @@ static IRAM_ATTR void ESP32CAN_isr(void *pvParameters)
       msg.body.frame = me->m_tx_frame;
       msg.body.bus = me;
       xQueueSendFromISR(MyCan.m_rxqueue, &msg, &task_woken);
+      }
+
+    // Errata workaround: CONFIG_TWAI_ERRATA_FIX_BUS_OFF_REC
+    // "Force REC to 0 by re-triggering bus-off (by setting TEC to 0 then 255)"
+    if ((interrupt & __CAN_IRQ_ERR_WARNING) != 0)
+      {
+      uint32_t status = MODULE_ESP32CAN->SR.U;
+      if ((status & __CAN_STS_BUS_OFF) != 0 && (status & __CAN_STS_ERR_WARNING) != 0)
+        {
+        // Explicitly enter reset mode
+        MODULE_ESP32CAN->MOD.B.RM = 1;
+
+        // Re-trigger bus-off
+        MODULE_ESP32CAN->TXERR.B.TXERR = 0;
+        MODULE_ESP32CAN->TXERR.B.TXERR = 0xff;
+
+        // Exit reset mode
+        MODULE_ESP32CAN->MOD.B.RM = 0;
+
+        // Clear the re-triggered bus-off interrupt
+        interrupt = MODULE_ESP32CAN->IR.U & 0xff;
+        }
       }
 
     // Collect error interrupts:


### PR DESCRIPTION
For reference, here is Michael's original issue: [https://github.com/espressif/esp-idf/issues/4276#issuecomment-548753085](https://github.com/espressif/esp-idf/issues/4276#issuecomment-548753085) and the commit of interest is [https://github.com/espressif/esp-idf/commit/2f5806092135e3d991057bc06225bdcf536e93a5](https://github.com/espressif/esp-idf/commit/2f5806092135e3d991057bc06225bdcf536e93a5)

Here is a reformatted description of this fix:

> TWAI_ERRATA_FIX_BUS_OFF_REC
> Add SW workaround for REC change during bus-off
>
> When the bus-off condition is reached, the REC should be reset to 0 and frozen (via LOM) by the driver's ISR. However on the ESP32, there is an edge case where the REC will increase before the driver's ISR can respond in time (e.g., due to the rapid occurrence of bus errors), thus causing the REC to be non-zero after bus-off. A non-zero REC can prevent bus-off recovery as the bus-off recovery condition is that both TEC and REC become Enabling this option will add a workaround in the driver to forcibly reset REC to zero on reaching bus-off.

The actual change is simple:

```
    // esp/components/hal/twai_hal_iram.c

    //Handle low latency events
    if (events & TWAI_HAL_EVENT_BUS_OFF) {
        twai_ll_set_mode(hal_ctx->dev, TWAI_MODE_LISTEN_ONLY);  //Freeze TEC/REC by entering LOM
        //Errata workaround: Force REC to 0 by re-triggering bus-off (by setting TEC to 0 then 255)
        twai_ll_set_tec(hal_ctx->dev, 0);
        twai_ll_set_tec(hal_ctx->dev, 255);
        (void) twai_ll_get_and_clear_intrs(hal_ctx->dev);    //Clear the re-triggered bus-off interrupt
    }
```

TWAI_HAL_EVENT_BUS_OFF is set in the routine above, twai_hal_decode_interrupt():

```
    //Error Warning Interrupt set whenever Error or Bus Status bit changes
    if (interrupts & TWAI_LL_INTR_EI) {
        if (status & TWAI_LL_STATUS_BS) {       //Currently in BUS OFF state
            if (status & TWAI_LL_STATUS_ES) {    //EWL is exceeded, thus must have entered BUS OFF
                TWAI_HAL_SET_BITS(events, TWAI_HAL_EVENT_BUS_OFF);
                TWAI_HAL_SET_BITS(state_flags, TWAI_HAL_STATE_FLAG_BUS_OFF);
```

My change looks for the __CAN_IRQ_ERR_WARNING interrupt, for the
__CAN_STS_BUS_OFF bit to be on (indicating bus off), and the
__CAN_STS_ERR_WARNING status bit to be on (indicating error status).

The only testing I've done is to confirm it that ovms can still use the ESP32 CAN bus to communicate with a car.

I think this PR will need some work, for example I haven't addressed, "Freeze TEC/REC by entering LOM".