### PR TITLE
Use MAP_CAN_SPEED() to get accurately return gvret 33.333 and 83.333 speeds

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/canformat_gvret.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_gvret.cpp
@@ -380,16 +380,16 @@ void canformat_gvret_binary::PopulateBusList12(gvret_replymsg_t* r)
 
   canbus* bus = (canbus*)MyPcpApp.FindDeviceByName("can1");
   r->body.get_canbus_params.can1_mode = (bus->m_mode != CAN_MODE_OFF) | ((bus->m_mode == CAN_MODE_LISTEN)<<4);
-  r->body.get_canbus_params.can1_speed = (int)bus->m_speed * 1000;
+  r->body.get_canbus_params.can1_speed = MAP_CAN_SPEED(bus->m_speed);
 
   bus = (canbus*)MyPcpApp.FindDeviceByName("can2");
   r->body.get_canbus_params.can2_mode = (bus->m_mode != CAN_MODE_OFF) | ((bus->m_mode == CAN_MODE_LISTEN)<<4);
-  r->body.get_canbus_params.can2_speed = (int)bus->m_speed * 1000;
+  r->body.get_canbus_params.can2_speed = MAP_CAN_SPEED(bus->m_speed);
   }
 
 void canformat_gvret_binary::PopulateBusList3(gvret_replymsg_t* r)
   {
   canbus* bus = (canbus*)MyPcpApp.FindDeviceByName("can3");
   r->body.get_ext_buses.swcan_mode = (bus->m_mode != CAN_MODE_OFF) | ((bus->m_mode == CAN_MODE_LISTEN)<<4);
-  r->body.get_ext_buses.swcan_speed = (int)bus->m_speed * 1000;
+  r->body.get_ext_buses.swcan_speed = MAP_CAN_SPEED(bus->m_speed);
   }


### PR DESCRIPTION
canformat_gvret_binary::PopulateBusList12() and canformat_gvret_binary::PopulateBusList3() were just multiplying
bus->m_speed by 1000; the MAP_CAN_SPEED() understands CAN_SPEED_33KBPS and CAN_SPEED_83KBPS

(I'm trying to get savvycan working with a 33.333k GMLAN and I'm pretty sure this is one of my problems)