### PR TITLE
serverV2: add v.g metrics

### DIFF
--- a/docs/source/protocol_v2/messages.rst
+++ b/docs/source/protocol_v2/messages.rst
@@ -530,3 +530,37 @@ Batch client connections do not trigger any peer count change for the car, but t
 <data> is:
 
 * Number of peers connected, expressed as a decimal string
+
+-----------------------------
+Car export power message 0x47 "G"
+-----------------------------
+
+This message is sent <cartoserver> "C", or <servertoapp> "s" and transmits "v.g" metrics from the vehicle.
+
+<data> is comma-separated list of:
+
+* v.g.generating (1 = currently delivering power)
+* v.g.pilot (1 = pilot present)
+* v.g.voltage (in V)
+* v.g.current (in A)
+* v.g.power (in kW)
+* v.g.efficiency (in %)
+* v.g.type (eg "chademo")
+* v.g.state (eg "exporting")
+* v.g.substate (eg "onrequest")
+* v.g.mode (eg "standard")
+* v.g.climit (in A)
+* v.g.limit.range (in km)
+* v.g.limit.soc (in %)
+* v.g.kwh (in kWh)
+* v.g.kwh.grid (in kWh)
+* v.g.kwh.grid.total (in kWh)
+* v.g.time (in s)
+* v.g.timermode (1 = generator timer enabled)
+* v.g.timerstart 
+* v.g.duration.empty (in min)
+* v.g.duration.range (in min)
+* v.g.duration.soc (in min)
+* v.g.temp (in deg C)
+
+Refer https://docs.openvehicles.com/en/latest/userguide/metrics.html

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -1764,6 +1764,18 @@ void OvmsServerV2::MetricModified(OvmsMetric* metric)
     {
     m_now_tpms = true;
     }
+    
+  if ((metric == StandardMetrics.ms_v_gen_kwh)||
+      (metric == StandardMetrics.ms_v_gen_climit)||
+      (metric == StandardMetrics.ms_v_gen_limit_range)||
+      (metric == StandardMetrics.ms_v_gen_limit_soc)||
+      (metric == StandardMetrics.ms_v_gen_state)||
+      (metric == StandardMetrics.ms_v_gen_substate)||
+      (metric == StandardMetrics.ms_v_gen_mode)||
+      (metric == StandardMetrics.ms_v_gen_inprogress))
+    {
+    m_now_gen = true;
+    }
   }
 
 bool OvmsServerV2::NotificationFilter(OvmsNotifyType* type, const char* subtype)
@@ -1944,7 +1956,7 @@ void OvmsServerV2::Ticker1(std::string event, void* data)
     if ((m_lasttx==0)||(now>(m_lasttx+next)))
       {
       TransmitMsgStat(true);          // Send always, periodically
-      TransmitMsgGen(true);          // Send always, periodically
+      TransmitMsgGen(m_lasttx==0);          
       TransmitMsgEnvironment(true);   // Send always, periodically
       TransmitMsgGPS(m_lasttx==0);
       TransmitMsgGroup(m_lasttx==0);

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -1765,8 +1765,7 @@ void OvmsServerV2::MetricModified(OvmsMetric* metric)
     m_now_tpms = true;
     }
     
-  if ((metric == StandardMetrics.ms_v_gen_kwh)||
-      (metric == StandardMetrics.ms_v_gen_climit)||
+  if ((metric == StandardMetrics.ms_v_gen_climit)||
       (metric == StandardMetrics.ms_v_gen_limit_range)||
       (metric == StandardMetrics.ms_v_gen_limit_soc)||
       (metric == StandardMetrics.ms_v_gen_state)||
@@ -1955,14 +1954,14 @@ void OvmsServerV2::Ticker1(std::string event, void* data)
     int next = (m_peers==0) ? m_updatetime_idle : m_updatetime_connected;
     if ((m_lasttx==0)||(now>(m_lasttx+next)))
       {
-      TransmitMsgStat(true);          // Send always, periodically
-      TransmitMsgGen(m_lasttx==0);          
+      TransmitMsgStat(true);          // Send always, periodically         
       TransmitMsgEnvironment(true);   // Send always, periodically
       TransmitMsgGPS(m_lasttx==0);
       TransmitMsgGroup(m_lasttx==0);
       TransmitMsgTPMS(m_lasttx==0);
       TransmitMsgFirmware(m_lasttx==0);
       TransmitMsgCapabilities(m_lasttx==0);
+      if (StandardMetrics.ms_v_gen_current->AsFloat() > 0) TransmitMsgGen(true); 
       m_lasttx = m_lasttx_stream = now;
       }
     else if (m_streaming && caron && m_peers && now > m_lasttx_stream+m_streaming)

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -1078,57 +1078,73 @@ void OvmsServerV2::TransmitMsgGen(bool always)
   m_now_gen = false;
 
   bool modified =
+    StandardMetrics.ms_v_gen_inprogress->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_pilot->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_voltage->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_current->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_power->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_efficiency->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_type->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_state->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_substate->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_mode->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_climit->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_limit_range->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_limit_soc->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_kwh->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_limit_range->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_limit_soc->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_kwh_grid->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_kwh_grid_total->IsModifiedAndClear(MyOvmsServerV2Modifier) |
+    StandardMetrics.ms_v_gen_time->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_timermode->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_timerstart->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_duration_empty->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_duration_range->IsModifiedAndClear(MyOvmsServerV2Modifier) |
     StandardMetrics.ms_v_gen_duration_soc->IsModifiedAndClear(MyOvmsServerV2Modifier) |
-    StandardMetrics.ms_v_gen_inprogress->IsModifiedAndClear(MyOvmsServerV2Modifier) |
-    StandardMetrics.ms_v_gen_limit_range->IsModifiedAndClear(MyOvmsServerV2Modifier) |
-    StandardMetrics.ms_v_gen_limit_soc->IsModifiedAndClear(MyOvmsServerV2Modifier) |
-    StandardMetrics.ms_v_gen_power->IsModifiedAndClear(MyOvmsServerV2Modifier) |
-    StandardMetrics.ms_v_gen_efficiency->IsModifiedAndClear(MyOvmsServerV2Modifier);
+    StandardMetrics.ms_v_gen_temp->IsModifiedAndClear(MyOvmsServerV2Modifier);
 
   // Quick exit if nothing modified
   if ((!always)&&(!modified)) return;
 
-  int mins_range = StandardMetrics.ms_v_gen_duration_range->AsInt();
-  int mins_soc = StandardMetrics.ms_v_gen_duration_soc->AsInt();
-  // bool generating = StandardMetrics.ms_v_gen_inprogress->AsBool();
-
   extram::ostringstream buffer;
   buffer
     << std::fixed
-    << std::setprecision(2)
+    << std::setprecision(1)
     << "MP-0 G"
-    << ((m_units_distance == Kilometers) ? "K" : "M")
+    << StandardMetrics.ms_v_gen_inprogress->AsBool()
+    << ";"
+    << StandardMetrics.ms_v_gen_pilot->AsBool()
     << ","
     << StandardMetrics.ms_v_gen_voltage->AsInt()
     << ","
     << StandardMetrics.ms_v_gen_current->AsFloat()
     << ","
+    << StandardMetrics.ms_v_gen_power->AsFloat()
+    << ","
+    << StandardMetrics.ms_v_gen_efficiency->AsFloat()
+    << ","
+    << StandardMetrics.ms_v_gen_type->AsString("")
+    << ","
     << StandardMetrics.ms_v_gen_state->AsString("stopped")
+    << ","
+    << StandardMetrics.ms_v_gen_substate->AsString("")
     << ","
     << StandardMetrics.ms_v_gen_mode->AsString("standard")
     << ","
-    << StandardMetrics.ms_v_gen_climit->AsInt()
+    << StandardMetrics.ms_v_gen_climit->AsFloat()
+    << ","
+    << StandardMetrics.ms_v_gen_limit_range->AsFloat(0, m_units_distance)
+    << ","
+    << StandardMetrics.ms_v_gen_limit_soc->AsInt()
+    << ","
+    << StandardMetrics.ms_v_gen_kwh->AsFloat()
+    << ","
+    << StandardMetrics.ms_v_gen_kwh_grid->AsFloat()
+    << ","
+    << StandardMetrics.ms_v_gen_kwh_grid_total->AsFloat()
     << ","
     << StandardMetrics.ms_v_gen_time->AsInt(0,Seconds)
-    << ","
-    << (int)(StandardMetrics.ms_v_gen_kwh->AsFloat() * 10)
-    << ","
-    << chargesubstate_key(StandardMetrics.ms_v_gen_substate->AsString(""))
-    << ","
-    << chargestate_key(StandardMetrics.ms_v_gen_state->AsString("stopped"))
-    << ","
-    << chargemode_key(StandardMetrics.ms_v_gen_mode->AsString("standard"))
     << ","
     << StandardMetrics.ms_v_gen_timermode->AsBool()
     << ","
@@ -1136,19 +1152,11 @@ void OvmsServerV2::TransmitMsgGen(bool always)
     << ","
     << StandardMetrics.ms_v_gen_duration_empty->AsInt()
     << ","
-    << (((mins_range >= 0) && (mins_range < mins_soc)) ? mins_range : mins_soc)
+    << StandardMetrics.ms_v_gen_duration_range->AsInt()
     << ","
-    << (int) StandardMetrics.ms_v_gen_limit_range->AsFloat(0, m_units_distance)
-    << ","
-    << StandardMetrics.ms_v_gen_limit_soc->AsInt()
-    << ","
-    << mins_range
-    << ","
-    << mins_soc
-    << ","
-    << StandardMetrics.ms_v_gen_power->AsFloat()
-    << ","
-    << StandardMetrics.ms_v_gen_efficiency->AsFloat()
+    << StandardMetrics.ms_v_gen_duration_soc->AsInt()
+    << ";"
+    << StandardMetrics.ms_v_gen_temp->AsFloat()
     ;
 
   Transmit(buffer.str().c_str());

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.h
@@ -68,6 +68,7 @@ class OvmsServerV2 : public OvmsServer
 
   protected:
     void TransmitMsgStat(bool always = false);
+    void TransmitMsgGen(bool always = false);
     void TransmitMsgGPS(bool always = false);
     void TransmitMsgTPMS(bool always = false);
     void TransmitMsgFirmware(bool always = false);
@@ -138,6 +139,7 @@ class OvmsServerV2 : public OvmsServer
     bool m_ptoken_ready;
 
     bool m_now_stat;
+    bool m_now_gen;
     bool m_now_gps;
     bool m_now_tpms;
     bool m_now_firmware;

--- a/vehicle/OVMS.V3/main/ovms_utils.cpp
+++ b/vehicle/OVMS.V3/main/ovms_utils.cpp
@@ -73,7 +73,6 @@ int chargestate_key(const std::string code)
   else if (code == "timerwait")   key = 14;
   else if (code == "heating")     key = 15;
   else if (code == "stopped")     key = 21;
-  else if (code == "exporting")   key = 22;
   else key = 0;
   return key;
   }

--- a/vehicle/OVMS.V3/main/ovms_utils.cpp
+++ b/vehicle/OVMS.V3/main/ovms_utils.cpp
@@ -54,7 +54,6 @@ std::string chargestate_code(const int key)
     case 14: code = "timerwait";  break;
     case 15: code = "heating";    break;
     case 21: code = "stopped";    break;
-    case 22: code = "exporting";  break;
     default: code = "";
     }
   return code;

--- a/vehicle/OVMS.V3/main/ovms_utils.cpp
+++ b/vehicle/OVMS.V3/main/ovms_utils.cpp
@@ -54,6 +54,7 @@ std::string chargestate_code(const int key)
     case 14: code = "timerwait";  break;
     case 15: code = "heating";    break;
     case 21: code = "stopped";    break;
+    case 22: code = "exporting";  break;
     default: code = "";
     }
   return code;
@@ -72,6 +73,7 @@ int chargestate_key(const std::string code)
   else if (code == "timerwait")   key = 14;
   else if (code == "heating")     key = 15;
   else if (code == "stopped")     key = 21;
+  else if (code == "exporting")   key = 22;
   else key = 0;
   return key;
   }


### PR DESCRIPTION
@dexterbg, Hi Michael, could you check whether the following is consistent with the rest of the V2 messaging framework. Is it necessary to include the "legacy keys" or just use the string versions of mode, state, substate? 

Is there anything else required to be updated to include the v.g metrics?