### PR TITLE
CAN: Second of four espressif TWAI/CAN errata fixes: SW workaround for TX interrupt lost

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/can.h
+++ b/vehicle/OVMS.V3/components/can/src/can.h
@@ -329,12 +329,15 @@ class canbus : public pcp, public InternalRamAllocated
     CAN_frame_t m_tx_frame;       // saved copy of last TX frame to be used in txcallback
     uint32_t m_status_chksum;
     uint32_t m_watchdog_timer;
+    uint32_t m_state;             // state bitset
     QueueHandle_t m_txqueue;
     int m_busnumber;
 
   protected:
     dbcfile *m_dbcfile;
   };
+
+#define CAN_M_STATE_TX_BUF_OCCUPIED   BIT(0) // transmit buffer is in use
 
 ////////////////////////////////////////////////////////////////////////
 // can - the CAN system controller

--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -239,10 +239,9 @@ static IRAM_ATTR void ESP32CAN_isr(void *pvParameters)
     // recover any lost transmit interrupt.
 
     // Handle TX interrupt:
-    uint32_t status;
     if ((interrupt & __CAN_IRQ_TX) != 0 ||
         ((MyESP32can->m_state & CAN_M_STATE_TX_BUF_OCCUPIED) != 0 &&
-        ((status = MODULE_ESP32CAN->SR.U) & __CAN_STS_TXDONE) != 0))
+        (MODULE_ESP32CAN->SR.U & __CAN_STS_TXDONE) != 0))
       {
       MyESP32can->m_state &= ~CAN_M_STATE_TX_BUF_OCCUPIED;
       CAN_queue_msg_t msg;
@@ -599,9 +598,9 @@ esp_err_t esp32can::WriteFrame(const CAN_frame_t* p_frame)
 
   // Transmit frame
   MODULE_ESP32CAN->CMR.B.TR=1;
+  MyESP32can->m_state |= CAN_M_STATE_TX_BUF_OCCUPIED;
 
   ESP32CAN_EXIT_CRITICAL();
-  MyESP32can->m_state |= CAN_M_STATE_TX_BUF_OCCUPIED;
   return ESP_OK;
   }
 


### PR DESCRIPTION
For reference, here is Michael's original issue:

    https://github.com/espressif/esp-idf/issues/4276#issuecomment-548753085

The commit of interest is here:

    https://github.com/espressif/esp-idf/commit/2f5806092135e3d991057bc06225bdcf536e93a5

Here is a reformatted description of this fix:

    Errata workaround: TWAI_ERRATA_FIX_TX_INTR_LOST

    Add SW workaround for TX interrupt lost

    On the ESP32, when a transmit interrupt occurs, and interrupt
    register is read on the same APB clock cycle, the transmit
    interrupt could be lost. Enabling this option will add a
    workaround that checks the transmit buffer status bit to
    recover any lost transmit interrupt.

The fix involves keeping track of when the tx buffer is in use; look for TWAI_HAL_STATE_FLAG_TX_BUFF_OCCUPIED in:

    esp/components/hal/twai_hal_iram.c

My change adds a place to keep track of the tx buf state (m_state) and looks for the possible lost tx interrupt in ESP32CAN_isr().