### PR TITLE
Vehicle: add recuperated power to trip report

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,2 +1,3 @@
 m2r
 docutils<0.18
+mistune<2.0.0

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,13 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Server V2/V3: added manual update request
+    Note: the servers normally don't need a manual trigger to perform
+    data updates, they listen to metrics changes and events. Use this
+    only if you need extraordinary single updates as fast as possible.
+  New commands:
+    server v2 update [all|modified]     -- Request V2 data update
+    server v3 update [all|modified]     -- Request V3 data update
 
 2021-11-22 MWJ  3.2.018  OTA release
 - Vehicle: added optional automatic trip report generation

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.h
@@ -95,6 +95,7 @@ class OvmsServerV2 : public OvmsServer
     void NetmanInit(std::string event, void* data);
     void NetmanStop(std::string event, void* data);
     void Ticker1(std::string event, void* data);
+    void RequestUpdate(bool txall);
 
   public:
     enum State

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -112,8 +112,6 @@ static void OvmsServerV3MongooseCallback(struct mg_connection *nc, int ev, void 
         {
         if (MyOvmsServerV3)
           {
-          StandardMetrics.ms_s_v3_connected->SetValue(true);
-          MyOvmsServerV3->SetStatus("OVMS V3 MQTT login successful", false, OvmsServerV3::Connected);
           MyOvmsServerV3->m_sendall = true;
           MyOvmsServerV3->m_notify_info_pending = true;
           MyOvmsServerV3->m_notify_error_pending = true;
@@ -122,6 +120,8 @@ static void OvmsServerV3MongooseCallback(struct mg_connection *nc, int ev, void 
           MyOvmsServerV3->m_notify_data_waitcomp = 0;
           MyOvmsServerV3->m_notify_data_waittype = NULL;
           MyOvmsServerV3->m_notify_data_waitentry = NULL;
+          StandardMetrics.ms_s_v3_connected->SetValue(true);
+          MyOvmsServerV3->SetStatus("OVMS V3 MQTT login successful", false, OvmsServerV3::Connected);
           }
         }
       break;
@@ -193,6 +193,7 @@ OvmsServerV3::OvmsServerV3(const char* name)
   m_sendall = false;
   m_lasttx = 0;
   m_lasttx_stream = 0;
+  m_lasttx_sendall = 0;
   m_peers = 0;
   m_streaming = 0;
   m_updatetime_idle = 600;
@@ -919,7 +920,8 @@ void OvmsServerV3::Ticker1(std::string event, void* data)
                (StandardMetrics.ms_v_env_awake->AsBool()) ? m_updatetime_awake :
                m_updatetime_idle;
 
-    if ( m_updatetime_sendall > 0 && (now > (m_lasttx_sendall + m_updatetime_sendall)) )
+    if ((m_lasttx_sendall == 0) ||
+        (m_updatetime_sendall > 0 && now > (m_lasttx_sendall + m_updatetime_sendall)))
       {
       ESP_LOGI(TAG, "Transmit all metrics");
       TransmitAllMetrics();
@@ -935,6 +937,18 @@ void OvmsServerV3::Ticker1(std::string event, void* data)
       // TODO: transmit streaming metrics
       m_lasttx_stream = now;
       }
+    }
+  }
+
+void OvmsServerV3::RequestUpdate(bool txall)
+  {
+  if (txall)
+    {
+    m_lasttx_sendall = 0;
+    }
+  else
+    {
+    m_lasttx = 0;
     }
   }
 
@@ -1017,6 +1031,21 @@ void ovmsv3_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
     }
   }
 
+void ovmsv3_update(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  if (MyOvmsServerV3 == NULL)
+    {
+    writer->puts("ERROR: OVMS v3 server has not been started");
+    }
+  else
+    {
+    bool txall = (strcmp(cmd->GetName(), "all") == 0);
+    MyOvmsServerV3->RequestUpdate(txall);
+    writer->printf("Server V3 data update for %s metrics has been scheduled\n",
+      txall ? "all" : "modified");
+    }
+  }
+
 OvmsServerV3Init MyOvmsServerV3Init  __attribute__ ((init_priority (6200)));
 
 OvmsServerV3Init::OvmsServerV3Init()
@@ -1028,6 +1057,10 @@ OvmsServerV3Init::OvmsServerV3Init()
   cmd_v3->RegisterCommand("start","Start an OVMS V3 Server Connection",ovmsv3_start);
   cmd_v3->RegisterCommand("stop","Stop an OVMS V3 Server Connection",ovmsv3_stop);
   cmd_v3->RegisterCommand("status","Show OVMS V3 Server connection status",ovmsv3_status);
+
+  OvmsCommand* cmd_update = cmd_v3->RegisterCommand("update", "Request OVMS V3 Server data update", ovmsv3_update);
+  cmd_update->RegisterCommand("all", "Transmit all metrics", ovmsv3_update);
+  cmd_update->RegisterCommand("modified", "Transmit modified metrics only", ovmsv3_update);
 
   using std::placeholders::_1;
   using std::placeholders::_2;

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -63,6 +63,7 @@ class OvmsServerV3 : public OvmsServer
     void NetmanStop(std::string event, void* data);
     void Ticker1(std::string event, void* data);
     void Ticker60(std::string event, void* data);
+    void RequestUpdate(bool txall);
 
   public:
     enum State

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -1124,9 +1124,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicle::CommandStatTrip(int verbosity, OvmsW
     : 0;
 
   float energy_used = StdMetrics.ms_v_bat_energy_used->AsFloat();
-  float energy_recd = StdMetrics.ms_v_bat_energy_recd->AsFloat();
-  float energy_recd_perc = (energy_used > 0) ? energy_recd / energy_used * 100 : 0;
-  float wh_per_rangeunit = (trip_length > 0) ? (energy_used - energy_recd) * 1000 / trip_length : 0;
+  float energy_recup = m_drive_recupenergysum / 1000;
+  float energy_rechd = StdMetrics.ms_v_bat_energy_recd->AsFloat();
+  float energy_recup_perc = (energy_used > 0) ? energy_recup / energy_used * 100 : 0;
+  float energy_rechd_perc = (energy_used > 0) ? energy_rechd / energy_used * 100 : 0;
+  float wh_per_rangeunit = (trip_length > 0) ? (energy_used - energy_rechd) * 1000 / trip_length : 0;
 
   float soc = StdMetrics.ms_v_bat_soc->AsFloat();
   float soc_diff = soc - m_drive_startsoc;
@@ -1154,7 +1156,8 @@ OvmsVehicle::vehicle_command_t OvmsVehicle::CommandStatTrip(int verbosity, OvmsW
       << "\nEnergy "
       << wh_per_rangeunit << energyUnitLabel
       << ", "
-      << energy_recd_perc << "% recd"
+      << energy_recup_perc << "% recup, "
+      << energy_rechd_perc << "% rechd"
       ;
     }
   buf
@@ -1236,6 +1239,8 @@ void OvmsVehicle::MetricModified(OvmsMetric* metric)
       m_drive_accelsum = 0;
       m_drive_decelcnt = 0;
       m_drive_decelsum = 0;
+      m_drive_recupenergysum = 0;
+      m_recuplasttime = esp_log_timestamp();
       MyEvents.SignalEvent("vehicle.on",NULL);
       if (m_autonotifications)
         {
@@ -1484,6 +1489,26 @@ void OvmsVehicle::MetricModified(OvmsMetric* metric)
       {
       m_drive_speedcnt++;
       m_drive_speedsum += speed;
+      }
+    }
+  else if (metric == StdMetrics.ms_v_inv_power)
+    {
+    // collect data for trip recovered energy from (negative) motor power
+    if (StdMetrics.ms_v_inv_power->AsFloat() < 0)
+      {
+      if (m_recupering)
+        {
+        float m_recuptimedelta = (esp_log_timestamp() - m_recuplasttime) / 3600; // ms -> 0.001h so we get Wh from kW
+        float recup_power = StdMetrics.ms_v_inv_power->AsFloat();
+        m_drive_recupenergysum -= recup_power*m_recuptimedelta;
+        m_recuplasttime = esp_log_timestamp();
+        ESP_LOGD(TAG, "recuperation %.3f kW, timedelta %.3f mh", recup_power, m_recuptimedelta);
+        }
+      m_recupering = true;
+      }
+    else
+      {
+      m_recupering = false; 
       }
     }
   else if (metric == StandardMetrics.ms_v_pos_acceleration)

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -358,6 +358,10 @@ class OvmsVehicle : public InternalRamAllocated
     uint32_t m_drive_decelcnt;              // Driving deceleration average data
     double m_drive_decelsum;                // Driving deceleration average data
 
+    bool m_recupering;                      // Driving detect resuperation
+    uint32_t m_recuplasttime;               // last time recupered power was measured
+    float m_drive_recupenergysum;           // Driving recupered energy sum
+
   protected:
     uint32_t m_ticker;
     int m_12v_ticker;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -357,10 +357,10 @@ class OvmsVehicle : public InternalRamAllocated
     double m_drive_accelsum;                // Driving acceleration average data
     uint32_t m_drive_decelcnt;              // Driving deceleration average data
     double m_drive_decelsum;                // Driving deceleration average data
-
-    bool m_recupering;                      // Driving detect resuperation
-    uint32_t m_recuplasttime;               // last time recupered power was measured
-    float m_drive_recupenergysum;           // Driving recupered energy sum
+    float motor_energy;                     // Driving motor energy sum
+    float recup_energy;                     // Driving recupered energy sum
+    uint32_t m_inv_reftime;                 // last time inverter(motor) power was measured
+    float m_inv_lastpower;                  // last inverter(motor) power
 
   protected:
     uint32_t m_ticker;


### PR DESCRIPTION
I propose to add to the new trip reports the actual recuperated power (when motor is in generator mode) additonally to the recharged power that goes back into the battery (up to now labeled as recovered power).

[If the used standard metric ms_v_inv_power isn't generic enough we could introduce a new metric for the motor power and just link them in the specific vehicle modules.]