### PR TITLE
NL: ZE0 charger fix, AC Voltage added, AZE0 cleanup

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -202,7 +202,8 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     float m_cum_energy_recd_wh; 					// Cumulated energy (in wh) recovered  within 1 second ticker interval
     float m_cum_energy_charge_wh;					// Cumulated energy (in wh) charged within 10 second ticker interval
     float m_cum_energy_gen_wh;					  // Cumulated energy (in wh) exported within 10 second ticker interval
-    bool  m_gen1_charger;					        // True if using original charger and 0x5bf messages, false if using 0x390 messages
+    bool  m_ZE0_charger;					        // True if 2011-2012 ZE0 LEAF with 0x380 message (Gen 1)
+	bool  m_AZE0_charger;							// True if 2013+ AZE0 LEAF with 0x390 message (Gen 2)
     bool  m_enable_write;                 // Enable/disable can write (polling and commands
 
   protected:


### PR DESCRIPTION
This PR aims to improve three things
- 2011-2012 LEAFs are reported as plugged in all the time (Waiting for ZE0 user to test)
- 2011-2012 LEAFs now report measured AC voltage from CAN message 0x380 (Waiting for ZE0 user to test)
- 2013+ LEAFs now report 220V/110V instead of 200V/100V when charging on L1/L2

For now I have only tested this on my 2015 AZE0. There might be some codechange still needed to display AC voltage properly in app while charging for ZE0, and also we need to see if this fixes the "always plugged in" issue 476