### PR TITLE
NL: Add new metrics

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -16,11 +16,11 @@ Open Vehicle Monitor System v3 - Change log
 - Nissan LEAF:
  - Stop charge feature added, works via app
  - 5 new metrics added
-    m_max_gids (Max number of GIDs the battery can reach (for 2016+))
-    m_battery_heatrequested (Battery is requesting heater elements to turn on (for 2013+))
-    m_battery_heatergranted (Vehicle is OKing heater elements to turn on (for 2013+))
-    m_charge_minutes_3kW_remaining (The 3kW charge time estimate the car calculates)
-    m_remaining_chargebars (Remaining charge "bars" on dashboard)
+    xnl.v.b.max.gids (Max number of GIDs the battery can reach (for 2016+))
+    xnl.v.b.heatrequested (Battery is requesting heater elements to turn on (for 2013+))
+    xnl.v.b.heatergranted (Vehicle is OKing heater elements to turn on (for 2013+))
+    xnl.v.c.chargeminutes3kW (The 3kW charge time estimate the car calculates)
+    xnl.v.c.chargebars (Remaining charge "bars" on dashboard)
  - Wakeup command now charges 12V battery if connected to EVSE
  - 2011-2012 LEAF now reads AC voltage from grid
 

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -10,6 +10,16 @@ Open Vehicle Monitor System v3 - Change log
   New commands:
     server v2 update [all|modified]     -- Request V2 data update
     server v3 update [all|modified]     -- Request V3 data update
+- Nissan LEAF:
+ - Stop charge feature added, works via app
+ - 5 new metrics added
+    m_max_gids (Max number of GIDs the battery can reach (for 2016+))
+    m_battery_heatrequested (Battery is requesting heater elements to turn on (for 2013+))
+    m_battery_heatergranted (Vehicle is OKing heater elements to turn on (for 2013+))
+    m_charge_minutes_3kW_remaining (The 3kW charge time estimate the car calculates)
+    m_remaining_chargebars (Remaining charge "bars" on dashboard)
+ - Wakeup command now charges 12V battery if connected to EVSE
+ - 2011-2012 LEAF now reads AC voltage from grid
 
 2021-11-22 MWJ  3.2.018  OTA release
 - Vehicle: added optional automatic trip report generation

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -132,6 +132,7 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   BmsSetCellArrangementTemperature(3, 1);
   
   m_gids = MyMetrics.InitInt("xnl.v.b.gids", SM_STALE_HIGH, 0);
+  m_max_gids = MyMetrics.InitInt("xnl.v.b.max.gids", SM_STALE_HIGH, 0);
   m_hx = MyMetrics.InitFloat("xnl.v.b.hx", SM_STALE_HIGH, 0);
   m_soc_new_car = MyMetrics.InitFloat("xnl.v.b.soc.newcar", SM_STALE_HIGH, 0, Percentage);
   m_soc_instrument = MyMetrics.InitFloat("xnl.v.b.soc.instrument", SM_STALE_HIGH, 0, Percentage);
@@ -1309,7 +1310,8 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
             break;
           case  0x01:
             {
-            // Max gids, this mx value only occurs on 30kwh models. For 24 kwh models we use the value from msg 0x59e
+            // Max gids, this mx value only occurs on 30kWh models and up
+            m_max_gids->SetValue(nl_gids);
             m_battery_energy_capacity->SetValue(nl_gids * GEN_1_WH_PER_GID, WattHours);
             type = BATTERY_TYPE_2_30kWh;
             }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -182,12 +182,16 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     OvmsMetricFloat *m_battery_energy_available;
     OvmsMetricInt *m_battery_type;
     OvmsMetricBool *m_battery_heaterpresent;
+    OvmsMetricBool *m_battery_heatrequested;
+    OvmsMetricBool *m_battery_heatergranted;
     OvmsMetricFloat *m_battery_out_power_limit;
     OvmsMetricFloat *m_battery_in_power_limit; 
     OvmsMetricFloat *m_battery_chargerate_max;
     OvmsMetricString *m_charge_limit;    
     OvmsMetricVector<int> *m_charge_duration;
     OvmsMetricVector<string> *m_charge_duration_label;
+    OvmsMetricInt *m_charge_minutes_3kW_remaining;
+    OvmsMetricInt *m_remaining_chargebars;
     OvmsMetricInt *m_quick_charge;
     OvmsMetricFloat *m_soc_nominal;
     OvmsMetricInt *m_charge_count_qc;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -168,6 +168,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     TimerHandle_t m_MITMstop;
     metric_unit_t m_odometer_units = Other;
     OvmsMetricInt *m_gids;
+    OvmsMetricInt *m_max_gids;
     OvmsMetricFloat *m_hx;
     OvmsMetricFloat *m_soc_new_car;
     OvmsMetricFloat *m_soc_instrument;

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/doc/changes.txt
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/doc/changes.txt
@@ -1,3 +1,0 @@
-Open Vehicle Monitor System v3 - Renault Twizy
-
-2017-10-21 MB           Initial stub


### PR DESCRIPTION
This PR does some cleanup and adds new metrics for the Nissan LEAF

- m_max_gids (Max number of GIDs the battery can reach (for 2016+))
- m_battery_heatrequested (Battery is requesting heater elements to turn on (for 2013+))
- m_battery_heatergranted (Vehicle is OKing heater elements to turn on (for 2013+))
- m_charge_minutes_3kW_remaining (The 3kW charge time estimate the car calculates)
- m_remaining_chargebars (Remaining charge "bars" on dashboard)

Further development should be done with the battery heating metrics, and alert the user once this is triggered. During colder than -17*C battery temperature, the battery will start to use its own power to heat itself up in the form of 300W heating elements. This will discharge the battery down to 30%SOC if left in the cold for too long, so it would be worthwhile to report this in the app!