### PR TITLE
Fix the TCP client CAN logger

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/canlog_tcpclient.h
+++ b/vehicle/OVMS.V3/components/can/src/canlog_tcpclient.h
@@ -31,6 +31,7 @@
 #include "canlog.h"
 #include "ovms_netmanager.h"
 #include "ovms_mutex.h"
+#include "ovms_semaphore.h"
 
 class canlog_tcpclient : public canlog
   {
@@ -48,7 +49,7 @@ class canlog_tcpclient : public canlog
 
   public:
     std::string         m_path;
-    bool                m_connecting;
+    OvmsSemaphore       m_connecting;
   };
 
 #endif // __CANLOG_TCP_CLIENT_H__

--- a/vehicle/OVMS.V3/components/can/src/canlog_tcpclient.h
+++ b/vehicle/OVMS.V3/components/can/src/canlog_tcpclient.h
@@ -48,6 +48,7 @@ class canlog_tcpclient : public canlog
 
   public:
     std::string         m_path;
+    bool                m_connecting;
   };
 
 #endif // __CANLOG_TCP_CLIENT_H__


### PR DESCRIPTION
The implementation of the TCP client CAN logger is broken.
canlog_tcpclient->Open() does not wait for connection to be established and immediatly returns, making canlog_tcpclient->IsOpen() always return false, and thus the logger object to be deleted immediately.
I propose a patch that waits at most 10s until the connection is established.
