### PR TITLE
fix `cs11` (canswitch) tag, and reference this format in the documentation (#728)

### DIFF
--- a/docs/source/crtd/can_logging.rst
+++ b/docs/source/crtd/can_logging.rst
@@ -77,7 +77,7 @@ or log specific CAN packets by applying a filter e.g 0x55b the Nissan LEAF SoC C
 
 ``ovms# can log start vfs crtd /sd/can.crtd 55b``
   
-Other CAN log file formats are supported e.g ``crtd, gvret-a, gvret-b, lawricel, pcap, raw``.
+Other CAN log file formats are supported e.g ``crtd, cs11, gvret-a, gvret-b, lawricel, pcap, raw``
   
 Check CAN logging satus with:
 

--- a/vehicle/OVMS.V3/components/can/src/canformat_canswitch.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_canswitch.cpp
@@ -25,7 +25,7 @@
 */
 
 #include "ovms_log.h"
-static const char *TAG = "canformat-crtd";
+static const char *TAG = "canformat-cs11";
 
 #include <errno.h>
 #include "pcp.h"


### PR DESCRIPTION
* the TAG was wrong for this format and has been fixed
* this format (`cs11`) is now metionned in [the documentation](https://docs.openvehicles.com/en/stable/crtd/can_logging.html#logging-to-sd-card)

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>