### PR TITLE
rename `lawricel` format to `lawicel` (#728)

### DIFF
--- a/docs/source/crtd/can_logging.rst
+++ b/docs/source/crtd/can_logging.rst
@@ -77,7 +77,7 @@ or log specific CAN packets by applying a filter e.g 0x55b the Nissan LEAF SoC C
 
 ``ovms# can log start vfs crtd /sd/can.crtd 55b``
   
-Other CAN log file formats are supported e.g ``crtd, cs11, gvret-a, gvret-b, lawricel, pcap, raw``
+Other CAN log file formats are supported e.g ``crtd, cs11, gvret-a, gvret-b, lawicel, pcap, raw``.
   
 Check CAN logging satus with:
 

--- a/vehicle/OVMS.V3/components/can/src/canformat_lawicel.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_lawicel.cpp
@@ -25,44 +25,44 @@
 */
 
 #include "ovms_log.h"
-static const char *TAG = "canformat-lawricel";
+static const char *TAG = "canformat-lawicel";
 
 #include <errno.h>
 #include "pcp.h"
-#include "canformat_lawricel.h"
+#include "canformat_lawicel.h"
 
 ////////////////////////////////////////////////////////////////////////
 // Initialisation and Registration
 ////////////////////////////////////////////////////////////////////////
 
-class OvmsCanFormatLawricelInit
+class OvmsCanFormatLawicelInit
   {
-  public: OvmsCanFormatLawricelInit();
-} MyOvmsCanFormatLawricelTInit  __attribute__ ((init_priority (4505)));
+  public: OvmsCanFormatLawicelInit();
+} MyOvmsCanFormatLawicelTInit  __attribute__ ((init_priority (4505)));
 
-OvmsCanFormatLawricelInit::OvmsCanFormatLawricelInit()
+OvmsCanFormatLawicelInit::OvmsCanFormatLawicelInit()
   {
-  ESP_LOGI(TAG, "Registering CAN Format: LAWRICEL (4505)");
+  ESP_LOGI(TAG, "Registering CAN Format: LAWICEL (4505)");
 
-  MyCanFormatFactory.RegisterCanFormat<canformat_lawricel>("lawricel");
+  MyCanFormatFactory.RegisterCanFormat<canformat_lawicel>("lawicel");
   }
 
 ////////////////////////////////////////////////////////////////////////
 // Base GVRET implementation (utility)
 ////////////////////////////////////////////////////////////////////////
 
-canformat_lawricel::canformat_lawricel(const char* type)
+canformat_lawicel::canformat_lawicel(const char* type)
   : canformat(type)
   {
   }
 
-canformat_lawricel::~canformat_lawricel()
+canformat_lawicel::~canformat_lawicel()
   {
   }
 
-std::string canformat_lawricel::get(CAN_log_message_t* message)
+std::string canformat_lawicel::get(CAN_log_message_t* message)
   {
-  char buf[CANFORMAT_LAWRICEL_MAXLEN];
+  char buf[CANFORMAT_LAWICEL_MAXLEN];
 
   if ((message->type != CAN_LogFrame_RX)&&
       (message->type != CAN_LogFrame_TX))
@@ -87,12 +87,12 @@ std::string canformat_lawricel::get(CAN_log_message_t* message)
   return std::string(buf);
   }
 
-std::string canformat_lawricel::getheader(struct timeval *time)
+std::string canformat_lawicel::getheader(struct timeval *time)
   {
   return std::string("");
   }
 
-size_t canformat_lawricel::put(CAN_log_message_t* message, uint8_t *buffer, size_t len, bool* hasmore, canlogconnection* clc)
+size_t canformat_lawicel::put(CAN_log_message_t* message, uint8_t *buffer, size_t len, bool* hasmore, canlogconnection* clc)
   {
   if (m_buf.FreeSpace()==0) SetServeDiscarding(true); // Buffer full, so discard from now on
   if (IsServeDiscarding()) return len;  // Quick return if discarding

--- a/vehicle/OVMS.V3/components/can/src/canformat_lawicel.h
+++ b/vehicle/OVMS.V3/components/can/src/canformat_lawicel.h
@@ -24,18 +24,18 @@
 ; THE SOFTWARE.
 */
 
-#ifndef __CANFORMAT_LAWRICEL_H__
-#define __CANFORMAT_LAWRICEL_H__
+#ifndef __CANFORMAT_LAWICEL_H__
+#define __CANFORMAT_LAWICEL_H__
 
 #include "canformat.h"
 
-#define CANFORMAT_LAWRICEL_MAXLEN 48
+#define CANFORMAT_LAWICEL_MAXLEN 48
 
-class canformat_lawricel : public canformat
+class canformat_lawicel : public canformat
   {
   public:
-    canformat_lawricel(const char* type);
-    virtual ~canformat_lawricel();
+    canformat_lawicel(const char* type);
+    virtual ~canformat_lawicel();
 
   public:
     virtual std::string get(CAN_log_message_t* message);
@@ -43,4 +43,4 @@ class canformat_lawricel : public canformat
     virtual size_t put(CAN_log_message_t* message, uint8_t *buffer, size_t len, bool* hasmore, canlogconnection* clc=NULL);
   };
 
-#endif // __CANFORMAT_LAWRICEL_H__
+#endif // __CANFORMAT_LAWICEL_H__


### PR DESCRIPTION
Typo - this format name (`lawicel`, a.k.a. `slcan` in the Linux Kernel) comes from the LAWICEL AB company and its product : http://www.lawicel.com/can232/can232.pdf

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>