### PR TITLE
fix negative integer DBC numbers having wrong values

### DIFF
--- a/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
@@ -830,8 +830,10 @@ dbcNumber dbcSignal::Decode(CAN_frame_t* msg)
 
   if (m_value_type == DBC_VALUETYPE_UNSIGNED)
     result.Cast((uint32_t)val, DBC_NUMBER_INTEGER_UNSIGNED);
-  else
-    result.Cast((uint32_t)val, DBC_NUMBER_INTEGER_SIGNED);
+  else {
+    int32_t signed_val = sign_extend<uint32_t, int32_t>((uint32_t)val, m_signal_size-1);
+    result.Cast(static_cast<uint32_t>(signed_val), DBC_NUMBER_INTEGER_SIGNED);
+  }
 
   // Apply factor and offset
   if (!(m_factor == 1))

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -338,4 +338,18 @@ double float2double(float f);
 std::string idtag(const char* tag, void* instance);
 #define IDTAG idtag(TAG,this)
 
+/**
+ * sign_extend: Sign extend an unsigned to a signed integer of the same size.
+ */
+template <typename UINT, typename INT>
+INT sign_extend(UINT uvalue, uint8_t signbit)
+  {
+  typedef typename std::make_unsigned<INT>::type uint_t;
+  uint_t newuvalue = uvalue;
+  if (newuvalue & (UINT(1U) << signbit)) {
+    newuvalue |= ~((uint_t(1U) << signbit) - 1);
+  }
+  return reinterpret_cast<INT &>(newuvalue);
+  }
+
 #endif // __OVMS_UTILS_H__


### PR DESCRIPTION
When non-32-bits negative numbers were processed by the DBC processor, there was an issue where the resulting metric values were incorrect.

As an example:

A 16-bit signed value coming from the can bus as 0xFFF7(-9) is being multiplied by a factor of -1.
When handled by the DBC processor, the incoming number is stored as 0x0000FFF7 ; which is not -9, but 65527.
After multiplication, it comes as 0xFFFF0009(-65527).

(While those should be: 0xFFFFFFF7(-9) and 0x00000009(9))

The root cause is that the sign of the non-32-bit number is not extended to the left, thus making it a different number.

The fix is to sign-extend the number to the left (it should work from 2-bit numbers to 32-bit numbers) when we're dealing with signed numbers.

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>