### PR TITLE
Vehicle - Factor out functions to finalise the cell voltages/temperatures

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -673,7 +673,9 @@ class OvmsVehicle : public InternalRamAllocated
     void BmsSetCellLimitsTemperature(float min, float max);
     void BmsSetCellVoltage(int index, float value);
     void BmsResetCellVoltages(bool full = false);
+    void BmsFinaliseCellVoltages();
     void BmsSetCellTemperature(int index, float value);
+    void BmsFinaliseCellTemperatures();
     void BmsResetCellTemperatures(bool full = false);
     void BmsRestartCellVoltages();
     void BmsRestartCellTemperatures();


### PR DESCRIPTION
This patch should not affect current behaviour.  When the voltages are all set up to the currently defined maximum, it will analyse and post the results.

What it allows the  vehicle module to do is obey the bit-set of valid cells and only post those that are valid.  When we get to the end of the valid cells, calling BmsFinaliseCellVoltages() / BmsFinaliseCellTemperatures() will post the data with the current values - not including any 'missing' cells in the final averages.

Presumably in the normal run of things, cells will be filled up to a point.  The problem is that the first time we fetch the cell values, we don't know what that point is to set the number of cells.

I'm not sure that a scenario where cells are missing from the middle would ever exist, so I would be happy to take out that possibility and simply allow resize of the number of cells after reading the data.  The factorisation would still apply, but it would be simplified.
