### PR TITLE
Vehicle - Use Enum for Bat/Temp status

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -273,6 +273,14 @@ typedef struct
   uint32_t                lastused;         // Timestamp of last channel access
   } vwtp_channel_t;
 
+enum class OvmsStatus : short {
+  OK = 0,
+  Warn = 1,
+  Alert = 2
+};
+inline bool operator<(OvmsStatus lhs, OvmsStatus rhs) {
+  return static_cast<short>(lhs) < static_cast<short>(rhs);
+}
 
 class OvmsVehicle : public InternalRamAllocated
   {
@@ -631,7 +639,7 @@ class OvmsVehicle : public InternalRamAllocated
     float* m_bms_vmins;                       // BMS minimum voltages seen (since reset)
     float* m_bms_vmaxs;                       // BMS maximum voltages seen (since reset)
     float* m_bms_vdevmaxs;                    // BMS maximum voltage deviations seen (since reset)
-    short* m_bms_valerts;                     // BMS voltage deviation alerts (since reset)
+    OvmsStatus* m_bms_valerts;                // BMS voltage deviation alerts (since reset)
     int m_bms_valerts_new;                    // BMS new voltage alerts since last notification
     int m_bms_vstddev_cnt;                    // BMS internal stddev counter
     float m_bms_vstddev_avg;                  // BMS internal stddev average
@@ -640,7 +648,7 @@ class OvmsVehicle : public InternalRamAllocated
     float* m_bms_tmins;                       // BMS minimum temperatures seen (since reset)
     float* m_bms_tmaxs;                       // BMS maximum temperatures seen (since reset)
     float* m_bms_tdevmaxs;                    // BMS maximum temperature deviations seen (since reset)
-    short* m_bms_talerts;                     // BMS temperature deviation alerts (since reset)
+    OvmsStatus* m_bms_talerts;                // BMS temperature deviation alerts (since reset)
     int m_bms_talerts_new;                    // BMS new temperature alerts since last notification
     bool m_bms_has_temperatures;              // True if BMS has a complete set of temperature values
     std::vector<bool> m_bms_bitset_v;         // BMS tracking: true if corresponding voltage set


### PR DESCRIPTION
Uses a strict (class) enum for the Battery and Temperature status rather than magic numbers in the code.

I didn't use the Enum for the Metric because I figured that was too big a change.