### PR TITLE
Add Method to change voltage cell arrangement, preserving existing data

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -689,6 +689,7 @@ class OvmsVehicle : public InternalRamAllocated
     virtual void BmsStatus(int verbosity, OvmsWriter* writer);
     virtual bool FormatBmsAlerts(int verbosity, OvmsWriter* writer, bool show_warnings);
     bool BmsCheckChangeCellArrangementVoltage(int readings, int readingspermodule = 0);
+    bool BmsCheckChangeCellArrangementTemperature(int readings, int readingspermodule = 0);
   };
 
 template<typename Type> OvmsVehicle* CreateVehicle()

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -688,6 +688,7 @@ class OvmsVehicle : public InternalRamAllocated
     void BmsResetCellStats();
     virtual void BmsStatus(int verbosity, OvmsWriter* writer);
     virtual bool FormatBmsAlerts(int verbosity, OvmsWriter* writer, bool show_warnings);
+    bool BmsCheckChangeCellArrangementVoltage(int readings, int readingspermodule = 0);
   };
 
 template<typename Type> OvmsVehicle* CreateVehicle()

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_bms.cpp
@@ -72,6 +72,7 @@ void OvmsVehicle::BmsSetCellArrangementVoltage(int readings, int readingspermodu
   BmsResetCellVoltages(true);
   }
 
+// Internal entry for changing cell arrangements.
 struct reading_entry_t
   {
   int cell_no;
@@ -82,6 +83,7 @@ struct reading_entry_t
  * Changes the cell arrangement for Voltage, if needs be restoring any readings that were there.
  * Really should only do work the first time it is called.. as for any one car, the number of readings
  * should be consistent.
+ * @return true If the cell arrangement was changed.
  */
 bool OvmsVehicle::BmsCheckChangeCellArrangementVoltage(int readings, int readingspermodule /*=0*/)
   {
@@ -122,14 +124,15 @@ bool OvmsVehicle::BmsCheckChangeCellArrangementVoltage(int readings, int reading
       BmsSetCellArrangementVoltage(readings, readingspermodule);
       for ( std::vector<reading_entry_t>::iterator iter = cells.begin(); iter != cells.end(); ++iter)
         {
-        BmsSetCellTemperature(iter->cell_no, iter->entry);
+        BmsSetCellVoltage(iter->cell_no, iter->entry);
         }
       }
     }
   else if (readingspermodule != m_bms_readingspermodule_v)
     {
-    // This seems only to change the read-out.
+    // This only changes the read-out.
     m_bms_readingspermodule_v = readingspermodule;
+    res = true;
     }
   return res;
   }


### PR DESCRIPTION
This adds a method that copies out existing data - resets to a new configuration, and then copies it back in.

