### PR TITLE
Enhance BMS shell display

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -2,6 +2,10 @@ Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
 - Renault Zoe Phase 2: Initial support
+- Improved output of bms shell command for narrow windows.
+  New commands:
+    bms volt                            -- Output only voltage info if available
+    bms temp                            -- Output only temperature info if available
 
 2022-09-01 MWJ  3.3.003  OTA release
 - Toyota RAV4 EV: Initial support added. Only the Tesla bus is decoded and just listening so far.

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -90,6 +90,8 @@ OvmsVehicleFactory::OvmsVehicleFactory()
 
   OvmsCommand* cmd_bms = MyCommandApp.RegisterCommand("bms","BMS framework", bms_status, "", 0, 0, false);
   cmd_bms->RegisterCommand("status","Show BMS status",bms_status);
+  cmd_bms->RegisterCommand("temp","Show BMS temperature status",bms_temp);
+  cmd_bms->RegisterCommand("volt","Show BMS voltage status",bms_volt);
   cmd_bms->RegisterCommand("reset","Reset BMS statistics",bms_reset);
   cmd_bms->RegisterCommand("alerts","Show BMS alerts",bms_alerts);
 

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -90,8 +90,8 @@ OvmsVehicleFactory::OvmsVehicleFactory()
 
   OvmsCommand* cmd_bms = MyCommandApp.RegisterCommand("bms","BMS framework", bms_status, "", 0, 0, false);
   cmd_bms->RegisterCommand("status","Show BMS status",bms_status);
-  cmd_bms->RegisterCommand("temp","Show BMS temperature status",bms_temp);
-  cmd_bms->RegisterCommand("volt","Show BMS voltage status",bms_volt);
+  cmd_bms->RegisterCommand("temp","Show BMS temperature status",bms_status);
+  cmd_bms->RegisterCommand("volt","Show BMS voltage status",bms_status);
   cmd_bms->RegisterCommand("reset","Reset BMS statistics",bms_reset);
   cmd_bms->RegisterCommand("alerts","Show BMS alerts",bms_alerts);
 

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -694,7 +694,7 @@ class OvmsVehicle : public InternalRamAllocated
     void BmsGetCellDefaultThresholdsVoltage(float* warn, float* alert, float* maxgrad=NULL, float* maxsddev=NULL);
     void BmsGetCellDefaultThresholdsTemperature(float* warn, float* alert);
     void BmsResetCellStats();
-    virtual void BmsStatus(int verbosity, OvmsWriter* writer);
+    virtual void BmsStatus(int verbosity, bool showvoltage, bool showtemperature, OvmsWriter* writer);
     virtual bool FormatBmsAlerts(int verbosity, OvmsWriter* writer, bool show_warnings);
     bool BmsCheckChangeCellArrangementVoltage(int readings, int readingspermodule = 0);
     bool BmsCheckChangeCellArrangementTemperature(int readings, int readingspermodule = 0);
@@ -764,6 +764,8 @@ class OvmsVehicleFactory
     static void vehicle_stat(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void vehicle_stat_trip(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void bms_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
+    static void bms_temp(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
+    static void bms_volt(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void bms_reset(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void bms_alerts(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void obdii_request(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -479,6 +479,12 @@ class OvmsVehicle : public InternalRamAllocated
       Range = 3,
       Performance = 4
       } vehicle_mode_t;
+    enum class vehicle_bms_status_t
+      {
+      Both,
+      Voltage,
+      Temperature
+      };
 
   public:
     vehicle_mode_t VehicleModeKey(const std::string code);
@@ -694,7 +700,7 @@ class OvmsVehicle : public InternalRamAllocated
     void BmsGetCellDefaultThresholdsVoltage(float* warn, float* alert, float* maxgrad=NULL, float* maxsddev=NULL);
     void BmsGetCellDefaultThresholdsTemperature(float* warn, float* alert);
     void BmsResetCellStats();
-    virtual void BmsStatus(int verbosity, bool showvoltage, bool showtemperature, OvmsWriter* writer);
+    virtual void BmsStatus(int verbosity, OvmsWriter* writer, vehicle_bms_status_t statusmode);
     virtual bool FormatBmsAlerts(int verbosity, OvmsWriter* writer, bool show_warnings);
     bool BmsCheckChangeCellArrangementVoltage(int readings, int readingspermodule = 0);
     bool BmsCheckChangeCellArrangementTemperature(int readings, int readingspermodule = 0);
@@ -764,8 +770,6 @@ class OvmsVehicleFactory
     static void vehicle_stat(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void vehicle_stat_trip(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void bms_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
-    static void bms_temp(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
-    static void bms_volt(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void bms_reset(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void bms_alerts(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void obdii_request(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_bms.cpp
@@ -550,11 +550,30 @@ void OvmsVehicle::BmsResetCellStats()
   BmsResetCellTemperatures(false);
   }
 
+int check_max_cols( int total_cols)
+  {
+  if (total_cols <= 5)
+    return total_cols;
+  if (total_cols % 4 == 0)
+    return 4;
+  if (total_cols % 3 == 0)
+    return 3;
+  if (total_cols % 5 == 0)
+    return 5;
+  return 4;
+  }
+
+template<typename INT>
+INT round_up_div(INT value, INT divis)
+  {
+    return (value + divis -1) / divis;
+  }
+
 void OvmsVehicle::BmsStatus(int verbosity, OvmsWriter* writer)
   {
   int c;
 
-  if ((! m_bms_has_voltages)||(! m_bms_has_temperatures))
+  if ((!m_bms_has_voltages) && (!m_bms_has_temperatures))
     {
     writer->puts("No BMS status data available");
     return;
@@ -580,61 +599,133 @@ void OvmsVehicle::BmsStatus(int verbosity, OvmsWriter* writer)
       case OvmsStatus::Alert: talert++; break;
       }
     }
+  if (m_bms_has_voltages)
+    {
+    writer->puts("Voltage:");
+    writer->printf("    Average: %5.3fV [%5.3fV - %5.3fV]\n",
+      StdMetrics.ms_v_bat_pack_vavg->AsFloat(),
+      StdMetrics.ms_v_bat_pack_vmin->AsFloat(),
+      StdMetrics.ms_v_bat_pack_vmax->AsFloat());
+    writer->printf("  Deviation: SD %6.2fmV [max %.2fmV], %d warnings, %d alerts\n",
+      StdMetrics.ms_v_bat_pack_vstddev->AsFloat()*1000,
+      StdMetrics.ms_v_bat_pack_vstddev_max->AsFloat()*1000,
+      vwarn, valert);
+    }
 
-  writer->puts("Voltage:");
-  writer->printf("    Average: %5.3fV [%5.3fV - %5.3fV]\n",
-    StdMetrics.ms_v_bat_pack_vavg->AsFloat(),
-    StdMetrics.ms_v_bat_pack_vmin->AsFloat(),
-    StdMetrics.ms_v_bat_pack_vmax->AsFloat());
-  writer->printf("  Deviation: SD %6.2fmV [max %.2fmV], %d warnings, %d alerts\n",
-    StdMetrics.ms_v_bat_pack_vstddev->AsFloat()*1000,
-    StdMetrics.ms_v_bat_pack_vstddev_max->AsFloat()*1000,
-    vwarn, valert);
-
-  writer->puts("Temperature:");
-  writer->printf("    Average: %5.1fC [%5.1fC - %5.1fC]\n",
-    StdMetrics.ms_v_bat_pack_tavg->AsFloat(),
-    StdMetrics.ms_v_bat_pack_tmin->AsFloat(),
-    StdMetrics.ms_v_bat_pack_tmax->AsFloat());
-  writer->printf("  Deviation: SD %6.2fC  [max %.2fC], %d warnings, %d alerts\n",
-    StdMetrics.ms_v_bat_pack_tstddev->AsFloat(),
-    StdMetrics.ms_v_bat_pack_tstddev_max->AsFloat(),
-    twarn, talert);
+  if (m_bms_has_temperatures)
+    {
+    writer->puts("Temperature:");
+    writer->printf("    Average: %5.1fC [%5.1fC - %5.1fC]\n",
+      StdMetrics.ms_v_bat_pack_tavg->AsFloat(),
+      StdMetrics.ms_v_bat_pack_tmin->AsFloat(),
+      StdMetrics.ms_v_bat_pack_tmax->AsFloat());
+    writer->printf("  Deviation: SD %6.2fC  [max %.2fC], %d warnings, %d alerts\n",
+      StdMetrics.ms_v_bat_pack_tstddev->AsFloat(),
+      StdMetrics.ms_v_bat_pack_tstddev_max->AsFloat(),
+      twarn, talert);
+    }
 
   writer->puts("Cells:");
   int kv = 0;
   int kt = 0;
-  for (int module = 0; module < ((m_bms_readings_v+m_bms_readingspermodule_v-1)/m_bms_readingspermodule_v); module++)
+  int module_count = 0;
+  if (m_bms_has_voltages)
+    module_count = round_up_div(m_bms_readings_v,m_bms_readingspermodule_v);
+  if (m_bms_has_temperatures)
+    {
+    int temp_module_count  = round_up_div(m_bms_readings_t,m_bms_readingspermodule_t);
+    if (temp_module_count > module_count)
+      module_count = temp_module_count;
+    }
+  int max_cols_v = 0;
+  if (m_bms_has_voltages)
+    max_cols_v = check_max_cols(m_bms_readingspermodule_v);
+  int max_cols_t = 0;
+  if (m_bms_has_temperatures)
+    max_cols_t = check_max_cols(m_bms_readingspermodule_t);
+
+  for (int module = 0; module < module_count; ++module)
     {
     writer->printf("    +");
-    for (c=0;c<m_bms_readingspermodule_v;c++) { writer->printf("-------"); }
-    writer->printf("-+");
-    for (c=0;c<m_bms_readingspermodule_t;c++) { writer->printf("-------"); }
-    writer->puts("-+");
-    writer->printf("%3d |",module+1);
-    for (c=0; c<m_bms_readingspermodule_v; c++)
+    if (m_bms_has_voltages)
       {
-      if (kv < m_bms_readings_v)
-        writer->printf(" %5.3fV",m_bms_voltages[kv++]);
-      else
-        writer->printf("       ");
+      for (c=0;c<max_cols_v;c++) { writer->printf("-------"); }
+      writer->printf("-+");
       }
-    writer->printf(" |");
-    for (c=0; c<m_bms_readingspermodule_t; c++)
+
+      if (m_bms_has_temperatures) {
+        for (c=0;c<max_cols_t;c++) { writer->printf("-------"); }
+        writer->printf("-+");
+      }
+      writer->puts("");
+
+    int rows_v = 0, rows_t = 0;
+    int reading_left_v = 0, reading_left_t = 0;
+    if (m_bms_has_voltages)
       {
-      if (kt < m_bms_readings_t)
-        writer->printf(" %5.1fC",m_bms_temperatures[kt++]);
-      else
-        writer->printf("       ");
+      int items_left_v = m_bms_readings_v - kv;
+      reading_left_v = std::min(items_left_v, m_bms_readingspermodule_v);
+      rows_v = round_up_div(reading_left_v, max_cols_v);
       }
-    writer->puts(" |");
+    if (m_bms_has_temperatures)
+      {
+      int items_left_t = m_bms_readings_t - kt;
+      reading_left_t = std::min(items_left_t, m_bms_readingspermodule_t);
+      rows_t = round_up_div(reading_left_t, max_cols_t);
+      }
+    int rows = std::max(rows_v,rows_t);
+    for (int row = 0 ; row < rows; ++row)
+      {
+      if (row == 0)
+        writer->printf("%3d |",module+1);
+      else
+        writer->printf("    |");
+      if (m_bms_has_voltages)
+        {
+        for (c=0; c<max_cols_v; c++)
+          {
+          if (kv < m_bms_readings_v && (reading_left_v > 0))
+            {
+            writer->printf(" %5.3fV",m_bms_voltages[kv]);
+            --reading_left_v;
+            ++kv;
+            }
+          else
+            writer->printf("       ");
+          }
+        writer->printf(" |");
+        }
+      if (m_bms_has_temperatures)
+        {
+        for (c=0; c<m_bms_readingspermodule_t; c++)
+          {
+          if (kt < m_bms_readings_t && (reading_left_t > 0))
+            {
+            writer->printf(" %5.1fC",m_bms_temperatures[kt]);
+            --reading_left_t;
+            ++kt;
+            }
+          else
+            writer->printf("       ");
+          }
+        writer->printf(" |");
+        }
+      writer->puts("");
+      }
     }
 
   writer->printf("    +");
-  for (c=0;c<m_bms_readingspermodule_v;c++) { writer->printf("-------"); }
-  writer->printf("-+");
-  for (c=0;c<m_bms_readingspermodule_t;c++) { writer->printf("-------"); }
-  writer->puts("-+");
+  if (m_bms_has_voltages)
+    {
+    for (c=0;c<max_cols_v;c++) { writer->printf("-------"); }
+    writer->printf("-+");
+    }
+  if (m_bms_has_temperatures)
+    {
+    for (c=0;c<max_cols_t;c++) { writer->printf("-------"); }
+    writer->printf("-+");
+    }
+  writer->puts("");
   }
 
 bool OvmsVehicle::FormatBmsAlerts(int verbosity, OvmsWriter* writer, bool show_warnings)

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
@@ -435,7 +435,30 @@ void OvmsVehicleFactory::bms_status(int verbosity, OvmsWriter* writer, OvmsComma
   {
   if (MyVehicleFactory.m_currentvehicle != NULL)
     {
-    MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, writer);
+    MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, true, true, writer);
+    }
+  else
+    {
+    writer->puts("No vehicle module selected");
+    }
+  }
+
+void OvmsVehicleFactory::bms_temp(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  if (MyVehicleFactory.m_currentvehicle != NULL)
+    {
+    MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, false, true, writer);
+    }
+  else
+    {
+    writer->puts("No vehicle module selected");
+    }
+  }
+void OvmsVehicleFactory::bms_volt(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  if (MyVehicleFactory.m_currentvehicle != NULL)
+    {
+    MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, true, false, writer);
     }
   else
     {

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
@@ -435,30 +435,14 @@ void OvmsVehicleFactory::bms_status(int verbosity, OvmsWriter* writer, OvmsComma
   {
   if (MyVehicleFactory.m_currentvehicle != NULL)
     {
-    MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, true, true, writer);
-    }
-  else
-    {
-    writer->puts("No vehicle module selected");
-    }
-  }
+      OvmsVehicle::vehicle_bms_status_t statusmode = OvmsVehicle::vehicle_bms_status_t::Both;
+      const char* smode = cmd->GetName();
+      if (strcmp(smode,"volt")==0)
+        statusmode = OvmsVehicle::vehicle_bms_status_t::Voltage;
+      else if (strcmp(smode,"temp")==0)
+        statusmode = OvmsVehicle::vehicle_bms_status_t::Temperature;
 
-void OvmsVehicleFactory::bms_temp(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
-  {
-  if (MyVehicleFactory.m_currentvehicle != NULL)
-    {
-    MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, false, true, writer);
-    }
-  else
-    {
-    writer->puts("No vehicle module selected");
-    }
-  }
-void OvmsVehicleFactory::bms_volt(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
-  {
-  if (MyVehicleFactory.m_currentvehicle != NULL)
-    {
-    MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, true, false, writer);
+      MyVehicleFactory.m_currentvehicle->BmsStatus(verbosity, writer, statusmode);
     }
   else
     {


### PR DESCRIPTION
- Allows for voltages and/or temperatures columns to be displayed depending on what's available.
- Wraps values for one module over multiple lines (where you have multiple cells per module) making it readable in a smaller display.
-  Have a maximum of 5 columns total
- Add commands  `bms temp` to display just temperature stats and `bms volt` to display just voltage stats.
