### PR TITLE
Use new power metrics in Hyundai kia/ioniq 5

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -7,6 +7,9 @@ Open Vehicle Monitor System v3 - Change log
     bms volt                            -- Output only voltage info if available
     bms temp                            -- Output only temperature info if available
 - Hyundai Ioniq 5: Initial support
+- Added power consumptions units:  kWhP100K,KPkWh,MPkWh
+- Consolidate custom trip power consumption metrics to single value (kWhP100K)
+  in Kia Niro and Kia Soul
 
 2022-09-01 MWJ  3.3.003  OTA release
 - Toyota RAV4 EV: Initial support added. Only the Tesla bus is decoded and just listening so far.

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/docs/index.rst
@@ -85,8 +85,7 @@ xiq.v.traction.control                   false                    Traction Contr
 xiq.e.trip                               12345Km                  Trip: Distance Travelled since Charged
 xiq.e.trip.energy.used                   12345kWh                 Trip: Energy Used since Charged
 xiq.e.trip.energy.recuperated            12345kWh                 Trip: Energy Recuperated since Charged
-xiq.v.trip.consumption.KWh/100km         9.5                      Trip: Power Consumption (kwH/100km) since Charged
-xiq.v.trip.consumption.km/kWh            1234                     Trip: Power Consumption (km/kWh) since Charged
+xiq.v.trip.consumption                   9.5kW/100km              Power Consumption (kwH/100km) for current trip
 xiq.v.sb.driver                          false                    Seat Belt Driver             
 xiq.v.sb.passenger                       false                    Seat Belt Passenger             
 xiq.v.sb.back.right                      false                    Seat Belt Back Right             

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -8,8 +8,6 @@
 ;               Fix naming of various metrics.
 ;               Fix/consolidate power consumption metrics
 ;
-#define I5_VERSION "0.0.2"
-
 ;    (C) 2022 Michael Geddes
 ; ----- Kona/Kia Module -----
 ;    (C) 2011       Michael Stegen / Stegen Electronics
@@ -35,6 +33,7 @@
 ; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 ; THE SOFTWARE.
 */
+#define IONIQ5_VERSION "0.0.2"
 
 #include "vehicle_hyundai_ioniq5.h"
 
@@ -343,7 +342,7 @@ OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv()
 {
   XARM("OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv");
 
-  ESP_LOGI(TAG, "Ioniq 5 EV " I5_VERSION " vehicle module");
+  ESP_LOGI(TAG, "Ioniq 5 EV " IONIQ5_VERSION " vehicle module");
 
   StopTesterPresentMessages();
 
@@ -397,7 +396,7 @@ OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv()
   MyConfig.SetParamValueBool("vehicle", "bms.alerts.enabled", false);
 
   // init metrics:
-  m_version = MyMetrics.InitString("xiq.m.version", 0, I5_VERSION " " __DATE__ " " __TIME__);
+  m_version = MyMetrics.InitString("xiq.m.version", 0, IONIQ5_VERSION " " __DATE__ " " __TIME__);
   m_b_cell_volt_max = MyMetrics.InitFloat("xiq.v.b.c.voltage.max", 10, 0, Volts);
   m_b_cell_volt_min = MyMetrics.InitFloat("xiq.v.b.c.voltage.min", 10, 0, Volts);
   m_b_cell_volt_max_no = MyMetrics.InitInt("xiq.v.b.c.voltage.max.no", 10, 0);

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -451,8 +451,7 @@ OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv()
 
   // m_v_power_usage = MyMetrics.InitFloat("xiq.v.power.usage", 10, 0, kW);
 
-  m_v_trip_consumption1 = MyMetrics.InitFloat("xiq.v.trip.consumption.KWh/100km", 10, 0, Other);
-  m_v_trip_consumption2 = MyMetrics.InitFloat("xiq.v.trip.consumption.km/kWh", 10, 0, Other);
+  m_v_trip_consumption = MyMetrics.InitFloat("xiq.v.trip.consumption", 10, 0, kWhP100K);
 
   m_v_door_lock_fl = MyMetrics.InitBool("xiq.v.d.l.fl", 10, false);
   m_v_door_lock_fr = MyMetrics.InitBool("xiq.v.d.l.fr", 10, false);
@@ -646,11 +645,10 @@ void OvmsHyundaiIoniqEv::Ticker1(uint32_t ticker)
     }
   }
 
-  if ( StdMetrics.ms_v_pos_trip->AsFloat(Kilometers) > 0 ) {
-    m_v_trip_consumption1->SetValue( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) * 100 / StdMetrics.ms_v_pos_trip->AsFloat(Kilometers) );
-  }
-  if ( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) > 0 ) {
-    m_v_trip_consumption2->SetValue( StdMetrics.ms_v_pos_trip->AsFloat(Kilometers) / StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) );
+  float trip_km = StdMetrics.ms_v_pos_trip->AsFloat(Kilometers);
+  float trip_energy = StdMetrics.ms_v_bat_energy_used->AsFloat(kWh);
+  if ( trip_km > 0 && trip_energy > 0 ) {
+    m_v_trip_consumption->SetValue( trip_energy * 100 / trip_km, kWhP100K );
   }
 
   StdMetrics.ms_v_bat_power->SetValue( StdMetrics.ms_v_bat_voltage->AsFloat(400, Volts) * StdMetrics.ms_v_bat_current->AsFloat(1, Amps) / 1000, kW );

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -4,7 +4,12 @@
 ;
 ;    Changes:
 ;       0.0.1:  Initial Fork of Kona/Kia module
+;       0.0.2:  Load Battery capacity from cell count
+;               Fix naming of various metrics.
+;               Fix/consolidate power consumption metrics
 ;
+#define I5_VERSION "0.0.2"
+
 ;    (C) 2022 Michael Geddes
 ; ----- Kona/Kia Module -----
 ;    (C) 2011       Michael Stegen / Stegen Electronics
@@ -44,8 +49,6 @@
 #include <sys/param.h>
 #include "../../vehicle_kiasoulev/src/kia_common.h"
 #include <sstream>
-
-#define VERSION "0.0.1"
 
 const char *OvmsHyundaiIoniqEv::TAG = "v-ioniq5";
 
@@ -340,7 +343,7 @@ OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv()
 {
   XARM("OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv");
 
-  ESP_LOGI(TAG, "Ioniq 5 EV " VERSION " vehicle module");
+  ESP_LOGI(TAG, "Ioniq 5 EV " I5_VERSION " vehicle module");
 
   StopTesterPresentMessages();
 
@@ -394,7 +397,7 @@ OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv()
   MyConfig.SetParamValueBool("vehicle", "bms.alerts.enabled", false);
 
   // init metrics:
-  m_version = MyMetrics.InitString("xiq.m.version", 0, VERSION " " __DATE__ " " __TIME__);
+  m_version = MyMetrics.InitString("xiq.m.version", 0, I5_VERSION " " __DATE__ " " __TIME__);
   m_b_cell_volt_max = MyMetrics.InitFloat("xiq.v.b.c.voltage.max", 10, 0, Volts);
   m_b_cell_volt_min = MyMetrics.InitFloat("xiq.v.b.c.voltage.min", 10, 0, Volts);
   m_b_cell_volt_max_no = MyMetrics.InitInt("xiq.v.b.c.voltage.max.no", 10, 0);

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
@@ -1,10 +1,9 @@
 /*
 ;    Project:       Open Vehicle Monitor System
-;    Date:          22th October 2017
+;    Date:          November 2022
 ;
-;    Changes:
-;    1.0  Initial stub
-;
+;    (C) 2022 Michael Geddes
+; ----- Kona/Kia Module -----
 ;    (C) 2018        Geir Øyvind Vælidalo <geir@validalo.net>
 ;
 ; Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.cpp
@@ -244,8 +244,7 @@ OvmsVehicleKiaNiroEv::OvmsVehicleKiaNiroEv()
 
   m_v_power_usage = MyMetrics.InitFloat("xkn.v.power.usage", 10, 0, kW);
 
-  m_v_trip_consumption1 = MyMetrics.InitFloat("xkn.v.trip.consumption.KWh/100km", 10, 0, Other);
-  m_v_trip_consumption2 = MyMetrics.InitFloat("xkn.v.trip.consumption.km/kWh", 10, 0, Other);
+  m_v_trip_consumption = MyMetrics.InitFloat("xkn.v.trip.consumption", 10, 0, kWhP100K);
 
   m_v_door_lock_fl = MyMetrics.InitBool("xkn.v.door.lock.front.left", 10, 0);
   m_v_door_lock_fr = MyMetrics.InitBool("xkn.v.door.lock.front.right", 10, 0);
@@ -416,9 +415,7 @@ void OvmsVehicleKiaNiroEv::Ticker1(uint32_t ticker)
 		}
 
 	if( StdMetrics.ms_v_pos_trip->AsFloat(Kilometers)>0 )
-			m_v_trip_consumption1->SetValue( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) * 100 / StdMetrics.ms_v_pos_trip->AsFloat(Kilometers) );
-	if( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh)>0 )
-			m_v_trip_consumption2->SetValue( StdMetrics.ms_v_pos_trip->AsFloat(Kilometers) / StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) );
+			m_v_trip_consumption->SetValue( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) * 100 / StdMetrics.ms_v_pos_trip->AsFloat(Kilometers), kWhP100K);
 
 	StdMetrics.ms_v_bat_power->SetValue( StdMetrics.ms_v_bat_voltage->AsFloat(400,Volts) * StdMetrics.ms_v_bat_current->AsFloat(1,Amps)/1000,kW );
 

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/docs/index.rst
@@ -159,8 +159,7 @@ xks.v.cruise.control.enabled     Cruise control enabled/disabled
 xks.v.emergency.lights           Emergency lights enabled/disabled
 xks.v.steering.mode              Steering mode: Sport, comfort, normal.
 xks.v.power.usage                Power usage of the car
-xks.v.trip.consumption.kWh/100km Battery consumption for current trip
-xks.v.trip.consumption.km/kWh    Battery consumption for current trip
+xks.v.trip.consumption           Battery consumption for current trip (kWh/100km)
 ================================ =============
 
 Note that some metrics are polled at different rates than others and some metrics are not available when car is off. This means that after a restart of the OVMS, some metrics will be missing until the car is turned on and maybe driven for few minutes.

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
@@ -99,8 +99,7 @@ public:
 
   OvmsMetricFloat* m_v_power_usage;
 
-  OvmsMetricFloat* m_v_trip_consumption1;
-  OvmsMetricFloat* m_v_trip_consumption2;
+  OvmsMetricFloat* m_v_trip_consumption;
 
   OvmsMetricBool*  m_v_emergency_lights;
 

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
@@ -376,8 +376,7 @@ OvmsVehicleKiaSoulEv::OvmsVehicleKiaSoulEv()
 
   m_v_power_usage = MyMetrics.InitFloat("xks.v.power.usage", 10, 0, kW);
 
-  m_v_trip_consumption1 = MyMetrics.InitFloat("xks.v.trip.consumption.KWh/100km", 10, 0, Other);
-  m_v_trip_consumption2 = MyMetrics.InitFloat("xks.v.trip.consumption.km/kWh", 10, 0, Other);
+  m_v_trip_consumption = MyMetrics.InitFloat("xks.v.trip.consumption", 10, 0, kWhP100K);
 
   m_b_cell_det_max->SetValue(0);
   m_b_cell_det_min->SetValue(0);
@@ -584,10 +583,8 @@ void OvmsVehicleKiaSoulEv::Ticker1(uint32_t ticker)
 		// Cooling?
 		StdMetrics.ms_v_env_cooling->SetValue (  m_v_env_climate_ac->AsBool() && StdMetrics.ms_v_env_temp->AsFloat(10,Celcius) > m_v_env_climate_temp->AsFloat(16, Celcius) );
 
-	  if( StdMetrics.ms_v_pos_trip->AsFloat(Kilometers)>0 )
-	  		m_v_trip_consumption1->SetValue( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) * 10 / StdMetrics.ms_v_pos_trip->AsFloat(Kilometers) );
-	  if( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh)>0 )
-	  		m_v_trip_consumption2->SetValue( StdMetrics.ms_v_pos_trip->AsFloat(Kilometers) * 10 / StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) );
+		if( StdMetrics.ms_v_pos_trip->AsFloat(Kilometers)>0 )
+			m_v_trip_consumption->SetValue( StdMetrics.ms_v_bat_energy_used->AsFloat(kWh) * 10 / StdMetrics.ms_v_pos_trip->AsFloat(Kilometers), kWhP100K);
 
 		}
 


### PR DESCRIPTION
The base modules had the power consumption doubled up with different metrics and using capitalisation and / characters.

This commit removes that from the base and inherited classes.  (An upcoming commit will allow access to metrics with different units)