### PR TITLE
add `realpath()` (backport from esp-idf) and ensure path is canonical before use

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_config.cpp
+++ b/vehicle/OVMS.V3/main/ovms_config.cpp
@@ -718,12 +718,25 @@ OvmsConfigParam* OvmsConfig::CachedParam(std::string param)
   return *p;
   }
 
+/**
+ * ProtectedPath: `true` if the path is protected (e.g. config)
+ * - Note: path is canonicalized before comparison, in case the path
+ * does not exist in the filesystem, the result will be `false`
+ * (i.e.: not protected).
+ */
 bool OvmsConfig::ProtectedPath(std::string path)
   {
 #ifdef CONFIG_OVMS_DEV_CONFIGVFS
   return false;
 #else
-  return (path.find(OVMS_CONFIGPATH) != std::string::npos);
+  char canonical_path[PATH_MAX];
+  char * result = realpath(path.c_str(), canonical_path);
+  if (NULL == result) {
+    // If error during path resolution, we consider it as not protected
+    return false;
+  }
+  std::string resolved_path(canonical_path);
+  return (resolved_path.find(OVMS_CONFIGPATH) != std::string::npos);
 #endif // #ifdef CONFIG_OVMS_DEV_CONFIGVFS
   }
 


### PR DESCRIPTION
`realpath()` has been [introduced in esp-idf 4.4](https://github.com/espressif/esp-idf/commit/d83ce227aa987d648e1a0dddba32b88846374815#diff-91b1abbc42db113c5dcf9c11c594f0b3e75cae5f6dfba9ef8b68e26bbd422f4a) and is useful to cleanup a path and check its existence.
We start using it in `OvmsConfig::ProtectedPath()`.
