### PR TITLE
add a free() that seems to be missing

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/canlog.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog.cpp
@@ -596,7 +596,11 @@ void canlog::LogInfo(canbus* bus, CAN_log_type_t type, const char* text)
     msg.origin = bus;
     msg.text = strdup(text);
     m_msgcount++;
-    if (xQueueSend(m_queue, &msg, 0) != pdTRUE) m_dropcount++;
+    if (xQueueSend(m_queue, &msg, 0) != pdTRUE)
+      {
+      m_dropcount++;
+      free(msg.text);
+      }
     }
   else
     {


### PR DESCRIPTION
if the message has not been able to be sent to the queue, we need to free() the msg.text memory that we just allocated with strdup()
(When the message is successfully sent to the queue, then the free() will occur when the message is retrieved.)

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>