### PR TITLE
Add user-configurable unit support

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -33,6 +33,7 @@ Open Vehicle Monitor System v3 - Change log
 - Add user configuration for groups of metrics
   Adds the 'ToUser' unit that converts to the user specified unit.
   Add -u to 'metrics list' to view metrics as  user units.
+- Add completion for metrics set/get as well as units
 
 2022-09-01 MWJ  3.3.003  OTA release
 - Toyota RAV4 EV: Initial support added. Only the Tesla bus is decoded and just listening so far.

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -29,6 +29,10 @@ Open Vehicle Monitor System v3 - Change log
   New events:
     vehicle.charge.type                 -- Vehicle charge connection type has changed (e.g. ccs/type2/…)
     vehicle.gen.type                    -- Vehicle generator connection type has changed
+- Add units Bar, Permille
+- Add user configuration for groups of metrics
+  Adds the 'ToUser' unit that converts to the user specified unit.
+  Add -u to 'metrics list' to view metrics as  user units.
 
 2022-09-01 MWJ  3.3.003  OTA release
 - Toyota RAV4 EV: Initial support added. Only the Tesla bus is decoded and just listening so far.

--- a/vehicle/OVMS.V3/components/ovms_location/src/ovms_location.cpp
+++ b/vehicle/OVMS.V3/components/ovms_location/src/ovms_location.cpp
@@ -370,6 +370,15 @@ void location_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
   writer->puts("NOTE: ACC actions are not implemented yet!");       // XXX IMPLEMENT AND REMOVE THIS!
   }
 
+int location_set_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv, bool complete)
+  {
+  if (argc == 5)
+    {
+    return OvmsMetricUnit_Validate(writer, argc, argv[4], complete, GrpDistanceShort);
+    }
+  return -1;
+  }
+
 void location_set(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
   const char *name = argv[0];
@@ -525,6 +534,16 @@ int location_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const char
   {
   if (argc == 1)
     return MyLocations.m_locations.Validate(writer, argc, argv[0], complete);
+  return -1;
+  }
+
+int location_radius_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv, bool complete)
+  {
+  switch (argc)
+    {
+    case 1: return MyLocations.m_locations.Validate(writer, argc, argv[0], complete);
+    case 3: return OvmsMetricUnit_Validate(writer, argc, argv[2], complete, GrpDistanceShort);
+    }
   return -1;
   }
 
@@ -685,8 +704,8 @@ OvmsLocations::OvmsLocations()
   // Register our commands
   OvmsCommand* cmd_location = MyCommandApp.RegisterCommand("location","LOCATION framework", location_status, "", 0, 0, false);
   cmd_location->RegisterCommand("list","Show all locations",location_list);
-  cmd_location->RegisterCommand("set","Set the position of a location",location_set, "<name> [<latitude> <longitude> [<radius> [<unit>]] ]", 1, 5);
-  cmd_location->RegisterCommand("radius","Set the radius of a location (defaults to user 'height' units)",location_radius, "<name> <radius> [<unit>]", 2, 3, true, location_validate);
+  cmd_location->RegisterCommand("set","Set the position of a location",location_set, "<name> [<latitude> <longitude> [<radius> [<unit>]] ]", 1, 5, true, location_set_validate);
+  cmd_location->RegisterCommand("radius","Set the radius of a location (defaults to user 'height' units)",location_radius, "<name> <radius> [<unit>]", 2, 3, true, location_radius_validate);
   cmd_location->RegisterCommand("rm","Remove a defined location",location_rm, "<name>", 1, 1, true, location_validate);
   cmd_location->RegisterCommand("status","Show location status",location_status);
   OvmsCommand* cmd_action = cmd_location->RegisterCommand("action","Set an action for a location");

--- a/vehicle/OVMS.V3/components/ovms_tpms/src/ovms_tpms.cpp
+++ b/vehicle/OVMS.V3/components/ovms_tpms/src/ovms_tpms.cpp
@@ -140,8 +140,10 @@ void tpms_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
 
   if (StandardMetrics.ms_v_tpms_pressure->IsDefined())
     {
-    writer->printf("Pressure...[kPa]: ");
-    for (auto val : StandardMetrics.ms_v_tpms_pressure->AsVector())
+
+    metric_unit_t user_pressure = OvmsMetricGetUserUnit(GrpPressure, kPa);
+    writer->printf("Pressure...[%s]: ", OvmsMetricUnitLabel(user_pressure) );
+    for (auto val : StandardMetrics.ms_v_tpms_pressure->AsVector(user_pressure))
       writer->printf(" %8.1f", val);
     writer->puts(StandardMetrics.ms_v_tpms_pressure->IsStale() ? "  [stale]" : "");
     data_shown = true;
@@ -149,8 +151,9 @@ void tpms_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
 
   if (StandardMetrics.ms_v_tpms_temp->IsDefined())
     {
-    writer->printf("Temperature.[°C]: ");
-    for (auto val : StandardMetrics.ms_v_tpms_temp->AsVector())
+    metric_unit_t user_temp = OvmsMetricGetUserUnit(GrpTemp, Celcius);
+    writer->printf("Temperature.[%s]: ", OvmsMetricUnitLabel(user_temp));
+    for (auto val : StandardMetrics.ms_v_tpms_temp->AsVector(user_temp))
       writer->printf(" %8.1f", val);
     writer->puts(StandardMetrics.ms_v_tpms_temp->IsStale() ? "  [stale]" : "");
     data_shown = true;

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -591,8 +591,12 @@ void OvmsWebServer::HandleCfgPassword(PageEntry_t& p, PageContext_t& c)
 void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
 {
   std::string error, info;
-  std::string vehicleid, vehicletype, vehiclename, timezone, timezone_region, units_distance, pin;
+  std::string vehicleid, vehicletype, vehiclename, timezone, timezone_region, pin;
   std::string bat12v_factor, bat12v_ref, bat12v_alert;
+
+  std::map<metric_group_t,std::string> units_values;
+  metric_group_list_t unit_groups;
+  OvmsMetricGroupConfigList(unit_groups);
 
   if (c.method == "POST") {
     // process form submission:
@@ -601,7 +605,14 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
     vehiclename = c.getvar("vehiclename");
     timezone = c.getvar("timezone");
     timezone_region = c.getvar("timezone_region");
-    units_distance = c.getvar("units_distance");
+    for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
+      {
+      std::string name = OvmsMetricGroupName(*grpiter);
+      std::string cfg = "units_";
+      cfg += name;
+      units_values[*grpiter] = c.getvar(cfg);
+      }
+
     bat12v_factor = c.getvar("bat12v_factor");
     bat12v_ref = c.getvar("bat12v_ref");
     bat12v_alert = c.getvar("bat12v_alert");
@@ -627,7 +638,13 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
       MyConfig.SetParamValue("vehicle", "name", vehiclename);
       MyConfig.SetParamValue("vehicle", "timezone", timezone);
       MyConfig.SetParamValue("vehicle", "timezone_region", timezone_region);
-      MyConfig.SetParamValue("vehicle", "units.distance", units_distance);
+      for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
+        {
+        std::string name = OvmsMetricGroupName(*grpiter);
+        std::string value = units_values[*grpiter];
+        OvmsMetricSetUserConfig(*grpiter, value);
+        }
+
       MyConfig.SetParamValue("system.adc", "factor12v", bat12v_factor);
       MyConfig.SetParamValue("vehicle", "12v.ref", bat12v_ref);
       MyConfig.SetParamValue("vehicle", "12v.alert", bat12v_alert);
@@ -656,7 +673,10 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
     vehiclename = MyConfig.GetParamValue("vehicle", "name");
     timezone = MyConfig.GetParamValue("vehicle", "timezone");
     timezone_region = MyConfig.GetParamValue("vehicle", "timezone_region");
-    units_distance = MyConfig.GetParamValue("vehicle", "units.distance");
+    for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
+      {
+      units_values[*grpiter] = OvmsMetricGetUserConfig(*grpiter);
+      }
     bat12v_factor = MyConfig.GetParamValue("system.adc", "factor12v");
     bat12v_ref = MyConfig.GetParamValue("vehicle", "12v.ref");
     bat12v_alert = MyConfig.GetParamValue("vehicle", "12v.alert");
@@ -703,10 +723,43 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
     , _attr(timezone_region)
     , _attr(timezone));
 
-  c.input_radiobtn_start("Distance units", "units_distance");
-  c.input_radiobtn_option("units_distance", "Kilometers", "K", units_distance == "K");
-  c.input_radiobtn_option("units_distance", "Miles", "M", units_distance == "M");
-  c.input_radiobtn_end();
+  for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
+    {
+    std::string name = OvmsMetricGroupName(*grpiter);
+    metric_unit_set_t group_units;
+    if (OvmsMetricGroupUnits(*grpiter,group_units))
+      {
+      bool use_select = group_units.size() > 3;
+      std::string cfg = "units_";
+      cfg += name;
+      std::string value = units_values[*grpiter];
+      if (use_select)
+        c.input_select_start(OvmsMetricGroupLabel(*grpiter), cfg.c_str() );
+      else
+        c.input_radiobtn_start(OvmsMetricGroupLabel(*grpiter), cfg.c_str() );
+
+      bool checked = value.empty();
+      if (use_select)
+        c.input_select_option( "Default", "", checked);
+      else
+        c.input_radiobtn_option(cfg.c_str(), "Default", "", checked);
+      for (auto unititer = group_units.begin(); unititer != group_units.end(); ++unititer)
+        {
+        const char* unit_name = OvmsMetricUnitName(*unititer);
+        const char* unit_label = OvmsMetricUnitLabel(*unititer);
+        checked = value == unit_name;
+        if (use_select)
+          c.input_select_option( unit_label, unit_name, checked);
+        else
+          c.input_radiobtn_option(cfg.c_str(), unit_label, unit_name, checked);
+        }
+      if (use_select)
+        c.input_select_end();
+      else
+        c.input_radiobtn_end();
+      }
+    }
+
   c.input_password("PIN", "pin", "", "empty = no change",
     "<p>Vehicle PIN code used for unlocking etc.</p>", "autocomplete=\"section-vehiclepin new-password\"");
 

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -605,13 +605,12 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
     vehiclename = c.getvar("vehiclename");
     timezone = c.getvar("timezone");
     timezone_region = c.getvar("timezone_region");
-    for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
-      {
+    for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter) {
       std::string name = OvmsMetricGroupName(*grpiter);
       std::string cfg = "units_";
       cfg += name;
       units_values[*grpiter] = c.getvar(cfg);
-      }
+    }
 
     bat12v_factor = c.getvar("bat12v_factor");
     bat12v_ref = c.getvar("bat12v_ref");
@@ -638,12 +637,11 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
       MyConfig.SetParamValue("vehicle", "name", vehiclename);
       MyConfig.SetParamValue("vehicle", "timezone", timezone);
       MyConfig.SetParamValue("vehicle", "timezone_region", timezone_region);
-      for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
-        {
+      for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter) {
         std::string name = OvmsMetricGroupName(*grpiter);
         std::string value = units_values[*grpiter];
         OvmsMetricSetUserConfig(*grpiter, value);
-        }
+      }
 
       MyConfig.SetParamValue("system.adc", "factor12v", bat12v_factor);
       MyConfig.SetParamValue("vehicle", "12v.ref", bat12v_ref);
@@ -674,9 +672,7 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
     timezone = MyConfig.GetParamValue("vehicle", "timezone");
     timezone_region = MyConfig.GetParamValue("vehicle", "timezone_region");
     for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
-      {
       units_values[*grpiter] = OvmsMetricGetUserConfig(*grpiter);
-      }
     bat12v_factor = MyConfig.GetParamValue("system.adc", "factor12v");
     bat12v_ref = MyConfig.GetParamValue("vehicle", "12v.ref");
     bat12v_alert = MyConfig.GetParamValue("vehicle", "12v.alert");
@@ -723,12 +719,10 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
     , _attr(timezone_region)
     , _attr(timezone));
 
-  for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter)
-    {
+  for ( auto grpiter = unit_groups.begin(); grpiter != unit_groups.end(); ++grpiter) {
     std::string name = OvmsMetricGroupName(*grpiter);
     metric_unit_set_t group_units;
-    if (OvmsMetricGroupUnits(*grpiter,group_units))
-      {
+    if (OvmsMetricGroupUnits(*grpiter,group_units)) {
       bool use_select = group_units.size() > 3;
       std::string cfg = "units_";
       cfg += name;
@@ -743,8 +737,7 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
         c.input_select_option( "Default", "", checked);
       else
         c.input_radiobtn_option(cfg.c_str(), "Default", "", checked);
-      for (auto unititer = group_units.begin(); unititer != group_units.end(); ++unititer)
-        {
+      for (auto unititer = group_units.begin(); unititer != group_units.end(); ++unititer) {
         const char* unit_name = OvmsMetricUnitName(*unititer);
         const char* unit_label = OvmsMetricUnitLabel(*unititer);
         checked = value == unit_name;
@@ -752,13 +745,13 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
           c.input_select_option( unit_label, unit_name, checked);
         else
           c.input_radiobtn_option(cfg.c_str(), unit_label, unit_name, checked);
-        }
+      }
       if (use_select)
         c.input_select_end();
       else
         c.input_radiobtn_end();
-      }
     }
+  }
 
   c.input_password("PIN", "pin", "", "empty = no change",
     "<p>Vehicle PIN code used for unlocking etc.</p>", "autocomplete=\"section-vehiclepin new-password\"");
@@ -1016,8 +1009,7 @@ void OvmsWebServer::HandleCfgPushover(PageEntry_t& p, PageContext_t& c)
     }
 
     if (error == "") {
-      if (c.getvar("action") == "save")
-        {
+      if (c.getvar("action") == "save") {
         // save:
         param->m_map.clear();
         param->m_map = std::move(pmap);
@@ -1028,9 +1020,8 @@ void OvmsWebServer::HandleCfgPushover(PageEntry_t& p, PageContext_t& c)
         OutputHome(p, c);
         c.done();
         return;
-        }
-      else if (c.getvar("action") == "test")
-        {
+      } else if (c.getvar("action") == "test")
+      {
         std::string reply;
         std::string popup;
         c.head(200);
@@ -1044,10 +1035,10 @@ void OvmsWebServer::HandleCfgPushover(PageEntry_t& p, PageContext_t& c)
             atoi(c.getvar("retry").c_str()),
             atoi(c.getvar("expire").c_str()),
             true /* receive server reply as reply/pushover-type notification */ ))
-          {
+        {
           c.alert("danger", "<p class=\"lead\">Could not send test message!</p>");
-          }
         }
+      }
     }
     else {
       // output error, return to form:

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
@@ -401,26 +401,26 @@ void xiq_tpms(int verbosity, OvmsWriter *writer, OvmsCommand *cmd, int argc, con
   writer->printf("TPMS\n");
   // Front left
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
-    const std::string &fl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", kPa, 1);
-    const std::string &fl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", Celcius, 1);
+    const std::string &fl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", ToUser, 1);
+    const std::string &fl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", ToUser, 1);
     writer->printf("1 Front-Left  ID:%lu %s %s\n", car->kia_tpms_id[0], fl_pressure.c_str(), fl_temp.c_str());
   }
   // Front right
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
-    const std::string &fr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", kPa, 1);
-    const std::string &fr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", Celcius, 1);
+    const std::string &fr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", ToUser, 1);
+    const std::string &fr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", ToUser, 1);
     writer->printf("2 Front-Right ID:%lu %s %s\n", car->kia_tpms_id[1], fr_pressure.c_str(), fr_temp.c_str());
   }
   // Rear left
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
-    const std::string &rl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", kPa, 1);
-    const std::string &rl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", Celcius, 1);
+    const std::string &rl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", ToUser, 1);
+    const std::string &rl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", ToUser, 1);
     writer->printf("3 Rear-Left ID:%lu %s %s\n", car->kia_tpms_id[2], rl_pressure.c_str(), rl_temp.c_str());
   }
   // Rear right
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
-    const std::string &rr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", kPa, 1);
-    const std::string &rr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", Celcius, 1);
+    const std::string &rr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", ToUser, 1);
+    const std::string &rr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", ToUser, 1);
     writer->printf("4 Rear-Right ID:%lu %s %s\n", car->kia_tpms_id[3], rr_pressure.c_str(), rr_temp.c_str());
   }
 }

--- a/vehicle/OVMS.V3/main/ovms_config.cpp
+++ b/vehicle/OVMS.V3/main/ovms_config.cpp
@@ -565,8 +565,21 @@ void OvmsConfig::upgrade()
     DeregisterParam("vwup");
     }
 
+  // Update single units setting of miles/km to multiple units settings
+  if (GetParamValueInt("module", "cfgversion") < 2022111900)
+    {
+    bool ismiles = GetParamValue("vehicle", "units.distance") == "M";
+    if (ismiles)
+      {
+      SetParamValue("vehicle", "units.speed", "miph");
+      SetParamValue("vehicle", "units.accel", "miphps");
+      SetParamValue("vehicle", "units.accelshort", "ftpss");
+      SetParamValue("vehicle", "units.consumption", "mipkwh");
+      }
+    }
+
   // Done, set config version:
-  SetParamValueInt("module", "cfgversion", 2020053100);
+  SetParamValueInt("module", "cfgversion", 2022111900);
   }
 
 void OvmsConfig::RegisterParam(std::string name, std::string title, bool writable, bool readable)

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -164,8 +164,8 @@ static const OvmsUnitInfo unit_info[int(MetricUnitLast)+1] =
   UNIT_GAP,// 87
   UNIT_GAP,// 88
   UNIT_GAP,// 89
-  {"percent",  "%",        Native,     Native,      GrpOther}, // 90
-  UNIT_GAP,// 91
+  {"percent",  "%",        Native,     Native,      GrpRatio}, // 90
+  {"permille", "\u2030",   Native,     Native,      GrpRatio}, // 91
   UNIT_GAP,// 92
   UNIT_GAP,// 93
   UNIT_GAP,// 94
@@ -213,11 +213,11 @@ static const OvmsUnitGroupInfo group_info[int(MetricGroupLast)+1] =
   { "signal",      "Signal Strength"         }, // 11
   { "torque",      NULL                      }, // 12
   { "direction",   NULL                      }, // 13
-  GROUP_GAP,
-  GROUP_GAP,
+  { "ratio",       "Ratio"                   }, // 14
+  GROUP_GAP, // 15
   // Short dimensions from here:
-  GROUP_GAP,
-  GROUP_GAP,
+  GROUP_GAP, // 16
+  GROUP_GAP, // 17
   { "distanceshort","Height"                 }, // 2+16=18
   GROUP_GAP,
   { "accelshort",   "Acceleration (short)"   }, // 4+16=20
@@ -2167,6 +2167,12 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
     case sq:
       if (to == dbm) return (value <= 31) ? (-113 + (value*2)) : 0;
       break;
+    case Percentage:
+      if (to == Permille) return value*10;
+      break;
+    case Permille:
+      if (to == Percentage) return value/10;
+      break;
     default:
       return value;
     }
@@ -2347,6 +2353,10 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
     case sq:
       if (to == dbm) return int((value <= 31) ? (-113 + (value*2)) : 0);
       break;
+    case Percentage:
+      if (to == Permille) return value*10.0;
+    case Permille:
+      if (to == Percentage) return value*0.10;
     default:
       return value;
     }

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -198,7 +198,7 @@ static const OvmsUnitInfo unit_info[int(MetricUnitLast)+1] =
   // Energy consumption:
   {"whpkm",    "Wh/km",    Native,     WattHoursPM, GrpConsumption}, // 100
   {"whpmi",    "Wh/mi",    WattHoursPK,Native,      GrpConsumption}, // 101
-  {"kwhp100km","kWh/100km",Native,     WattHoursPM, GrpConsumption}, // 102
+  {"kwhp100km","kWh/100km",Native,     MPkWh,       GrpConsumption}, // 102
   {"kmpkwh",   "km/kWh",   Native,     MPkWh,       GrpConsumption}, // 103
   {"mipkwh",   "mi/kWh",   KPkWh,      Native,      GrpConsumption}, // 104
   UNIT_GAP,// 105

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -127,7 +127,7 @@ static const OvmsUnitInfo unit_info[int(MetricUnitLast)+1] =
   {"kpa",      "kPa",      Native,     PSI,         GrpPressure}, // 30
   {"pa",       "Pa",       Native,     PSI,         GrpPressure}, // 31
   {"psi",      "psi",      kPa,        Native,      GrpPressure}, // 32
-  UNIT_GAP, // 33
+  {"bar",      "bar",      Native,     PSI,         GrpPressure}, // 33
   UNIT_GAP, // 34
   UNIT_GAP, // 35
   UNIT_GAP, // 36
@@ -1977,17 +1977,37 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
       if (to == Celcius) return ((value-32)*5)/9;
       break;
     case kPa:
-      if (to == Pa) return value*1000;
-      else if (to == PSI) return int((float)value * 0.14503773773020923);
-      break;
+      switch (to)
+        {
+        case Pa:  return value*1000;
+        case Bar: return value/100;
+        case PSI: return int((float)value * 0.14503773773020923);
+        default: break;
+        }
     case Pa:
-      if (to == kPa) return value/1000;
-      else if (to == PSI) return int((float)value * 0.00014503773773020923);
-      break;
+      switch (to)
+        {
+        case kPa: return value/1000;
+        case Bar: return value/100000;
+        case PSI: return int((float)value * 0.00014503773773020923);
+        default: break;
+        }
     case PSI:
-      if (to == kPa) return int((float)value * 6.894757293168361);
-      else if (to == Pa) return int((float)value * 0.006894757293168361);
-      break;
+      switch (to)
+        {
+        case kPa: return int((float)value * 6.894757293168361);
+        case Pa:  return int((float)value * 6894.757293168361);
+        case Bar: return int((float)value * 0.06894757293168361);
+        default: break;
+        }
+    case Bar:
+      switch (to)
+        {
+        case Pa:  return value*100000;
+        case kPa: return value*100;
+        case PSI: return int((float)value * 14.503773773020923);
+        default: break;
+        }
     case Seconds:
       if (to == Minutes) return value/60;
       else if (to == Hours) return value/3600;
@@ -2150,17 +2170,37 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
       if (to == Celcius) return ((value-32)*5)/9;
       break;
     case kPa:
-      if (to == Pa) return value*1000;
-      else if (to == PSI) return value * 0.14503773773020923;
-      break;
+      switch (to)
+        {
+        case Pa:  return value*1000;
+        case Bar: return value/100;
+        case PSI: return value * 0.14503773773020923;
+        default: break;
+        }
     case Pa:
-      if (to == kPa) return value/1000;
-      else if (to == PSI) return value * 0.00014503773773020923;
-      break;
+      switch (to)
+        {
+        case kPa: return value/1000;
+        case Bar: return value/100000;
+        case PSI: return value * 0.00014503773773020923;
+        default: break;
+        }
     case PSI:
-      if (to == kPa) return value * 6.894757293168361;
-      else if (to == Pa) return value * 0.006894757293168361;
-      break;
+      switch (to)
+        {
+        case kPa: return value * 6.894757293168361;
+        case Pa:  return value * 6894.757293168361;
+        case Bar: return value * 0.06894757293168361;
+        default: break;
+        }
+    case Bar:
+      switch (to)
+        {
+        case Pa:  return value*100000;
+        case kPa: return value*100;
+        case PSI: return value * 14.503773773020923;
+        default: break;
+        }
     case Seconds:
       if (to == Minutes) return value/60;
       else if (to == Hours) return value/3600;

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -268,7 +268,7 @@ T pkm_to_pmi(T pkm)
  * simplify - Means those separated for (eventual) user config
  *            are folded to one metric.
  */
-static metric_group_t GetMetricGroup(metric_unit_t unit)
+metric_group_t GetMetricGroup(metric_unit_t unit)
   {
   uint8_t unit_i = static_cast<uint8_t>(unit);
   if (unit_i <= uint8_t(MetricUnitLast))
@@ -362,14 +362,14 @@ void OvmsMetricSetUserConfig(metric_group_t group, std::string value)
   MyConfig.SetParamValue("vehicle", cfg, value);
   }
 
-metric_unit_t OvmsMetricGetUserUnit(metric_group_t group)
+metric_unit_t OvmsMetricGetUserUnit(metric_group_t group, metric_unit_t defaultUnit )
   {
   std::string unit_name = OvmsMetricGetUserConfig(group);
   if (unit_name.empty())
-    return Native;
+    return defaultUnit;
   metric_unit_t unit = OvmsMetricUnitFromName(unit_name.c_str());
   if (unit == UnitNotFound)
-    return Native;
+    return defaultUnit;
   return unit;
   }
 
@@ -1928,6 +1928,7 @@ void OvmsMetricString::Clear()
   OvmsMetric::Clear();
   }
 
+/// Get the label for the metric.
 const char* OvmsMetricUnitLabel(metric_unit_t units)
   {
   uint8_t unit_i = static_cast<uint8_t>(units);
@@ -1939,6 +1940,7 @@ const char* OvmsMetricUnitLabel(metric_unit_t units)
   return res;
   }
 
+/// Get the Name for the unit.
 const char* OvmsMetricUnitName(metric_unit_t units)
   {
   uint8_t unit_i = static_cast<uint8_t>(units);

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -177,8 +177,8 @@ extern bool OvmsMetricGroupUnits(metric_group_t group, metric_unit_set_t& units)
 // Get/Set Metric default config
 extern std::string OvmsMetricGetUserConfig(metric_group_t group);
 extern void OvmsMetricSetUserConfig(metric_group_t group, std::string value);
-extern metric_unit_t OvmsMetricGetUserUnit(metric_group_t group);
-
+extern metric_unit_t OvmsMetricGetUserUnit(metric_group_t group, metric_unit_t defaultUnit = Native);
+extern metric_group_t GetMetricGroup(metric_unit_t unit);
 
 typedef uint32_t persistent_value_t;
 
@@ -894,6 +894,12 @@ class OvmsMetricVector : public OvmsMetric
       return val;
       }
 
+    ElemType GetElemValue(size_t n, metric_unit_t units)
+      {
+      ElemType val = GetElemValue(n);
+      return UnitConvert(m_units, units, val);
+      }
+
     void SetElemValue(size_t n, const ElemType nvalue, metric_unit_t units = Other)
       {
       ElemType value;
@@ -1055,6 +1061,9 @@ class OvmsMetrics
     OvmsMetric* m_first;
     bool m_trace;
   };
+
+extern const char* OvmsMetricUnitLabel(metric_unit_t units);
+extern const char* OvmsMetricUnitName(metric_unit_t units);
 
 extern OvmsMetrics MyMetrics;
 

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -73,6 +73,7 @@ typedef enum : uint8_t
   kPa           = 30,
   Pa            = 31,
   PSI           = 32,
+  Bar           = 33,
 
   Volts         = 40,
   Amps          = 41,

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -177,8 +177,10 @@ extern bool OvmsMetricGroupUnits(metric_group_t group, metric_unit_set_t& units)
 // Get/Set Metric default config
 extern std::string OvmsMetricGetUserConfig(metric_group_t group);
 extern void OvmsMetricSetUserConfig(metric_group_t group, std::string value);
+extern void OvmsMetricSetUserConfig(metric_group_t group, metric_unit_t unit);
 extern metric_unit_t OvmsMetricGetUserUnit(metric_group_t group, metric_unit_t defaultUnit = Native);
 extern metric_group_t GetMetricGroup(metric_unit_t unit);
+metric_unit_t OvmsMetricCheckUnit(metric_unit_t fromUnit, metric_unit_t toUnit);
 
 typedef uint32_t persistent_value_t;
 

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -61,6 +61,7 @@ typedef enum : uint8_t
   Native        = Other,
   ToMetric      = 1,
   ToImperial    = 2,
+  ToUser        = 3,
 
   Kilometers    = 10,
   Miles         = 11,
@@ -129,12 +130,53 @@ typedef enum : uint8_t
   Defined
 } metric_defined_t;
 
+// Mask for folding "Short groups" to their equivalent "Long Group"
+const uint8_t GrpFoldMask = 0x0f;
+const uint8_t GrpUnfold = 0x10;
+typedef enum : uint8_t
+  {
+  GrpNone = 0,
+  GrpOther = 1,
+  GrpDistance = 2,
+  GrpSpeed = 3,
+  GrpAccel = 4,
+  GrpPower = 5,
+  GrpEnergy = 6,
+  GrpConsumption = 7,
+  GrpTemp = 8,
+  GrpPressure = 9,
+  GrpTime = 10,
+  GrpSignal = 11,
+  GrpTorque = 12,
+  GrpDirection = 13,
+  // These are where a dimension group is split and allows
+  // easily folding the 'short distances' back onto their equivalents.
+  GrpDistanceShort = GrpDistance + GrpUnfold,
+  GrpAccelShort = GrpAccel + GrpUnfold
+  } metric_group_t;
+const metric_group_t MetricGroupLast = GrpAccelShort;
+
 extern const char* OvmsMetricUnitLabel(metric_unit_t units);
 extern const char* OvmsMetricUnitName(metric_unit_t units);
 extern metric_unit_t OvmsMetricUnitFromName(const char* unit);
 
 extern int UnitConvert(metric_unit_t from, metric_unit_t to, int value);
 extern float UnitConvert(metric_unit_t from, metric_unit_t to, float value);
+
+typedef std::vector<metric_group_t> metric_group_list_t;
+typedef std::set<metric_unit_t> metric_unit_set_t;
+
+// Groups in order of display.
+extern bool OvmsMetricGroupConfigList(metric_group_list_t& groups);
+extern const char* OvmsMetricGroupLabel(metric_group_t group);
+extern const char* OvmsMetricGroupName(metric_group_t group);
+extern bool OvmsMetricGroupUnits(metric_group_t group, metric_unit_set_t& units);
+
+// Get/Set Metric default config
+extern std::string OvmsMetricGetUserConfig(metric_group_t group);
+extern void OvmsMetricSetUserConfig(metric_group_t group, std::string value);
+extern metric_unit_t OvmsMetricGetUserUnit(metric_group_t group);
+
 
 typedef uint32_t persistent_value_t;
 

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -884,6 +884,10 @@ class OvmsMetricVector : public OvmsMetric
       OvmsMutexLock lock(&m_mutex);
       return m_value;
       }
+    inline std::vector<ElemType, Allocator> AsVector(metric_unit_t units)
+      {
+      return AsVector(std::vector<ElemType, Allocator>(), units);
+      }
 
     ElemType GetElemValue(size_t n)
       {

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -105,6 +105,7 @@ typedef enum : uint8_t
   sq            = 81,   // Signal Quality (in SQ units)
 
   Percentage    = 90,
+  Permille      = 91,
 
   // Energy consumption:
   WattHoursPK   = 100,  // Wh/km
@@ -149,6 +150,7 @@ typedef enum : uint8_t
   GrpSignal = 11,
   GrpTorque = 12,
   GrpDirection = 13,
+  GrpRatio = 14,
   // These are where a dimension group is split and allows
   // easily folding the 'short distances' back onto their equivalents.
   GrpDistanceShort = GrpDistance + GrpUnfold,

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -160,7 +160,9 @@ const metric_group_t MetricGroupLast = GrpAccelShort;
 
 extern const char* OvmsMetricUnitLabel(metric_unit_t units);
 extern const char* OvmsMetricUnitName(metric_unit_t units);
-extern metric_unit_t OvmsMetricUnitFromName(const char* unit);
+extern metric_unit_t OvmsMetricUnitFromName(const char* unit, bool allowUniquePrefix = false);
+int OvmsMetricUnit_Validate(OvmsWriter* writer, int argc, const char* token, bool complete, metric_group_t group = GrpNone);
+const char *OvmsMetricUnit_FindUniquePrefix(const char* token);
 
 extern int UnitConvert(metric_unit_t from, metric_unit_t to, int value);
 extern float UnitConvert(metric_unit_t from, metric_unit_t to, float value);
@@ -1013,6 +1015,10 @@ class OvmsMetrics
     bool SetFloat(const char* metric, float value);
     std::string GetUnitStr(const char* metric, const char *unit = NULL);
     OvmsMetric* Find(const char* metric);
+
+    OvmsMetric* FindUniquePrefix(const char* token) const;
+    bool GetCompletion(OvmsWriter* writer, const char* token) const;
+    int Validate(OvmsWriter* writer, int argc, const char* token, bool complete) const;
 
     OvmsMetricInt *InitInt(const char* metric, uint16_t autostale=0, int value=0, metric_unit_t units = Other, bool persist = false);
     OvmsMetricBool *InitBool(const char* metric, uint16_t autostale=0, bool value=0, metric_unit_t units = Other, bool persist = false);

--- a/vehicle/OVMS.V3/main/ovms_utils.cpp
+++ b/vehicle/OVMS.V3/main/ovms_utils.cpp
@@ -42,8 +42,6 @@
 #include "ovms_version.h"
 #include "esp_idf_version.h"
 
-static const char *TAG = "utils";
-
 /**
  * chargestate_code: convert legacy chargestate key to code
  */
@@ -734,18 +732,17 @@ fail:
 /**
  * Format string with std::string result (sprintf for std::string).
  */
-std::string string_format(const std::string fmt_str, ...)
+std::string string_format(const char * fmt_str, ...)
   {
   va_list ap;
   char *fp = NULL;
   va_start(ap, fmt_str);
-  int ret = vasprintf(&fp, fmt_str.c_str(), ap);
+  int ret = vasprintf(&fp, fmt_str, ap);
   va_end(ap);
   std::unique_ptr<char[]> formatted(fp);
   if (ret >= 0)
     return std::string(formatted.get());
-  ESP_LOGE(TAG, "Invalid format string: \"%s\"", fmt_str.c_str());
-  return fmt_str;
+  return "";
   }
 
 /**

--- a/vehicle/OVMS.V3/main/ovms_utils.cpp
+++ b/vehicle/OVMS.V3/main/ovms_utils.cpp
@@ -32,6 +32,8 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <stdarg.h>
+#include <memory>
 #include <fstream>
 #include "ovms_utils.h"
 #include "ovms_config.h"
@@ -724,5 +726,25 @@ fail:
         free(out_path);
     }
     return NULL;
+}
+/**
+ * Format string with std::string result (sprintf for std::string).
+ */
+std::string string_format(const std::string fmt_str, ...) {
+    int final_n, n = ((int)fmt_str.size()) * 2; /* Reserve two times as much as the length of the fmt_str */
+    std::unique_ptr<char[]> formatted;
+    va_list ap;
+    while(1) {
+        formatted.reset(new char[n]); /* Wrap the plain char array into the unique_ptr */
+        strcpy(&formatted[0], fmt_str.c_str());
+        va_start(ap, fmt_str);
+        final_n = vsnprintf(&formatted[0], n, fmt_str.c_str(), ap);
+        va_end(ap);
+        if (final_n < 0 || final_n >= n)
+            n += abs(final_n - n + 1);
+        else
+            break;
+    }
+    return std::string(formatted.get());
 }
 #endif

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -615,9 +615,9 @@ static inline std::string trim_copy(std::string s) {
  */
 void format_file_size(char* buffer, std::size_t buf_size, std::size_t fsize);
 
-/** Format a std::string.
+/** Format to a std::string.
  */
-std::string string_format(const std::string fmt_str, ...) ;
+std::string string_format(const char *fmt_str, ...) __attribute__ ((format (printf, 1, 2)));
 
 /**
  * Return `std::string` in lower-case.

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -570,4 +570,8 @@ inline bool get_buff_string(const std::string &data, uint32_t index, uint32_t le
   return get_buff_string(reinterpret_cast<const uint8_t *>(data.data()), data.size(), index, len, strret);
   }
 
+/** Format a std::string.
+ */
+std::string string_format(const std::string fmt_str, ...) ;
+
 #endif // __OVMS_UTILS_H__


### PR DESCRIPTION
This series of patches adds the ability for a user to configure the units they want for the various types of metrics.  It extends the simple km/M configuration to Speed, acceleration, Pressure etc.

The general 'metric list' as an option to show user-configured units.
The TPMS shell modules will now use the user-configured units.  I think this should be the way it works, however I'm also prepared to have the default as it was and to have a (-u) option to show TPMS in user-configured units (or vica versa).