### PR TITLE
Change metrics listener registration parameter types

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -763,7 +763,7 @@ static duk_ret_t DukOvmsMetricGetValues(duk_context *ctx)
 
 #endif //#ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE
 
-MetricCallbackEntry::MetricCallbackEntry(const char* caller, MetricCallback callback)
+MetricCallbackEntry::MetricCallbackEntry(std::string caller, MetricCallback callback)
   {
   m_caller = caller;
   m_callback = callback;
@@ -1002,7 +1002,7 @@ OvmsMetricString* OvmsMetrics::InitString(const char* metric, uint16_t autostale
   return m;
   }
 
-void OvmsMetrics::RegisterListener(const char* caller, const char* name, MetricCallback callback)
+void OvmsMetrics::RegisterListener(std::string caller, const char* name, MetricCallback callback)
   {
   auto k = m_listeners.find(name);
   if (k == m_listeners.end())
@@ -1012,7 +1012,7 @@ void OvmsMetrics::RegisterListener(const char* caller, const char* name, MetricC
     }
   if (k == m_listeners.end())
     {
-    ESP_LOGE(TAG, "Problem registering metric %s for caller %s",name,caller);
+    ESP_LOGE(TAG, "Problem registering metric %s for caller %s",name,caller.c_str());
     return;
     }
 
@@ -1020,7 +1020,7 @@ void OvmsMetrics::RegisterListener(const char* caller, const char* name, MetricC
   ml->push_back(new MetricCallbackEntry(caller,callback));
   }
 
-void OvmsMetrics::DeregisterListener(const char* caller)
+void OvmsMetrics::DeregisterListener(std::string caller)
   {
   MetricCallbackMap::iterator itm=m_listeners.begin();
   while (itm!=m_listeners.end())

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -1002,7 +1002,7 @@ OvmsMetricString* OvmsMetrics::InitString(const char* metric, uint16_t autostale
   return m;
   }
 
-void OvmsMetrics::RegisterListener(std::string caller, const char* name, MetricCallback callback)
+void OvmsMetrics::RegisterListener(std::string caller, std::string name, MetricCallback callback)
   {
   auto k = m_listeners.find(name);
   if (k == m_listeners.end())
@@ -1012,7 +1012,7 @@ void OvmsMetrics::RegisterListener(std::string caller, const char* name, MetricC
     }
   if (k == m_listeners.end())
     {
-    ESP_LOGE(TAG, "Problem registering metric %s for caller %s",name,caller.c_str());
+    ESP_LOGE(TAG, "Problem registering metric %s for caller %s",name.c_str(),caller.c_str());
     return;
     }
 

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -928,11 +928,11 @@ typedef std::function<void(OvmsMetric*)> MetricCallback;
 class MetricCallbackEntry
   {
   public:
-    MetricCallbackEntry(const char* caller, MetricCallback callback);
+    MetricCallbackEntry(std::string caller, MetricCallback callback);
     virtual ~MetricCallbackEntry();
 
   public:
-    const char *m_caller;
+    std::string m_caller;
     MetricCallback m_callback;
   };
 
@@ -990,8 +990,8 @@ class OvmsMetrics
       }
 
   public:
-    void RegisterListener(const char* caller, const char* name, MetricCallback callback);
-    void DeregisterListener(const char* caller);
+    void RegisterListener(std::string caller, const char* name, MetricCallback callback);
+    void DeregisterListener(std::string caller);
     void NotifyModified(OvmsMetric* metric);
 
   protected:

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -41,7 +41,6 @@
 #include <set>
 #include <vector>
 #include <atomic>
-#include "ovms_utils.h"
 #include "ovms_mutex.h"
 #include "dbc_number.h"
 #ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE
@@ -937,7 +936,7 @@ class MetricCallbackEntry
   };
 
 typedef std::list<MetricCallbackEntry*> MetricCallbackList;
-typedef std::map<const char*, MetricCallbackList*, CmpStrOp> MetricCallbackMap;
+typedef std::map<std::string, MetricCallbackList*> MetricCallbackMap;
 
 class OvmsMetrics
   {
@@ -990,7 +989,7 @@ class OvmsMetrics
       }
 
   public:
-    void RegisterListener(std::string caller, const char* name, MetricCallback callback);
+    void RegisterListener(std::string caller, std::string name, MetricCallback callback);
     void DeregisterListener(std::string caller);
     void NotifyModified(OvmsMetric* metric);
 


### PR DESCRIPTION
Previously the metrics listeners were registered by storing the `caller` parameter
as a `const char *`.
This made mistakes possible when we would register and deregister with the same string
but not the same memory address.

This patch changes the `caller` parameter type to `std::string` which will prevent this kind
of mistakes.

For consistency with `OvmsEvents::RegisterEvent`, the second parameter to `OvmsMetrics::RegisterListener`
is also converted to `std::string`.
