### PR TITLE
add configurable metrics to CAN logs, and allows configuration of events

### DIFF
--- a/docs/source/crtd/can_logging.rst
+++ b/docs/source/crtd/can_logging.rst
@@ -1,3 +1,5 @@
+.. highlight:: none
+
 ====================
 CAN Bus Data Logging
 ====================
@@ -105,6 +107,74 @@ The log file can also be viewed in a browser with ``http://<ovms-ipaddress>/sd/c
 
 The logfiles can then be imported into a tool like SavvyCan for analysis.
 
+
+--------------------------
+Logging Events and Metrics
+--------------------------
+
+Alongside the CAN data, it's also possible to log any **event** or **metric** of your choosing.
+
+For an event, the name of the event will be logged. For a metric, a JSON representation of the metric will be logged
+(an object with 3 properties: ``name``, ``value``, and ``unit``).
+
+To select the events and/or metrics to log, a comma-separated list of filter (``"<filter1>,<filter2>,..."``) needs to be
+configured:
+
+* events filters are configured by the configuration item ``can log.events_filters``
+* metrics filters are configured by the configuration item ``can log.metrics_filters``
+
+Each filter of the list can be one of:
+
+a) an event or metric name that will be matched in its entirety (e.g. matching the metric ``v.e.charging12v``, or the event ``system.wifi.ap.sta.connected``)
+b) a pattern ending with a wildcard ``*`` - to match the beginning of an event or metric name (e.g. ``v.p.*`` will match all metrics starting with ``v.p.``, like ``v.p.odometer`` for instance)
+c) a pattern starting with a wildcard ``*`` - to match the end of an event or metric name (e.g. ``*.stop`` will match all metrics ending with ``.stop``, like ``network.mgr.stop``, ``system.wifi.ap.stop``, ... for instance)
+
+.. note:: Only those 3 kind of filters are supported. The wildcard character ``*`` can only occur once, either at the beginning, or
+  at the end of the filter.
+
+^^^^^^^^^^^^^^^
+Default filters
+^^^^^^^^^^^^^^^
+
+The default filter configuration for **event** logging is to log all events starting with ``x`` or with ``vehicle``, which is equivalent to the following configuration command::
+
+  OVMS# config set can log.events_filters "x*,vehicle*"
+
+
+The default filter configuration for **metric** logging is not to log any metric.
+
+^^^^^^^^
+Examples
+^^^^^^^^
+
+If you would like to log all GNSS **events** for example, in addition to the default events, you could use the following configuration::
+
+  OVMS# config set can log.events_filters "x*,vehicle*,gps.*"
+
+
+If you would like to log all GNSS **metrics** for example, you could use the following configuration::
+
+  OVMS# config set can log.metrics_filters "v.p.gps*, v.p.latitude, v.p.longitude, v.p.altitude, v.p.direction, v.p.satcount"
+
+^^^^^^^^^^^^^^^^^^^^^
+Supported log formats
+^^^^^^^^^^^^^^^^^^^^^
+For the moment, only the CRTD log format is able to store the events or metrics in the logs.
+Those are logged with the tags:
+
+* ``CEV`` for an event
+* ``CMT`` for a metric
+
+Example of a CRTD log output containing a mix of CAN messages, metrics and events::
+
+  1668992145.032123 1CMT Metric { "name": "v.p.satcount", "value": 6, "unit": "" }
+  1668992145.034551 1CMT Metric { "name": "v.p.gpshdop", "value": 1.1, "unit": "" }
+  1668992145.036341 1R11 358 18 08 20 00 00 00 00 20
+  1668992145.037777 1CEV Event vehicle.alert.tpms
+  1668992145.041696 1CMT Metric { "name": "v.p.altitude", "value": 121.3, "unit": "m" }
+  1668992147.042809 1R11 27E c0 c0 c0 c0 00 00 00 00
+  1668992150.035591 1CMT Metric { "name": "v.p.gpssq", "value": 20, "unit": "%" }
+  1668992150.042837 1CEV Event gps.sq.bad
 
 -----------------
 Network Streaming

--- a/docs/source/crtd/index.rst
+++ b/docs/source/crtd/index.rst
@@ -33,6 +33,7 @@ History
 * 1.0: Initial version supporting CXX, R11, R29, T11, and T29 messages only
 * 2.0: Add optional bus ID prefix to record types
 * 3.0: Add support for comment commands, and clarify documentation inconsistencies
+* 3.1: Add support for CMT - metric data in comments
 
 -------------
 Specification
@@ -131,6 +132,7 @@ The following comment record types are defined:
 * CER: An indication of a (usually recoverable) error
 * CST: Periodical statistics
 * CEV: An indication of an event
+* CMT: An indication of a metric data
 * CVR: Version of CRTD protocol adhered to (with version number as text comment)
 
 and the following command record types are defined:
@@ -147,6 +149,7 @@ Here are some examples::
   19292.299819 CEV vehicle.alert this is a textual vehicle alert
   198923.283738 CST intr=0 rxpkt=0 txpkt=0 errflags=0 rxerr=0 txerr=0 rxovr=0 txovr=0 txdelay=0 wdgreset=0
   2783.384726 CER intr=0 rxpkt=0 txpkt=0 errflags=0 rxerr=0 txerr=0 rxovr=0 txovr=0 txdelay=0 wdgreset=0
+  1668730982.038759 CMT Metric { "name": "v.p.gpstime", "value": 1668730982, "unit": "Sec" }
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Command Record CBC - Configure a CAN bus

--- a/docs/source/userguide/scripting.rst
+++ b/docs/source/userguide/scripting.rst
@@ -864,6 +864,7 @@ OvmsMetrics
     returned as a string with any unit specifiers.
 
 .. code-block:: javascript
+
   // Get the speed as a string with units ( eg: 37.4km/h )
   var speed  = OvmsMetrics.Value("v.b.range.speed", "native", false)
 

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -29,6 +29,10 @@ Open Vehicle Monitor System v3 - Change log
   New events:
     vehicle.charge.type                 -- Vehicle charge connection type has changed (e.g. ccs/type2/…)
     vehicle.gen.type                    -- Vehicle generator connection type has changed
+- CAN logging: add possibility to log events (name) and metrics (JSON object with name, value, unit)
+  New configs:
+    [can] log.events_filters            -- comma-separated list of filters (with possible wildcard) matching an event name
+    [can] log.metrics_filters           -- comma-separated list of filters (with possible wildcard) matching a metric name
 
 2022-09-01 MWJ  3.3.003  OTA release
 - Toyota RAV4 EV: Initial support added. Only the Tesla bus is decoded and just listening so far.

--- a/vehicle/OVMS.V3/components/can/src/can.cpp
+++ b/vehicle/OVMS.V3/components/can/src/can.cpp
@@ -570,7 +570,8 @@ static const char* const CAN_log_type_names[] = {
   "Status",
   "Comment",
   "Info",
-  "Event"
+  "Event",
+  "Metric"
   };
 
 const char* GetCanLogTypeName(CAN_log_type_t type)

--- a/vehicle/OVMS.V3/components/can/src/can.h
+++ b/vehicle/OVMS.V3/components/can/src/can.h
@@ -251,6 +251,7 @@ typedef enum
   CAN_LogInfo_Comment,        // general comment
   CAN_LogInfo_Config,         // logger setup info (type, file, filters, vehicle)
   CAN_LogInfo_Event,          // system event (i.e. vehicle started)
+  CAN_LogInfo_Metric,         // system or plugin metric (i.e. v.p.altitude)
   } CAN_log_type_t;
 
 // Log message:

--- a/vehicle/OVMS.V3/components/can/src/canformat_crtd.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_crtd.cpp
@@ -123,10 +123,11 @@ std::string canformat_crtd::get(CAN_log_message_t* message)
     case CAN_LogInfo_Comment:
     case CAN_LogInfo_Config:
     case CAN_LogInfo_Event:
+    case CAN_LogInfo_Metric:
       snprintf(buf,sizeof(buf),"%ld.%06ld %c%s %s %s",
         message->timestamp.tv_sec, message->timestamp.tv_usec,
         busnumber,
-        (message->type == CAN_LogInfo_Event) ? "CEV" : "CXX",
+        (message->type == CAN_LogInfo_Event) ? "CEV" : (message->type == CAN_LogInfo_Metric) ? "CMT" : "CXX",
         GetCanLogTypeName(message->type),
         message->text);
       break;
@@ -151,7 +152,7 @@ std::string canformat_crtd::getheader(struct timeval *time)
     time = &t;
     }
 
-  snprintf(buf,sizeof(buf),"%ld.%06ld CXX OVMS CRTD\n%ld.%06ld CVR 3.0\n",
+  snprintf(buf,sizeof(buf),"%ld.%06ld CXX OVMS CRTD\n%ld.%06ld CVR 3.1\n",
     time->tv_sec, time->tv_usec,
     time->tv_sec, time->tv_usec);
 

--- a/vehicle/OVMS.V3/components/can/src/canlog.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog.cpp
@@ -42,6 +42,8 @@ static const char *TAG = "canlog";
 #include "ovms_peripherals.h"
 #include "metrics_standard.h"
 
+static const char *CAN_PARAM = "can";
+
 ////////////////////////////////////////////////////////////////////////
 // Command Processing
 ////////////////////////////////////////////////////////////////////////
@@ -352,8 +354,11 @@ canlog::canlog(const char* type, std::string format, canformat::canformat_serve_
   using std::placeholders::_1;
   using std::placeholders::_2;
   MyEvents.RegisterEvent(IDTAG, "*", std::bind(&canlog::EventListener, this, _1, _2));
+  MyEvents.RegisterEvent(IDTAG,"config.mounted", std::bind(&canlog::UpdatedConfig, this, _1, _2));
+  MyEvents.RegisterEvent(IDTAG,"config.changed", std::bind(&canlog::UpdatedConfig, this, _1, _2));
 
-  int queuesize = MyConfig.GetParamValueInt("can", "log.queuesize",100);
+  int queuesize = MyConfig.GetParamValueInt(CAN_PARAM, "log.queuesize",100);
+  LoadConfig();
   m_queue = xQueueCreate(queuesize, sizeof(CAN_log_message_t));
   xTaskCreatePinnedToCore(RxTask, "OVMS CanLog", 4096, (void*)this, 10, &m_task, CORE(1));
   }
@@ -429,10 +434,154 @@ void canlog::RxTask(void *context)
     }
   }
 
+/**
+ * Parse a comma-separated list of filters, and assign them to a member of the class.
+ * We have 3 kind of comparisons, and an unlimited list of filters.
+ *
+ * A filter can be:
+ * - A "startsWith" comparison - when ending with '*',
+ * - An "endsWith" comparison - when starting with '*',
+ * - Invalid (and skipped) if empty, or with a '*' in any other position than beginning or end,
+ * - A "string equal" comparison for all other cases
+ */
+static void LoadFilters(conn_filters_arr_t &member, const std::string &value)
+  {
+  // Empty all previously defined filters, for all operators
+  for (int i=0; i<COUNT_OF_OPERATORS; i++)
+    {
+    member[i].clear();
+    }
+
+  if (!value.empty())
+    {
+    std::stringstream stream (value);
+    std::string item;
+    unsigned char comparison_operator;
+
+    // Comma-separated list
+    while (getline (stream, item, ','))
+      {
+      trim(item); // Removing leading and trailing spaces
+
+      if (item.empty())
+        {
+        ESP_LOGW(TAG, "LoadFilters: skipping empty value in the filter list");
+        continue;
+        }
+
+      // Check if there is a wildcard ('*') in any other place than first or last position
+      size_t wildcard_position = item.find('*', 1);
+      if ((wildcard_position != std::string::npos) && (wildcard_position != item.size()-1))
+        {
+        ESP_LOGW(TAG, "LoadFilters: skipping incorrect value (%s) in the filter list (wildcard in wrong position)", item.c_str());
+        continue;
+        }
+
+      // Depending on the presence and position of the wildcard, push the filter
+      // in the proper vector (without the wildcard)
+      if (item.front() == '*')
+        {
+        comparison_operator = OPERATOR_ENDSWITH;
+        item.erase(0, 1);
+        }
+      else if (item.back() == '*')
+        {
+        comparison_operator = OPERATOR_STARTSWITH;
+        item.pop_back();
+        }
+      else
+        {
+        comparison_operator = OPERATOR_EQUALS;
+        }
+      member[comparison_operator].push_back(item);
+      }
+    }
+
+  // for (int i=0; i<COUNT_OF_OPERATORS; i++)
+  //   {
+  //   ESP_LOGI(TAG, "LoadFilters: filters for operator %d:", i);
+  //   for (std::vector<std::string>::iterator it=member[i].begin(); it!=member[i].end(); ++it)
+  //     {
+  //     ESP_LOGI(TAG, "LoadFilters: filter value '%s'", it->c_str());
+  //     }
+  //   if (member[i].begin() == member[i].end())
+  //     {
+  //     ESP_LOGI(TAG, "LoadFilters: (empty filter list)");
+  //     }
+  //   }
+  }
+
+/**
+ * Load, or reload, the configuration of events and metrics filters.
+ *
+ * The configuration item is a string containing a comma-separated list of filters.
+ */
+void canlog::LoadConfig()
+  {
+  std::size_t str_hash;
+
+  std::string list_of_events_filters = MyConfig.GetParamValue(CAN_PARAM, "log.events_filters", "x*,vehicle*");
+  str_hash = std::hash<std::string>{}(list_of_events_filters);
+  if (str_hash != m_events_filters_hash)
+    {
+    m_events_filters_hash = str_hash;
+    LoadFilters(m_events_filters, list_of_events_filters);
+    MyCan.LogInfo(NULL, CAN_LogInfo_Config, ("Events filters: " + list_of_events_filters).c_str());
+    }
+  }
+
+/**
+ * Load, or reload, the configuration if a config event occurred.
+ */
+void canlog::UpdatedConfig(std::string event, void* data)
+  {
+  if (event == "config.changed")
+    {
+    // Only reload if our parameter has changed
+    OvmsConfigParam*p = (OvmsConfigParam*)data;
+    if (p->GetName() != CAN_PARAM)
+      {
+      return;
+      }
+    }
+  LoadConfig();
+  }
+
+/**
+ * Check if a value matches in a list of filters.
+ *
+ * Match can be a:
+ * - startsWith match,
+ * - endsWith match,
+ * - equality match.
+ */
+static bool CheckFilter(conn_filters_arr_t &member, const std::string &value)
+  {
+  for (int i=0; i<COUNT_OF_OPERATORS; i++)
+    {
+    for (std::vector<std::string>::iterator it=member[i].begin(); it!=member[i].end(); ++it)
+      {
+      if ((i == OPERATOR_STARTSWITH) && (startsWith(value, *it)))
+        {
+        return true;
+        }
+      else if ((i == OPERATOR_ENDSWITH) && (endsWith(value, *it)))
+        {
+        return true;
+        }
+      else if ((i == OPERATOR_EQUALS) && (value == *it))
+        {
+        return true;
+        }
+      }
+    }
+  return false;
+  }
+
 void canlog::EventListener(std::string event, void* data)
   {
   // Log vehicle custom (x…) & framework events:
-  if (startsWith(event, 'x') || startsWith(event, "vehicle"))
+  if (CheckFilter(m_events_filters, event))
     LogInfo(NULL, CAN_LogInfo_Event, event.c_str());
   }
 

--- a/vehicle/OVMS.V3/components/can/src/canlog.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog.cpp
@@ -388,6 +388,7 @@ canlog::~canlog()
         case CAN_LogInfo_Comment:
         case CAN_LogInfo_Config:
         case CAN_LogInfo_Event:
+        case CAN_LogInfo_Metric:
           free(msg.text);
           break;
         default:
@@ -423,6 +424,7 @@ void canlog::RxTask(void *context)
         case CAN_LogInfo_Comment:
         case CAN_LogInfo_Config:
         case CAN_LogInfo_Event:
+        case CAN_LogInfo_Metric:
           me->OutputMsg(msg);
           free(msg.text);
           break;

--- a/vehicle/OVMS.V3/components/can/src/canlog.h
+++ b/vehicle/OVMS.V3/components/can/src/canlog.h
@@ -110,6 +110,7 @@ class canlog : public InternalRamAllocated
   public:
     static void RxTask(void* context);
     void EventListener(std::string event, void* data);
+    void MetricListener(OvmsMetric* metric);
 
   public:
     const char* GetType();
@@ -165,6 +166,8 @@ class canlog : public InternalRamAllocated
   protected:
     conn_filters_arr_t  m_events_filters;
     size_t              m_events_filters_hash = 0;
+    conn_filters_arr_t  m_metrics_filters;
+    size_t              m_metrics_filters_hash = 0;
   };
 
 #endif // __CANLOG_H__

--- a/vehicle/OVMS.V3/components/can/src/canlog.h
+++ b/vehicle/OVMS.V3/components/can/src/canlog.h
@@ -95,6 +95,11 @@ class canlogconnection: public InternalRamAllocated
     uint32_t       m_filtercount;
   };
 
+#define OPERATOR_STARTSWITH 0
+#define OPERATOR_ENDSWITH 1
+#define OPERATOR_EQUALS 2
+#define COUNT_OF_OPERATORS 3
+typedef std::array<std::vector<std::string>, COUNT_OF_OPERATORS> conn_filters_arr_t;
 
 class canlog : public InternalRamAllocated
   {
@@ -152,6 +157,14 @@ class canlog : public InternalRamAllocated
     uint32_t            m_msgcount;
     uint32_t            m_dropcount;
     uint32_t            m_filtercount;
+
+  protected:
+    virtual void UpdatedConfig(std::string event, void* data);
+    virtual void LoadConfig();
+
+  protected:
+    conn_filters_arr_t  m_events_filters;
+    size_t              m_events_filters_hash = 0;
   };
 
 #endif // __CANLOG_H__

--- a/vehicle/OVMS.V3/components/can/src/canlog_monitor.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog_monitor.cpp
@@ -109,6 +109,7 @@ void canlog_monitor_conn::OutputMsg(CAN_log_message_t& msg, std::string &result)
       case CAN_LogInfo_Comment:
       case CAN_LogInfo_Config:
       case CAN_LogInfo_Event:
+      case CAN_LogInfo_Metric:
         ESP_LOGD(TAG,"%s",result.c_str());
         break;
       default:

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -33,6 +33,7 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include <algorithm>
 #include <cstring>
 #include <string>
 #include <iomanip>
@@ -569,5 +570,43 @@ inline bool get_buff_string(const std::string &data, uint32_t index, uint32_t le
   {
   return get_buff_string(reinterpret_cast<const uint8_t *>(data.data()), data.size(), index, len, strret);
   }
+
+// trim from start (in place)
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s) {
+    rtrim(s);
+    ltrim(s);
+}
+
+// trim from start (copying)
+static inline std::string ltrim_copy(std::string s) {
+    ltrim(s);
+    return s;
+}
+
+// trim from end (copying)
+static inline std::string rtrim_copy(std::string s) {
+    rtrim(s);
+    return s;
+}
+
+// trim from both ends (copying)
+static inline std::string trim_copy(std::string s) {
+    trim(s);
+    return s;
+}
 
 #endif // __OVMS_UTILS_H__


### PR DESCRIPTION
This PR adds the ability to log some metrics to the CAN logs ; and allows the configuration of which events are going to be logged (event logging was already existent)

# Metrics
A new configuration item `can log.metrics_filters` allows to choose which metrics will be sent to the can logs.

The default configurations is NOT to log any metric.

The metrics are sent to the can log subsystem as events. When using the CRTD format for example, those will appear as `1CEV` lines.

The metrics are sent as a JSON object prefixed with `metric: `, having the following fields:
* `name` : the name of the metric
* `value`: the value of the metric in the default unit
* `unit`: the default unit of the metric

Example:
```
metric: { "name": "v.p.gpstime", "value": 1668730982, "unit": "Sec" }
```

Example in a CRTD file:
```
1668730982.038759 1CEV Event metric: { "name": "v.p.gpstime", "value": 1668730982, "unit": "Sec" }
```

A possible configuration to log all GNSS-related metrics:
```
config set can log.metrics_filters "v.p.gps*, v.p.latitude, v.p.longitude, v.p.altitude, v.p.direction, v.p.satcount"
```

# Events
A new configuration item `can log.events_filters` allows to choose which events will be sent to the can logs.

To maintain compatibility, the default value is `x*,vehicle*`, which is going to allow only the events starting with `x` or with `vehicle`.

The default value is equivalent to entering the following command:
```
config set can log.events_filters "x*,vehicle*"
```

# Format of filters
The format of filters is a comma-separated list of metrics filters, possibly containing wildcards (`*`):
* Any filter starting with `*` is an `endsWith()` comparison.
* A filter ending with `*` is a `startsWith()` comparison.
* A filter without any wildcard is a `==` comparison.

(A wildcard in any other position in the filter is invalid)

Values are trimmed, so the presence of leading / trailing spaces is not an issue.
Invalid or empty filters are skipped (and a warning is sent).