### PR TITLE
Can log track file size

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/canlog_vfs.h
+++ b/vehicle/OVMS.V3/components/can/src/canlog_vfs.h
@@ -39,9 +39,11 @@ class canlog_vfs_conn: public canlogconnection
 
   public:
     virtual void OutputMsg(CAN_log_message_t& msg, std::string &result);
+    virtual std::string GetStats();
 
   public:
     FILE*               m_file;
+    size_t              m_file_size;
   };
 
 
@@ -55,9 +57,11 @@ class canlog_vfs : public canlog
     virtual bool Open();
     virtual void Close();
     virtual std::string GetInfo();
+    virtual size_t GetFileSize();
 
   public:
     virtual void MountListener(std::string event, void* data);
+    virtual std::string GetStats();
 
   public:
     std::string         m_path;

--- a/vehicle/OVMS.V3/main/ovms_utils.cpp
+++ b/vehicle/OVMS.V3/main/ovms_utils.cpp
@@ -726,3 +726,19 @@ fail:
     return NULL;
 }
 #endif
+
+/**
+ * format_file_size: format a file size in human-readable format.
+ * (like 1.5k 234.2M 2.1G)
+ */
+void format_file_size(char* buffer, std::size_t buf_size, std::size_t fsize) {
+  if (fsize < 1024) {
+    snprintf(buffer, buf_size, "%d", (int) fsize);
+  } else if (fsize < 0x100000) {
+    snprintf(buffer, buf_size, "%.1fk", (double) fsize / 1024.0);
+  } else if (fsize < 0x40000000) {
+    snprintf(buffer, buf_size, "%.1fM", (double) fsize / 1048576);
+  } else {
+    snprintf(buffer, buf_size, "%.1fG", (double) fsize / 1073741824);
+  }
+}

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -609,4 +609,10 @@ static inline std::string trim_copy(std::string s) {
     return s;
 }
 
+/**
+ * format_file_size: format a file size in human-readable format.
+ * (like 1.5k 234.2M 2.1G)
+ */
+void format_file_size(char* buffer, std::size_t buf_size, std::size_t fsize);
+
 #endif // __OVMS_UTILS_H__

--- a/vehicle/OVMS.V3/main/ovms_vfs.cpp
+++ b/vehicle/OVMS.V3/main/ovms_vfs.cpp
@@ -101,15 +101,7 @@ class Direntry {
         if (is_protected) {
           strcpy(bufsize, "[P]     ");
         } else {
-          if (size < 1024) {
-            snprintf(bufsize, sizeof(bufsize), "%d ", (int) size);
-          } else if (size < 0x100000) {
-            snprintf(bufsize, sizeof(bufsize), "%.1fk", (double) size / 1024.0);
-          } else if (size < 0x40000000) {
-            snprintf(bufsize, sizeof(bufsize), "%.1fM", (double) size / 1048576);
-          } else {
-            snprintf(bufsize, sizeof(bufsize), "%.1fG", (double) size / 1073741824);
-          }
+          format_file_size(bufsize, sizeof(bufsize), size);
         }
       }
       strftime(mod, sizeof(mod), "%d-%b-%Y %H:%M", localtime(&mtime));


### PR DESCRIPTION
This PR tracks (and displays) the current file size of opened CAN log files.

The file size is tracked in the `canlog_vfs_conn` class, and is displayed in `GetStats()` for both the `canlog_vfs_conn` class and the `canlog_vfs` class.

File size is then available as a result of command:
```
OVMS# can log status
#1: open Type:vfs Format:crtd(discard) Vehicle:DEMO Path:/sd/logs/autolog/autolog.crtd Size:6.9k Messages:82 Dropped:0 Filtered:0 Rate:0.0%
  /sd/logs/autolog/autolog.crtd: running Size:6.9k Messages:82 Discarded:0 Dropped:0 Filtered:0 Rate:0.0%
```

Having the file size available is a pre-requisite for #748 if we want to split files by size.