### PR TITLE
OvmsHttpClient : case-insensitive comparison of `Content-Length` header

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_http/src/ovms_http.cpp
+++ b/vehicle/OVMS.V3/components/ovms_http/src/ovms_http.cpp
@@ -136,7 +136,7 @@ bool OvmsHttpClient::Request(std::string url, const char* method)
         {
         // ESP_LOGI(TAG, "Got response %s",m_buf->ReadLine().c_str());
         std::string header = m_buf->ReadLine();
-        if (header.compare(0,15,"Content-Length:") == 0)
+        if (strncasecmp(header.c_str(), "Content-Length:", 15) == 0)
           {
           m_bodysize = atoi(header.substr(15).c_str());
           }

--- a/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.cpp
+++ b/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.cpp
@@ -198,7 +198,7 @@ size_t OvmsNetHttpAsyncClient::IncomingData(void *data, size_t length)
         {
         // Process the header
         ESP_LOGD(TAG, "OvmsNetHttpAsyncClient Headers got %s", header.c_str());
-        if (header.compare(0,15,"Content-Length:") == 0)
+        if (strncasecmp(header.c_str(), "Content-Length:", 15) == 0)
           {
           m_bodysize = atoi(header.substr(15).c_str());
           ESP_LOGD(TAG, "OvmsNetHttpAsyncClient content-length is %d", m_bodysize);

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_http.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_http.cpp
@@ -180,9 +180,9 @@ DuktapeHTTPRequest::DuktapeHTTPRequest(duk_context *ctx, int obj_idx)
           m_headers.append(": ");
           m_headers.append(val);
           m_headers.append("\r\n");
-          if (key == "User-Agent")
+          if (strcasecmp(key.c_str(), "User-Agent") == 0)
             have_useragent = true;
-          else if (key == "Content-Type")
+          else if (strcasecmp(key.c_str(), "Content-Type") == 0)
             have_contenttype = true;
           }
         duk_pop(ctx); // enum
@@ -325,7 +325,7 @@ void DuktapeHTTPRequest::MongooseCallback(struct mg_connection *nc, int ev, void
         key.assign(hm->header_names[i].p, hm->header_names[i].len);
         val.assign(hm->header_values[i].p, hm->header_values[i].len);
         m_response_headers.push_back(std::make_pair(key, val));
-        if (key == "Location") location = val;
+        if (strcasecmp(key.c_str(), "Location") == 0) location = val;
         }
 
       // follow redirect?

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -615,4 +615,18 @@ static inline std::string trim_copy(std::string s) {
  */
 void format_file_size(char* buffer, std::size_t buf_size, std::size_t fsize);
 
+/**
+ * Return `std::string` in lower-case.
+ *
+ * Cf https://en.cppreference.com/w/cpp/string/byte/tolower
+ *
+ * Note: This may introduce unnecessary overhead as `std::tolower()` is locale aware.
+ * Sometimes it may be better to use plain C `strncasecmp()`.
+ */
+static inline std::string str_tolower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c){ return std::tolower(c); }
+                  );
+    return s;
+}
 #endif // __OVMS_UTILS_H__


### PR DESCRIPTION
I had some issues fetching OTA firmware from some servers (S3-compatible buckets), because of the headers that were all lower-case.
In that case, the OvmsHttpClient returns a size of 0, and the OTA fails with:
```
Error: Expected download file size (0) is invalid
```

As HTTP Header fields names are case-insensitive, having a case-insensitive comparison means that we can be compatible with more servers.

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>