### PR TITLE
condition `strverscmp` inclusion to the version of ESP-IDF

### DIFF
--- a/vehicle/OVMS.V3/components/strverscmp/component.mk
+++ b/vehicle/OVMS.V3/components/strverscmp/component.mk
@@ -7,6 +7,8 @@
 # please read the ESP-IDF documents if you need to do this.
 #
 
+ifeq ($(shell expr $(IDF_VERSION_MAJOR) \< 4), 1)
 COMPONENT_ADD_INCLUDEDIRS:=src
 COMPONENT_SRCDIRS:=src
 COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive
+endif


### PR DESCRIPTION
We have a local implementation of `strverscmp` ; however ESP-IDF seems to include it in newlib since version 4.x
(I'm not 100% sure but at least in 4.4 it is present)

A small test allows to include or not the component.

Tested on both our local fork of ESP-IDF and release 4.4

See #360

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>