### PR TITLE
change assignment of sdcard members to appease GCC 8.4.0

### DIFF
--- a/vehicle/OVMS.V3/components/sdcard/src/sdcard.cpp
+++ b/vehicle/OVMS.V3/components/sdcard/src/sdcard.cpp
@@ -97,13 +97,13 @@ static void IRAM_ATTR sdcard_isr_handler(void* arg)
 sdcard::sdcard(const char* name, bool mode1bit, bool autoformat, int cdpin)
   : pcp(name)
   {
-  m_host = SDMMC_HOST_DEFAULT();
+  m_host = sdmmc_host_t SDMMC_HOST_DEFAULT();
   if (mode1bit)
     {
     m_host.flags = SDMMC_HOST_FLAG_1BIT;
     }
 
-  m_slot = SDMMC_SLOT_CONFIG_DEFAULT();
+  m_slot = sdmmc_slot_config_t SDMMC_SLOT_CONFIG_DEFAULT();
 // Disable driver-level CD pin, as we do this ourselves
 //  if (cdpin)
 //    {


### PR DESCRIPTION
GCC 8.4.0 does not accept an assignment with the macros [`SDMMC_HOST_DEFAULT()`](https://github.com/espressif/esp-idf/blob/8153bfe4125e6a608abccf1561fd10285016c90a/components/driver/include/driver/sdmmc_host.h#L30) and [`SDMMC_SLOT_CONFIG_DEFAULT()`](https://github.com/espressif/esp-idf/blob/8153bfe4125e6a608abccf1561fd10285016c90a/components/driver/include/driver/sdmmc_host.h#L92), because the macros are defined as a curly braces list ; it fails with `error: no match for 'operator=' (operand types are 'sdmmc_host_t' and '<brace-enclosed initializer list>')`

This patch fixes the syntax so that it works with GCC 8.4.0, by prepending the type before the list. GCC 5.2.0 is OK with the fix.

See #360

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>