### PR TITLE
remove some of the warnings regarding unitialized variables

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
@@ -193,14 +193,14 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
   uint8_t* fr_data;               // Frame data address
   uint8_t  fr_maxlen;             // Frame data max length
   uint8_t  tp_frametype;          // ISO-TP frame type (0…3)
-  uint8_t  tp_frameindex;         // TP cyclic frame index (0…15)
-  uint16_t tp_len;                // TP remaining payload length including this frame (0…4095)
-  uint8_t* tp_data;               // TP frame data section address
-  uint8_t  tp_datalen;            // TP frame data section length (0…7)
+  uint8_t  tp_frameindex = 0;     // TP cyclic frame index (0…15)
+  uint16_t tp_len = 0;            // TP remaining payload length including this frame (0…4095)
+  uint8_t* tp_data = 0;           // TP frame data section address
+  uint8_t  tp_datalen = 0;        // TP frame data section length (0…7)
 
-  uint8_t  tp_fc_command;         // Flow control command (0 = continue, 1 = wait, 2 = abort)
-  uint8_t  tp_fc_framecnt;        // Flow control max frame count (0 = unlimited)
-  uint8_t  tp_fc_septime;         // Flow control frame separation time
+  uint8_t  tp_fc_command = 0;     // Flow control command (0 = continue, 1 = wait, 2 = abort)
+  uint8_t  tp_fc_framecnt = 0;    // Flow control max frame count (0 = unlimited)
+  uint8_t  tp_fc_septime = 0;     // Flow control frame separation time
 
   if (m_poll_protocol == ISOTP_EXTADR)
     {

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
@@ -169,7 +169,7 @@ void OvmsVehicleKiaSoulEv::IncomingOBC(canbus* bus, uint16_t type, uint16_t pid,
  */
 void OvmsVehicleKiaSoulEv::IncomingVMCU(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain)
 	{
-	INT base;
+	uint16_t base;
 	uint8_t bVal;
 
 	switch (pid)

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
@@ -1001,15 +1001,15 @@ void OvmsVehicleRenaultZoe::IncomingLBC(uint16_t type, uint16_t pid, const char*
     case 0x04: {
       if (IsZoe()) {
         for(int i=2; i<36; i+=3){
-          BmsSetCellTemperature( (i-2)/3, (INT)CAN_BYTE(i)-40 );
+          BmsSetCellTemperature( (i-2)/3, CAN_BYTE(i)-40 );
           //ESP_LOGD(TAG, "temp %d - %d", (i-2)/3, (INT)CAN_BYTE(i)-40);
         }
       }
       if (IsKangoo()) {
         int x=0;
         for(int i=2; i<12; i+=3){
-          BmsSetCellTemperature( x, (INT)CAN_BYTE(i) );
-          ESP_LOGD(TAG, "temp %d - %d", x, (INT)CAN_BYTE(i));
+          BmsSetCellTemperature( x, CAN_BYTE(i) );
+          ESP_LOGD(TAG, "temp %d - %d", x, CAN_BYTE(i));
           x++;
         }
       }


### PR DESCRIPTION
GCC 8.4.0 throws some warnings and we try to fix them.

Not sure if this is always the right way, please review and comment.

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>