### PR TITLE
condition `strverscmp` inclusion to the version of ESP-IDF

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
+++ b/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
@@ -38,7 +38,9 @@ static const char *TAG = "ota";
 #include <string.h>
 #include <esp_system.h>
 #include <esp_ota_ops.h>
+#if ESP_IDF_VERSION_MAJOR < 4
 #include "strverscmp.h"
+#endif
 #include "ovms_ota.h"
 #include "ovms_command.h"
 #include "ovms_boot.h"

--- a/vehicle/OVMS.V3/components/ovms_plugins/src/ovms_plugins.cpp
+++ b/vehicle/OVMS.V3/components/ovms_plugins/src/ovms_plugins.cpp
@@ -36,7 +36,10 @@ static const char *TAG = "pluginstore";
 #include <sys/stat.h>
 #include <string>
 #include <string.h>
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION_MAJOR < 4
 #include "strverscmp.h"
+#endif
 #include "ovms_plugins.h"
 #include "ovms_command.h"
 #include "ovms_config.h"

--- a/vehicle/OVMS.V3/main/test_framework.cpp
+++ b/vehicle/OVMS.V3/main/test_framework.cpp
@@ -45,7 +45,9 @@ static const char *TAG = "test";
 #include "metrics_standard.h"
 #include "ovms_config.h"
 #include "can.h"
+#if ESP_IDF_VERSION_MAJOR < 4
 #include "strverscmp.h"
+#endif
 
 void test_deepsleep(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {


### PR DESCRIPTION
We have a local implementation of `strverscmp` ; however ESP-IDF seems to include it in newlib since version 4.x
(I'm not 100% sure but at least in 4.4 it is present)

A small test allows to include or not the component include files (which are otherwise defined in `<string.h>`)

Tested on both our local fork of ESP-IDF and release 4.4

See #360

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>