### PR TITLE
Fix vehicle status command display

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -358,6 +358,8 @@ OvmsVehicle::OvmsVehicle()
   m_brakelight_ignftbrk = false;
 
   m_tpms_lastcheck = 0;
+  m_inv_energyused = 0;
+  m_inv_energyrecd = 0;
 
   m_rxqueue = xQueueCreate(CONFIG_OVMS_VEHICLE_CAN_RX_QUEUE_SIZE,sizeof(CAN_frame_t));
   xTaskCreatePinnedToCore(OvmsVehicleRxTask, "OVMS Vehicle",

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -1113,12 +1113,12 @@ OvmsVehicle::vehicle_command_t OvmsVehicle::CommandStat(int verbosity, OvmsWrite
  */
 OvmsVehicle::vehicle_command_t OvmsVehicle::CommandStatTrip(int verbosity, OvmsWriter* writer)
   {
-  metric_unit_t rangeUnit = OvmsMetricGetUserUnit(GrpDistance);
-  metric_unit_t speedUnit = OvmsMetricGetUserUnit(GrpSpeed);
-  metric_unit_t accelUnit = OvmsMetricGetUserUnit(GrpAccel);
-  metric_unit_t consumUnit = OvmsMetricGetUserUnit(GrpConsumption);
+  metric_unit_t rangeUnit = OvmsMetricGetUserUnit(GrpDistance, Kilometers);
+  metric_unit_t speedUnit = OvmsMetricGetUserUnit(GrpSpeed, Kph);
+  metric_unit_t accelUnit = OvmsMetricGetUserUnit(GrpAccel, KphPS);
+  metric_unit_t consumUnit = OvmsMetricGetUserUnit(GrpConsumption, WattHoursPK);
   metric_unit_t energyUnit = kWh;
-  metric_unit_t altitudeUnit = OvmsMetricGetUserUnit(GrpDistanceShort);
+  metric_unit_t altitudeUnit = OvmsMetricGetUserUnit(GrpDistanceShort, Meters);
   const char* rangeUnitLabel = OvmsMetricUnitLabel(rangeUnit);
   const char* speedUnitLabel = OvmsMetricUnitLabel(speedUnit);
   const char* accelUnitLabel = OvmsMetricUnitLabel(accelUnit);


### PR DESCRIPTION
Fix display of metrics in the status trip command  if they are set to default. 
Initialise the energy used and received so it doesn't display bad values when first initialised.