### PR TITLE
Bms cells

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -54,49 +54,21 @@ void OvmsVehicleMgEv::ProcessBatteryStats(int index, uint8_t* data, uint16_t rem
     // The stats are per block rather than per cell, but we'll record them in cells
     // Rather than cache all of the data as it's split over two frames, just cache the one
     // byte that we need
+    int i = index * 2;
     if (remain)
     {
         uint16_t vmin = (data[0] << 8 | data[1]);
         m_bmsCache = data[2];
-
-        StandardMetrics.ms_v_bat_cell_vmin->SetElemValue(index, (vmin / 2000.0f) + 1.0f);
-        
-        {
-            auto pvmin = StandardMetrics.ms_v_bat_cell_vmin->AsVector();
-            StandardMetrics.ms_v_bat_pack_vmin->SetValue(
-                *std::min_element(pvmin.begin(), pvmin.end())
-            );
-        }
-    }
-    else
-    {
+        BmsSetCellVoltage(i, (vmin / 2000.0f) + 1.0f);
+        //ESP_LOGI("BMS_CELL_VOLTAGE", "Setting Min Cell Voltage at %i to %f", index, (vmin / 2000.0f) + 1.0f);
+    } else {
         uint16_t vmax = (m_bmsCache << 8 | data[0]);
         uint8_t tmin = data[1];
         uint8_t tmax = data[2];
-        //uint8_t tpcb = data[3]; tpcb / 2.0 - 40.0;
-
-        StandardMetrics.ms_v_bat_cell_vmax->SetElemValue(index, (vmax / 2000.0f) + 1.0f);
-        StandardMetrics.ms_v_bat_cell_tmin->SetElemValue(index, tmin * 0.5f - 40.0f);
-        StandardMetrics.ms_v_bat_cell_tmax->SetElemValue(index, tmax * 0.5f - 40.0f);
-
-        {
-            auto pvmax = StandardMetrics.ms_v_bat_cell_vmax->AsVector();
-            StandardMetrics.ms_v_bat_pack_vmax->SetValue(
-                *std::max_element(pvmax.begin(), pvmax.end())
-            );
-        }
-        {
-            auto ptmin = StandardMetrics.ms_v_bat_cell_tmin->AsVector();
-            StandardMetrics.ms_v_bat_pack_tmin->SetValue(
-                *std::min_element(ptmin.begin(), ptmin.end())
-            );
-        }
-        {
-            auto ptmax = StandardMetrics.ms_v_bat_cell_tmax->AsVector();
-            StandardMetrics.ms_v_bat_pack_tmax->SetValue(
-                *std::max_element(ptmax.begin(), ptmax.end())
-            );
-        }
+        BmsSetCellVoltage(i + 1, (vmax / 2000.0f) + 1.0f);
+        //ESP_LOGI("BMS_CELL_VOLTAGE", "Setting Max Cell Voltage at %i to %f", index * 2 + 1, (vmax / 2000.0f) + 1.0f);
+        BmsSetCellTemperature(i, tmin * 0.5f - 40.0f);
+        BmsSetCellTemperature(i + 1, tmax * 0.5f - 40.0f);
     }
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -51,22 +51,24 @@ enum BmsStatus : unsigned char {
 
 void OvmsVehicleMgEv::ProcessBatteryStats(int index, uint8_t* data, uint16_t remain)
 {
-    // The stats are per block rather than per cell, but we'll record them in cells
-    // Rather than cache all of the data as it's split over two frames, just cache the one
-    // byte that we need
+    // The stats are per block rather than per cell, but we'll record them in cells.
+    // Each cell consisting of 2 values. One for minimum value and the other for the maximum value.
+    // This should produce meaningful results for Cell Avg, Cell Min, Cell Max, Std Dev.
+    
+    // Rather than cache all of the data as it's split over two frames, just cache the one byte we need.
     int i = index * 2;
     if (remain)
     {
         uint16_t vmin = (data[0] << 8 | data[1]);
         m_bmsCache = data[2];
         BmsSetCellVoltage(i, (vmin / 2000.0f) + 1.0f);
-        //ESP_LOGI("BMS_CELL_VOLTAGE", "Setting Min Cell Voltage at %i to %f", index, (vmin / 2000.0f) + 1.0f);
+        //ESP_LOGV("BMS_CELL_VOLTAGE", "Setting Min Cell Voltage at %i to %f", index, (vmin / 2000.0f) + 1.0f);
     } else {
         uint16_t vmax = (m_bmsCache << 8 | data[0]);
         uint8_t tmin = data[1];
         uint8_t tmax = data[2];
         BmsSetCellVoltage(i + 1, (vmax / 2000.0f) + 1.0f);
-        //ESP_LOGI("BMS_CELL_VOLTAGE", "Setting Max Cell Voltage at %i to %f", index * 2 + 1, (vmax / 2000.0f) + 1.0f);
+        //ESP_LOGV("BMS_CELL_VOLTAGE", "Setting Max Cell Voltage at %i to %f", index * 2 + 1, (vmax / 2000.0f) + 1.0f);
         BmsSetCellTemperature(i, tmin * 0.5f - 40.0f);
         BmsSetCellTemperature(i + 1, tmax * 0.5f - 40.0f);
     }

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_web.cpp
@@ -66,7 +66,7 @@ void OvmsVehicleMgEv::WebInit()
     // vehicle menu:
     MyWebServer.RegisterPage("/xmg/features", "Features", WebCfgFeatures, PageMenu_Vehicle, PageAuth_Cookie);
     MyWebServer.RegisterPage("/xmg/battery",  "Battery config",   WebCfgBattery, PageMenu_Vehicle, PageAuth_Cookie);
-    //MyWebServer.RegisterPage("/bms/cellmon", "BMS cell monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
+    MyWebServer.RegisterPage("/bms/cellmon", "BMS cell monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
     MyWebServer.RegisterPage("/bms/metrics_charger", "Charging Metrics", WebDispChgMetrics, PageMenu_Vehicle, PageAuth_Cookie);
 }
 
@@ -75,9 +75,10 @@ void OvmsVehicleMgEv::WebInit()
  */
 void OvmsVehicleMgEv::WebDeInit()
 {
-  MyWebServer.DeregisterPage("/xmg/features");
-  MyWebServer.DeregisterPage("/bms/metrics_charger");
-  MyWebServer.DeregisterPage("/xmg/battery");
+    MyWebServer.DeregisterPage("/xmg/features");
+    MyWebServer.DeregisterPage("/bms/metrics_charger");
+    MyWebServer.DeregisterPage("/xmg/battery");
+    MyWebServer.DeregisterPage("/bms/cellmon");
 }
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.cpp
@@ -78,6 +78,15 @@ OvmsVehicleMgEvA::OvmsVehicleMgEvA()
 
     //Add variant specific poll data
     ConfigurePollData(obdii_polls_a, sizeof(obdii_polls_a));
+    
+    //BMS Configuration
+    BmsSetCellArrangementVoltage(18, 2);
+    BmsSetCellArrangementTemperature(18, 2);
+    BmsSetCellLimitsVoltage(3.0, 5.0);
+    BmsSetCellLimitsTemperature(-39, 200);
+    BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
+    BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
+
 }
 
 //Called by OVMS when vehicle type is changed from current

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_b.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_b.cpp
@@ -56,6 +56,15 @@ OvmsVehicleMgEvB::OvmsVehicleMgEvB()
 
     //Add variant specific poll data
     ConfigurePollData(obdii_polls_b, sizeof(obdii_polls_b));
+    
+    //BMS Configuration
+    BmsSetCellArrangementVoltage(18, 2);
+    BmsSetCellArrangementTemperature(18, 2);
+    BmsSetCellLimitsVoltage(3.0, 5.0);
+    BmsSetCellLimitsTemperature(-39, 200);
+    BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
+    BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
+
 }
 
 //Called by OVMS when vehicle type is changed from current


### PR DESCRIPTION
Changed the BMS polling to use BmsSetCellVoltage and BmsSetCellTemperature. As individual
 battery information's not available and only max/min figures for each module, I have created an entry for both min and max -  9 modules with 2 entries each. I hope this will create more useable information. 