### PR TITLE
replace some constants with their more adapted counterpart

### DIFF
--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -1002,7 +1002,7 @@ void esp32wifi::EventWifiGotIp(std::string event, void* data)
   {
   system_event_info_t *info = (system_event_info_t*)data;
   m_ip_info_sta = info->got_ip.ip_info;
-  esp_wifi_get_mac(ESP_IF_WIFI_STA, m_mac_sta);
+  esp_wifi_get_mac(WIFI_IF_STA, m_mac_sta);
   UpdateNetMetrics();
   ESP_LOGI(TAG, "STA got IP with SSID '%s' AP " MACSTR ": MAC: " MACSTR ", IP: " IPSTR ", mask: " IPSTR ", gw: " IPSTR,
     m_wifi_sta_cfg.sta.ssid, MAC2STR(m_sta_ap_info.bssid), MAC2STR(m_mac_sta),
@@ -1090,7 +1090,7 @@ void esp32wifi::EventWifiApState(std::string event, void* data)
     {
     // Start
     AdjustTaskPriority();
-    esp_wifi_get_mac(ESP_IF_WIFI_AP, m_mac_ap);
+    esp_wifi_get_mac(WIFI_IF_AP, m_mac_ap);
     tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &m_ip_info_ap);
 
     // Disable routing (gateway) and DNS offer on DHCP server for AP:
@@ -1402,13 +1402,13 @@ void esp32wifi::SetAPWifiBW()
     switch (bw)
       {
       case 20:
-        err = esp_wifi_set_bandwidth(ESP_IF_WIFI_AP, WIFI_BW_HT20);
+        err = esp_wifi_set_bandwidth(WIFI_IF_AP, WIFI_BW_HT20);
         break;
       case 40:
-        err = esp_wifi_set_bandwidth(ESP_IF_WIFI_AP, WIFI_BW_HT40);
+        err = esp_wifi_set_bandwidth(WIFI_IF_AP, WIFI_BW_HT40);
         break;
       default:
-        err = esp_wifi_set_bandwidth(ESP_IF_WIFI_AP, WIFI_BW_HT20);
+        err = esp_wifi_set_bandwidth(WIFI_IF_AP, WIFI_BW_HT20);
       }
     if (err != ESP_OK)
       {


### PR DESCRIPTION
`wifi_interface_t` is more or less equivalent to `esp_interface_t` and the values are the same, however in terms of argument type it's more consistent to use `wifi_interface_t` for `esp_wifi_set_bandwidth()` and `esp_wifi_get_mac()`.  

Cf:
* redefinition:
  * https://docs.espressif.com/projects/esp-idf/en/v3.3.6/api-reference/network/esp_wifi.html?highlight=wifi_event#id4
  * https://docs.espressif.com/projects/esp-idf/en/v4.2.3/esp32/api-reference/network/esp_wifi.html#_CPPv416wifi_interface_t 
* no more present:
  * https://docs.espressif.com/projects/esp-idf/en/v4.3.3/esp32/api-reference/network/esp_wifi.html#_CPPv416wifi_interface_t
  * https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv416wifi_interface_t

Cf #806  / #810 

Signed-off-by: Ludovic LANGE <llange@users.noreply.github.com>