### PR TITLE
Add header and fix function signature

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_can_poll.cpp
@@ -82,6 +82,7 @@ static const char *TAG = "v-smarted";
 #include <algorithm>
 #include <string>
 #include <iomanip>
+#include <numeric>
 #include "pcp.h"
 #include "ovms_events.h"
 #include "metrics_standard.h"

--- a/vehicle/OVMS.V3/main/ovms_boot.cpp
+++ b/vehicle/OVMS.V3/main/ovms_boot.cpp
@@ -37,6 +37,7 @@ static const char *TAG = "boot";
 #include "rom/uart.h"
 #include "soc/rtc_cntl_reg.h"
 #include "esp_system.h"
+#include "esp_sleep.h"
 #include "esp_panic.h"
 #include "esp_task_wdt.h"
 #include <driver/adc.h>
@@ -535,7 +536,7 @@ extern "C" void esp_task_wdt_isr_user_handler(void)
 /*
  * This function is called if FreeRTOS detects a stack overflow.
  */
-extern "C" void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+extern "C" void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
   {
   panicPutStr("\r\n[OVMS] ***ERROR*** A stack overflow in task ");
   panicPutStr((char *)pcTaskName);


### PR DESCRIPTION
The missing header is important for ESP-IDF > 3.

The function signature is incorrect, and while it's only a warning, in ESP-IDF > 3 warnings are treated as errors.

Cf #806 / #810