### PR TITLE
ESP-IDF v4+ : esp_intr.h is deprecated, replaced by esp_intr_alloc.h

### DIFF
--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.h
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.h
@@ -43,7 +43,7 @@
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
-#include "esp_intr.h"
+#include "esp_intr_alloc.h"
 #include "soc/dport_reg.h"
 #include <math.h>
 

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -36,7 +36,7 @@ static const char *TAG = "mcp2515";
 #include "mcp2515_regdef.h"
 #include "soc/gpio_struct.h"
 #include "driver/gpio.h"
-#include "esp_intr.h"
+#include "esp_intr_alloc.h"
 #include "soc/dport_reg.h"
 
 static IRAM_ATTR void MCP2515_isr(void *pvParameters)

--- a/vehicle/OVMS.V3/main/ovms_peripherals.cpp
+++ b/vehicle/OVMS.V3/main/ovms_peripherals.cpp
@@ -38,7 +38,6 @@ static const char *TAG = "peripherals";
 #include "ovms_command.h"
 #include "esp_intr_alloc.h"
 #include "driver/gpio.h"
-#include "esp_intr.h"
 #include "ovms_peripherals.h"
 
 Peripherals::Peripherals()


### PR DESCRIPTION
This change is compatible with 3.3.x.