### PR TITLE
remove warning by replacing rom/queue.h with sys/queue.h

### DIFF
--- a/vehicle/OVMS.V3/components/console/commands.c
+++ b/vehicle/OVMS.V3/components/console/commands.c
@@ -21,7 +21,7 @@
 #include "linenoise/linenoise.h"
 #include "argtable3/argtable3.h"
 #include "ovms_malloc.h"
-#include "rom/queue.h"
+#include "sys/queue.h"
 
 #define ANSI_COLOR_DEFAULT      39      /** Default foreground color */
 


### PR DESCRIPTION
Both are very similar (but not equal) in 3.3:
* https://github.com/espressif/esp-idf/blob/release/v3.3/components/esp32/include/rom/queue.h
* https://github.com/espressif/esp-idf/blob/release/v3.3/components/newlib/include/sys/queue.h

Starting with 4.4, rom/queue.h is officially deprecated in favor of sys/queue.h:
https://github.com/espressif/esp-idf/blob/release/v4.4/components/esp32/include/rom/queue.h