### PR TITLE
ESP-IDF v5+: static assertion failed: comparison object must be invocable as const

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_command.cpp
+++ b/vehicle/OVMS.V3/main/ovms_command.cpp
@@ -53,7 +53,7 @@ static const char *TAG = "command";
 
 OvmsCommandApp MyCommandApp __attribute__ ((init_priority (1010)));
 
-bool CompareCharPtr::operator()(const char* a, const char* b)
+bool CompareCharPtr::operator()(const char* a, const char* b) const
   {
   return strcmp(a, b) < 0;
   }

--- a/vehicle/OVMS.V3/main/ovms_command.h
+++ b/vehicle/OVMS.V3/main/ovms_command.h
@@ -223,7 +223,7 @@ class CNameMap : public std::map<const char*, T, CmpStrOp>
 
 struct CompareCharPtr
   {
-  bool operator()(const char* a, const char* b);
+  bool operator()(const char* a, const char* b) const;
   };
 
 class OvmsCommandMap : public std::map<const char*, OvmsCommand*, CompareCharPtr>

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -76,7 +76,7 @@
 // C string sorting for std::map et al:
 struct CmpStrOp
   {
-  bool operator()(char const *a, char const *b)
+  bool operator()(char const *a, char const *b) const
     {
     return std::strcmp(a, b) < 0;
     }


### PR DESCRIPTION
This kind of warning gives an error in ESP-IDF v5+