### PR TITLE
ESP-IDF v5+: static assertion failed: std::vector must have the same value_type as its allocator

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -618,7 +618,8 @@ class OvmsMetricSet : public OvmsMetric
 template
   <
   typename ElemType,
-  class Allocator = std::allocator<ElemType>
+  class Allocator = std::allocator<ElemType>,
+  class AllocatorStar = std::allocator<ElemType*>
   >
 class OvmsMetricVector : public OvmsMetric
   {
@@ -1008,7 +1009,7 @@ class OvmsMetricVector : public OvmsMetric
     OvmsMutex m_mutex;
     std::vector<ElemType, Allocator> m_value;
     std::size_t* m_valuep_size;
-    std::vector<ElemType*, Allocator> m_valuep_elem;
+    std::vector<ElemType*, AllocatorStar> m_valuep_elem;
   };
 
 

--- a/vehicle/OVMS.V3/main/ovms_notify.h
+++ b/vehicle/OVMS.V3/main/ovms_notify.h
@@ -159,9 +159,9 @@ typedef struct
   } OvmsNotifyErrorCodeEntry_t;
 
 typedef std::map<size_t, OvmsNotifyCallbackEntry*, std::less<size_t>,
-  ExtRamAllocator<std::pair<size_t, OvmsNotifyCallbackEntry*>>> OvmsNotifyCallbackMap_t;
+  ExtRamAllocator<std::pair<const size_t, OvmsNotifyCallbackEntry*>>> OvmsNotifyCallbackMap_t;
 typedef std::map<const char*, OvmsNotifyType*, CmpStrOp,
-  ExtRamAllocator<std::pair<const char*, OvmsNotifyCallbackEntry*>>> OvmsNotifyTypeMap_t;
+  ExtRamAllocator<std::pair<const char* const, OvmsNotifyType*>>> OvmsNotifyTypeMap_t;
 typedef std::map<uint32_t, OvmsNotifyErrorCodeEntry_t*> OvmsNotifyErrorCodeMap_t;
 
 class OvmsNotify : public ExternalRamAllocated


### PR DESCRIPTION
This kind of warning gives an error in ESP-IDF v5+