### PR TITLE
changes to (long deprecated) ADC constants

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_boot.cpp
+++ b/vehicle/OVMS.V3/main/ovms_boot.cpp
@@ -255,8 +255,8 @@ Boot::Boot()
     #ifdef CONFIG_OVMS_COMP_ADC
       // Note: RTC_MODULE nags about a lock release before aquire, this can be ignored
       //  (reason: RTC_MODULE needs FreeRTOS for locking, which hasn't been started yet)
-      adc1_config_width(ADC_WIDTH_12Bit);
-      adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_11db);
+      adc1_config_width(ADC_WIDTH_BIT_12);
+      adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_11);
       uint32_t adc_level = 0;
       for (int i = 0; i < 5; i++)
         adc_level += adc1_get_raw(ADC1_CHANNEL_0);

--- a/vehicle/OVMS.V3/main/ovms_peripherals.cpp
+++ b/vehicle/OVMS.V3/main/ovms_peripherals.cpp
@@ -134,7 +134,8 @@ Peripherals::Peripherals()
 
 #ifdef CONFIG_OVMS_COMP_ADC
   ESP_LOGI(TAG, "  ESP32 ADC");
-  m_esp32adc = new esp32adc("adc", ADC1_CHANNEL_0, ADC_WIDTH_12Bit, ADC_ATTEN_11db);
+  m_esp32adc = new esp32adc("adc", ADC1_CHANNEL_0, ADC_WIDTH_BIT_12, ADC_ATTEN_DB_11);
+
 #endif // #ifdef CONFIG_OVMS_COMP_ADC
 
 #ifdef CONFIG_OVMS_COMP_MCP2515


### PR DESCRIPTION
Some bit size constants are already a back-compatible define and are removed in later ESP-IDF versions:
https://github.com/espressif/esp-idf/blob/v3.3.6/components/driver/include/driver/adc.h#L45-L53