### PR TITLE
ESP-IDF v5+: change type of TaskHandle_t

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -1358,7 +1358,7 @@ void modem::StartTask()
   if (!m_task)
     {
     ESP_LOGV(TAG, "Starting modem task");
-    xTaskCreatePinnedToCore(MODEM_task, "OVMS Cellular", CONFIG_OVMS_HW_CELLULAR_MODEM_STACK_SIZE, (void*)this, 20, (void**)&m_task, CORE(0));
+    xTaskCreatePinnedToCore(MODEM_task, "OVMS Cellular", CONFIG_OVMS_HW_CELLULAR_MODEM_STACK_SIZE, (void*)this, 20, (TaskHandle_t*)&m_task, CORE(0));
     }
   }
 


### PR DESCRIPTION
The signature of function `xTaskCreatePinnedToCore` was not referencing the type `TaskHandle_t`, so it would cause an error when this type changes in future ESP-IDF versions.