### PR TITLE
ESP-IDF v5+: dependency on ovms_webserver.h

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -645,7 +645,9 @@ OvmsHyundaiIoniqEv::~OvmsHyundaiIoniqEv()
 {
   XARM("OvmsHyundaiIoniqEv::~OvmsHyundaiIoniqEv");
   ESP_LOGI(TAG, "Shutdown Hyundai Ioniq 5 EV vehicle module");
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   MyWebServer.DeregisterPage("/bms/cellmon");
+#endif
   MyEvents.DeregisterEvent(TAG);
   MyMetrics.DeregisterListener(TAG);
   delete iq_range_calc;

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/ioniqvfl_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/ioniqvfl_web.cpp
@@ -27,6 +27,8 @@
 ; THE SOFTWARE.
 */
 
+#include <sdkconfig.h>
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #define _GLIBCXX_USE_C99 // to enable std::stoi etc.
 #include <stdio.h>
 #include <string>
@@ -132,3 +134,5 @@ void OvmsVehicleHyundaiVFL::WebCfgFeatures(PageEntry_t &p, PageContext_t &c)
   c.panel_end();
   c.done();
 }
+
+#endif //CONFIG_OVMS_COMP_WEBSERVER

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.cpp
@@ -32,7 +32,9 @@ static const char *TAG = "v-hyundaivfl";
 
 #include <stdio.h>
 #include "vehicle_hyundai_ioniqvfl.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 
 // RX buffer access macros: b=byte#
 #define RXB_BYTE(b)           m_rxbuf[b]
@@ -106,9 +108,11 @@ OvmsVehicleHyundaiVFL::OvmsVehicleHyundaiVFL()
   BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
   BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
 
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   // Init web UI:
   MyWebServer.RegisterPage("/xhi/features", "Features", WebCfgFeatures, PageMenu_Vehicle, PageAuth_Cookie);
   MyWebServer.RegisterPage("/xhi/battmon", "Battery Monitor", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
+#endif
 
   // Init polling:
   PollSetThrottling(0);
@@ -128,8 +132,10 @@ OvmsVehicleHyundaiVFL::~OvmsVehicleHyundaiVFL()
 {
   ESP_LOGI(TAG, "Shutdown Hyundai Ioniq vFL vehicle module");
   PollSetPidList(m_can1, NULL);
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   MyWebServer.DeregisterPage("/xhi/battmon");
   MyWebServer.DeregisterPage("/xhi/features");
+#endif
   MyMetrics.DeregisterMetric(m_xhi_charge_state);
   MyMetrics.DeregisterMetric(m_xhi_env_state);
   MyMetrics.DeregisterMetric(m_xhi_bat_soc_bms);

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.h
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.h
@@ -31,7 +31,9 @@
 #define __VEHICLE_HYUNDAI_IONIQVFL_H__
 
 #include "vehicle.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 
 using namespace std;
 
@@ -48,8 +50,10 @@ class OvmsVehicleHyundaiVFL : public OvmsVehicle
   protected:
     void Ticker60(uint32_t ticker);
 
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   public:
     static void WebCfgFeatures(PageEntry_t &p, PageContext_t &c);
+#endif
 
   protected:
     void PollerStateTicker();

--- a/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.cpp
@@ -307,7 +307,9 @@ OvmsVehicleKiaNiroEv::OvmsVehicleKiaNiroEv()
 OvmsVehicleKiaNiroEv::~OvmsVehicleKiaNiroEv()
   {
   ESP_LOGI(TAG, "Shutdown Kia Niro / Hyundai Kona EV vehicle module");
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   MyWebServer.DeregisterPage("/bms/cellmon");
+#endif
   }
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.cpp
@@ -6,7 +6,9 @@
  */
 #include <fstream>
 #include <sdkconfig.h>
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 #include "ovms_peripherals.h"
 #include "kia_common.h"
 #include "ovms_metrics.h"

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
@@ -2,8 +2,10 @@
 #define __VEHICLE_KIA_COMMON_H__
 
 #include "vehicle.h"
-#include "ovms_webserver.h"
 #include <sdkconfig.h>
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
+#include "ovms_webserver.h"
+#endif
 
 using namespace std;
 

--- a/vehicle/OVMS.V3/components/vehicle_maxus_edeliver3/src/vehicle_med3.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_edeliver3/src/vehicle_med3.cpp
@@ -34,7 +34,9 @@ static const char *TAG = "v-maxed3";
 #include <stdio.h>
 #include "vehicle_med3.h"
 #include "med3_pids.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 #include <algorithm>
 #include "metrics_standard.h"
 

--- a/vehicle/OVMS.V3/components/vehicle_maxus_edeliver3/src/vehicle_med3.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_edeliver3/src/vehicle_med3.h
@@ -33,7 +33,9 @@
 
 #include "vehicle.h"
 #include "metrics_standard.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 #include "med3_pids.h"
 
 #include "freertos/timers.h"

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
@@ -34,7 +34,9 @@
 
 #include "vehicle.h"
 #include "metrics_standard.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 #include "mg_obd_pids.h"
 #include "mg_poll_states.h"
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
@@ -24,7 +24,8 @@
  * THE SOFTWARE.
  */
 
-
+#include <sdkconfig.h>
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include <stdio.h>
 #include <string>
 #include "ovms_metrics.h"
@@ -435,3 +436,5 @@ void OvmsVehicleNissanLeaf::GetDashboardConfig(DashboardConfig& cfg)
       << "]";
   cfg.gaugeset1 = str.str();
 }
+
+#endif //CONFIG_OVMS_COMP_WEBSERVER

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -40,7 +40,9 @@ static const char *TAG = "v-nissanleaf";
 #include "ovms_metrics.h"
 #include "metrics_standard.h"
 #include "ovms_notify.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 #include "ovms_command.h"
 #include "ovms_config.h"
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -36,7 +36,9 @@
 #include <algorithm>
 #include "freertos/timers.h"
 #include "vehicle.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 #include "ovms_semaphore.h"
 #include "ovms_mutex.h"
 #include "ovms_peripherals.h"
@@ -134,10 +136,12 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
   //
 
   public:
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
     void WebInit();
     void WebDeInit();
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
+#endif
     static void shell_obd_request(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
 
   public:

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.cpp
@@ -156,7 +156,9 @@ OvmsVehicleRenaultTwizy::~OvmsVehicleRenaultTwizy()
   ObdShutdown();
   if (m_sevcon)
     delete m_sevcon;
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   WebShutdown();
+#endif
   ChargeShutdown();
   PowerShutdown();
   BatteryShutdown();

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.h
@@ -101,10 +101,12 @@ class OvmsVehicleRenaultZoe : public OvmsVehicle {
     OvmsMetricFloat  *mt_heatwater_temp;      // Heat Water Temp
 
   public:
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
     void WebInit();
     void WebDeInit();
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
+#endif
     void ConfigChanged(OvmsConfigParam* param);
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.h
@@ -65,13 +65,17 @@ class OvmsVehicleRenaultZoePh2OBD : public OvmsVehicle {
   public:
     OvmsVehicleRenaultZoePh2OBD();
     ~OvmsVehicleRenaultZoePh2OBD();
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
     static void WebCfgCommon(PageEntry_t& p, PageContext_t& c);
+#endif
     void ConfigChanged(OvmsConfigParam* param);
     void ZoeWakeUp();
 		void IncomingFrameCan1(CAN_frame_t* p_frame);
 		void IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t remain);
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
     void WebInit();
     void WebDeInit();
+#endif
     bool CarIsCharging = false;
     bool CarPluggedIn = false;
     bool CarLastCharging = false;

--- a/vehicle/OVMS.V3/components/vehicle_smarted/src/vehicle_smarted.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarted/src/vehicle_smarted.h
@@ -67,9 +67,12 @@ class OvmsVehicleSmartED : public OvmsVehicle
     char m_vin[18];
 
   public:
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
     void WebInit();
     void WebDeInit();
+#endif
     void ObdInitPoll();
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
     static void WebCfgCommands(PageEntry_t& p, PageContext_t& c);
@@ -77,6 +80,7 @@ class OvmsVehicleSmartED : public OvmsVehicle
     static void WebCfgBmsCellMonitor(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBmsCellCapacity(PageEntry_t& p, PageContext_t& c);
     static void WebCfgEco(PageEntry_t& p, PageContext_t& c);
+#endif
     void ConfigChanged(OvmsConfigParam* param);
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -61,10 +61,12 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void HandleEnergy();
 
   public:
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
     void WebInit();
     void WebDeInit();
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
+#endif
     void ConfigChanged(OvmsConfigParam* param);
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);

--- a/vehicle/OVMS.V3/components/vehicle_toyotarav4ev/src/vehicle_toyotarav4ev.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyotarav4ev/src/vehicle_toyotarav4ev.h
@@ -40,7 +40,9 @@
 
 #include "vehicle.h"
 #include "ovms_metrics.h"
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 
 using namespace std;
 

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.h
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.h
@@ -43,7 +43,9 @@
 #include "ovms_metrics.h"
 #include "ovms_command.h"
 
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
+#endif
 
 #include "ovms_mutex.h"
 #include "ovms_semaphore.h"
@@ -228,6 +230,7 @@ private:
   //  - implementation: vweup_web.(h,cpp)
   //
 
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 protected:
   void WebInit();
   void WebDeInit();
@@ -235,6 +238,7 @@ protected:
   static void WebCfgFeatures(PageEntry_t &p, PageContext_t &c);
   static void WebCfgClimate(PageEntry_t &p, PageContext_t &c);
   static void WebDispChgMetrics(PageEntry_t &p, PageContext_t &c);
+#endif
 
 public:
   void GetDashboardConfig(DashboardConfig& cfg);

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.h
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.h
@@ -34,7 +34,6 @@
 #define __VEHICLE_EUP_OBD_H__
 
 #include "vehicle.h"
-#include "ovms_webserver.h"
 #include "poll_reply_helper.h"
 
 using namespace std;

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
@@ -130,7 +130,6 @@ static const char *TAG = "v-vweup";
 #include "vehicle_vweup.h"
 #include "vweup_t26.h"
 #include "metrics_standard.h"
-#include "ovms_webserver.h"
 #include "ovms_events.h"
 #include "ovms_metrics.h"
 

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_web.cpp
@@ -25,6 +25,8 @@
  * THE SOFTWARE.
  */
 
+#include <sdkconfig.h>
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
 #define _GLIBCXX_USE_C99 // to enable std::stoi etc.
 #include <stdio.h>
 #include <string>
@@ -34,7 +36,6 @@
 #include "ovms_command.h"
 #include "metrics_standard.h"
 #include "ovms_notify.h"
-#include "ovms_webserver.h"
 
 #include "vehicle_vweup.h"
 
@@ -684,3 +685,5 @@ void OvmsVehicleVWeUp::GetDashboardConfig(DashboardConfig& cfg)
       << "]";
   cfg.gaugeset1 = str.str();
 }
+
+#endif //CONFIG_OVMS_COMP_WEBSERVER


### PR DESCRIPTION
When compiling without the webserver component (obviously an uncommon situation), a few part of the code are not guarded with defines - this fixes that.