### PR TITLE
ESP-IDF 4.x : impact of renamed constants

### DIFF
--- a/vehicle/OVMS.V3/main/ovms.h
+++ b/vehicle/OVMS.V3/main/ovms.h
@@ -41,6 +41,11 @@
 #include <sstream>
 #include "ovms_malloc.h"
 
+#if ESP_IDF_VERSION_MAJOR >= 4
+#define CONFIG_CONSOLE_UART_NUM CONFIG_ESP_CONSOLE_UART_NUM
+#define CONFIG_TASK_WDT_TIMEOUT_S CONFIG_ESP_TASK_WDT_TIMEOUT_S
+#endif
+
 #ifdef CONFIG_FREERTOS_UNICORE
   #define CORE(n) (0)
 #else


### PR DESCRIPTION
ESP-IDF 4.x renamed some constants (cf https://github.com/espressif/esp-idf/commit/51e66d0f8247fd8314458f8e209a93cb12823cf4) so we reintroduce them for compatibility with existing code.

Another solution would be to impact the said code (`main/ovms_boot.cpp`, `main/ovms_module.cpp`) with #ifdef.