### PR TITLE
cleanup warnings about switch case fallthrough

### DIFF
--- a/vehicle/OVMS.V3/components/simcom/src/simcom_5360.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_5360.cpp
@@ -91,6 +91,7 @@ void simcom5360::StatusPoller()
         //  +COPS: 0,0,"vodafone.de Hologram",0
 
         // done, fallthrough:
+        FALLTHROUGH;
       default:
         m_statuspoller_step = 0;
         break;

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7000.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7000.cpp
@@ -119,6 +119,7 @@ modem::modem_state1_t simcom7000::State1Ticker1(modem::modem_state1_t curstate)
       {
       case 8:
         m_modem->tx("ATE0\r\n");
+        break;
       case 10:
         m_modem->tx("AT+CPIN?;+CREG=1;+CTZU=1;+CTZR=1;+CMGF=1;+CNMI=1,2,0,0,0;+CSDH=1;+CMEE=2;+CSQ;S0=0\r\n");
         break;

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7600.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7600.cpp
@@ -129,6 +129,7 @@ void simcom7600::StatusPoller()
         //  +COPS: 0,0,"vodafone.de Hologram",7  
 
         // done, fallthrough:
+        FALLTHROUGH;
       default:
         m_statuspoller_step = 0;
         break;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
@@ -235,6 +235,7 @@ void OvmsVehicle::PollerVWTPEnter(vwtp_channelstate_t state)
 
       // fall through to VWTP_Transmit
       }
+      FALLTHROUGH;
     case VWTP_Transmit:
       {
       ESP_LOGD(TAG, "PollerVWTPEnter[%02X]: transmit frame=%u remain=%u",

--- a/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.cpp
@@ -2444,6 +2444,7 @@ case I3_PID_EDM_PEDALWERTGEBER: {                                               
         break;
       }
       StdMetrics.ms_v_vin->SetValue(rxbuf);
+      break;
   }
 
   // --- IHX --------------------------------------------------------------------------------------------------------

--- a/vehicle/OVMS.V3/components/vehicle_fiat500/src/vehicle_fiat500e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_fiat500/src/vehicle_fiat500e.cpp
@@ -415,6 +415,7 @@ void OvmsVehicleFiat500e::IncomingFrameCan2(CAN_frame_t* p_frame) {
     float itemp = ((uint16_t) d[3] << 1) | (d[4]&0x80 >> 7 );
     StandardMetrics.ms_v_env_cabintemp->SetValue(itemp*0.5-40);
     //01111111 10000000
+    break;
     }
      case 0xC014003: //TRIP_A_B
     {

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.cpp
@@ -119,7 +119,7 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
     {
       StandardMetrics.ms_v_bat_12v_voltage->SetValue((float)d[1]*0.1); // Volts
       break;
-    }	
+    }
   case 0x20B: // HVAC
     {
       StandardMetrics.ms_v_env_cabinsetpoint->SetValue((float)d[0]*0.1+10); // deg C
@@ -127,7 +127,7 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
       // d[4] ls nible, could be ms_v_env_cabinfan
       // d[5] contain ms_v_env_cooling and heating, possibly separated for drive and park      
       break;
-    }	
+    }
   case 0x2FF: // TPMS
     {
       if (d[3] < 255)
@@ -139,7 +139,7 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
       if (d[6] < 255)
 	StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RR, (float)d[6]*2.5); // KPa
       break;
-    }	
+    }
   case 0x33D: // Momentary power
     {
       float power = d[4]-100; // Percents, +/- 100
@@ -148,7 +148,7 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
         power = -50; // I just guess that maximum recuperation would be 50kW, probably less
       StandardMetrics.ms_v_bat_power->SetValue(power); // kW 
       break;
-    }	    
+    }
   case 0x34E:  // Distance Today , Distance since reset, scale is 0.1 km
     { 
       int trip_start = d[0] * 256 * 256 + d[1] * 256 + d[2];
@@ -157,7 +157,8 @@ void OvmsVehicleMercedesB250e::IncomingFrameCan1(CAN_frame_t* p_frame)
 	mt_mb_trip_start->SetValue(trip_start * 0.1); 
       if (trip_reset < 0xfffffe) 
         mt_mb_trip_reset->SetValue(trip_reset * 0.1);
-    }      
+      break;
+    }
   case 0x34F: // Range
     {
       float consumption = (float)(d[0]&0x7)*256 + (float)d[1];

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -369,6 +369,7 @@ void OvmsVehicleNissanLeaf::vehicle_nissanleaf_charger_status(ChargerStatus stat
       break;
     case CHARGER_STATUS_QUICK_CHARGING:
       fast_charge = true;
+      FALLTHROUGH;
     case CHARGER_STATUS_CHARGING:
       if (!StandardMetrics.ms_v_charge_inprogress->AsBool())
         {
@@ -980,6 +981,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_charge_climit->SetValue(max_charge_power / StandardMetrics.ms_v_charge_voltage->AsFloat());
       }
     }
+      break;
     case 0x390:
     {
       m_AZE0_charger = true;

--- a/vehicle/OVMS.V3/main/ovms.h
+++ b/vehicle/OVMS.V3/main/ovms.h
@@ -47,6 +47,19 @@
   #define CORE(n) (n)
 #endif
 
+#if defined __has_cpp_attribute
+    #if __has_cpp_attribute(fallthrough)
+        #define FALLTHROUGH [[fallthrough]]
+    #endif
+#elif defined __has_attribute
+    #if __has_attribute(__fallthrough__)
+        #define FALLTHROUGH __attribute__((__fallthrough__))
+    #endif
+#endif
+#if !defined(FALLTHROUGH)
+    #define FALLTHROUGH do {} while (0)  /* fallthrough */
+#endif
+
 extern uint32_t monotonictime;
 
 class ExternalRamAllocated

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -2286,6 +2286,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case Feet:    return km_to_mi(value) * feet_per_mile;
         default: break;
         }
+      break;
     case Miles:
       switch (to)
         {
@@ -2294,6 +2295,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case Feet:       return value * feet_per_mile;
         default: break;
         }
+      break;
     case Meters:
       switch (to)
         {
@@ -2302,6 +2304,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case Feet:       return km_to_mi( value * feet_per_mile)/ 1000;
         default: break;
         }
+      break;
     case Feet:
       switch (to)
         {
@@ -2310,6 +2313,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case Miles:      return value / feet_per_mile;
         default: break;
         }
+      break;
     case KphPS:
       switch (to)
         {
@@ -2318,6 +2322,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case FeetPSS:   return km_to_mi(value*feet_per_mile)/3600;
         default: break;
         }
+      break;
     case MphPS:
       switch (to)
         {
@@ -2326,6 +2331,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case FeetPSS:   return value*feet_per_mile/3600;
         default: break;
         }
+      break;
     case MetersPSS:
       switch (to)
         {
@@ -2334,6 +2340,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case FeetPSS:   return km_to_mi(value*feet_per_mile);
         default: break;
         }
+      break;
     case FeetPSS:
       switch (to)
         {
@@ -2342,6 +2349,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case MetersPSS: return mi_to_km(value/feet_per_mile)*1000;
         default: break;
         }
+      break;
     case kW:
       if (to == Watts) return (value*1000);
       break;
@@ -2390,6 +2398,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case MPkWh:    return value ? static_cast<int>(km_to_mi(1000.0 / value)) : 0;
         default: break;
         }
+      break;
     case WattHoursPM:
       switch (to)
         {
@@ -2409,6 +2418,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case MPkWh:       return value ? static_cast<int>(km_to_mi(100.0 / value)) : 0;
         default: break;
         }
+      break;
     case KPkWh:
       switch (to)
         {
@@ -2418,6 +2428,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case MPkWh:       return km_to_mi(value);
         default: break;
         }
+      break;
     case MPkWh:
       switch (to)
         {
@@ -2427,6 +2438,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case KPkWh:       return mi_to_km(value);
         default: break;
         }
+      break;
     case Celcius:
       if (to == Fahrenheit) return ((value*9)/5) + 32;
       break;
@@ -2441,6 +2453,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case PSI: return int((float)value * 0.14503773773020923);
         default: break;
         }
+      break;
     case Pa:
       switch (to)
         {
@@ -2449,6 +2462,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case PSI: return int((float)value * 0.00014503773773020923);
         default: break;
         }
+      break;
     case PSI:
       switch (to)
         {
@@ -2457,6 +2471,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case Bar: return int((float)value * 0.06894757293168361);
         default: break;
         }
+      break;
     case Bar:
       switch (to)
         {
@@ -2465,6 +2480,7 @@ int UnitConvert(metric_unit_t from, metric_unit_t to, int value)
         case PSI: return int((float)value * 14.503773773020923);
         default: break;
         }
+      break;
     case Seconds:
       if (to == Minutes) return value/60;
       else if (to == Hours) return value/3600;
@@ -2556,6 +2572,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case Feet:    return km_to_mi(value) * feet_per_mile;
         default: break;
         }
+      break;
     case Miles:
       switch (to)
         {
@@ -2564,6 +2581,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case Feet:       return value * feet_per_mile;
         default: break;
         }
+      break;
     case Meters:
       switch (to)
         {
@@ -2572,6 +2590,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case Feet:        return km_to_mi(value/1000) * feet_per_mile;
         default: break;
         }
+      break;
     case Feet:
       switch (to)
         {
@@ -2580,6 +2599,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case Miles:      return value / feet_per_mile;
         default: break;
         }
+      break;
     case KphPS:
       switch (to)
         {
@@ -2588,6 +2608,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case FeetPSS:   return km_to_mi(value)*feet_per_mile/3600;
         default: break;
         }
+      break;
     case MphPS:
       switch (to)
         {
@@ -2596,6 +2617,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case FeetPSS:   return value*feet_per_mile/3600;
         default: break;
         }
+      break;
     case MetersPSS:
       switch (to)
         {
@@ -2604,6 +2626,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case FeetPSS:   return km_to_mi(value)*feet_per_mile;
         default: break;
         }
+      break;
     case FeetPSS:
       switch (to)
         {
@@ -2612,6 +2635,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case MetersPSS: return mi_to_km(value/feet_per_mile)*1000;
         default: break;
         }
+      break;
     case kW:
       if (to == Watts) return (value*1000);
       break;
@@ -2661,6 +2685,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case MPkWh:       return value ? (km_to_mi(1000.0 / value)) : 0;
         default: break;
         }
+      break;
     case WattHoursPM:
       switch (to)
         {
@@ -2680,6 +2705,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case MPkWh:       return value ? km_to_mi(100.0 / value) : 0;
         default: break;
         }
+      break;
     case KPkWh:
       switch (to)
         {
@@ -2689,6 +2715,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case MPkWh:       return km_to_mi(value);
         default: break;
         }
+      break;
     case MPkWh:
       switch (to)
         {
@@ -2698,6 +2725,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case KPkWh:       return mi_to_km(value);
         default: break;
         }
+      break;
     case Celcius:
       if (to == Fahrenheit) return ((value*9)/5) + 32;
       break;
@@ -2712,6 +2740,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case PSI: return value * 0.14503773773020923;
         default: break;
         }
+      break;
     case Pa:
       switch (to)
         {
@@ -2720,6 +2749,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case PSI: return value * 0.00014503773773020923;
         default: break;
         }
+      break;
     case PSI:
       switch (to)
         {
@@ -2728,6 +2758,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case Bar: return value * 0.06894757293168361;
         default: break;
         }
+      break;
     case Bar:
       switch (to)
         {
@@ -2736,6 +2767,7 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
         case PSI: return value * 14.503773773020923;
         default: break;
         }
+      break;
     case Seconds:
       if (to == Minutes) return value/60;
       else if (to == Hours) return value/3600;
@@ -2788,8 +2820,10 @@ float UnitConvert(metric_unit_t from, metric_unit_t to, float value)
       break;
     case Percentage:
       if (to == Permille) return value*10.0;
+      break;
     case Permille:
       if (to == Percentage) return value*0.10;
+      break;
     default:
       return value;
     }


### PR DESCRIPTION
With the new warnings activated in ESP-IDF 4+, a `switch`-`case` must now properly and explicitely identify when a fall-through is wanted or is a forgotten `break`.

One way to mark those wanted fall-through is to mark them with a [GCC-specific attribute](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough), a [C++ attribute](https://en.cppreference.com/w/cpp/language/attributes/fallthrough) or even with a specific comment as [documented in the GCC compiler](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough).

We took inspiration from the [Linux Kernel approach](https://elixir.bootlin.com/linux/v5.10/source/include/linux/compiler_attributes.h#L208) to create a macro `FALLTHROUGH;` that should do the proper decoration (either CPP attribute, compiler attribute or comment) depending on the capabilities of the compiler - when the fall-through is wanted, and explicitly decorated those.
For the other cases, we added a `break`.

⚠️ We may have mistaken a missing break for a wanted fall-through, or vice-versa - please double / triple check during code review.... thanks !