### PR TITLE
ESP-IDF v4+ : replace legacy event loop with esp_event Library Event Loop

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_events.cpp
+++ b/vehicle/OVMS.V3/main/ovms_events.cpp
@@ -39,6 +39,10 @@ static const char *TAG = "events";
 #include "ovms_command.h"
 #include "ovms_script.h"
 #include "ovms_boot.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
+#include <esp_netif_types.h>
+#include <esp_eth_com.h>
+#endif
 
 #ifdef CONFIG_OVMS_COMP_OTA
 #include "ovms_ota.h"

--- a/vehicle/OVMS.V3/main/ovms_events.cpp
+++ b/vehicle/OVMS.V3/main/ovms_events.cpp
@@ -33,7 +33,6 @@ static const char *TAG = "events";
 
 #include <string.h>
 #include <stdio.h>
-#include <esp_event_loop.h>
 #include <esp_task_wdt.h>
 #include "ovms_module.h"
 #include "ovms_events.h"
@@ -202,7 +201,12 @@ OvmsEvents::OvmsEvents()
   m_trace = false;
 #endif // #ifdef CONFIG_OVMS_DEV_DEBUGEVENTS
 
+#if ESP_IDF_VERSION_MAJOR >= 4
+  ESP_ERROR_CHECK(esp_event_loop_create_default());
+  ESP_ERROR_CHECK(esp_event_handler_instance_register(ESP_EVENT_ANY_BASE, ESP_EVENT_ANY_ID, ReceiveSystemEvent, (void*)this, &event_handler_instance));
+#else
   ESP_ERROR_CHECK(esp_event_loop_init(ReceiveSystemEvent, (void*)this));
+#endif
 
   // Register our commands
   OvmsCommand* cmd_event = MyCommandApp.RegisterCommand("event","EVENT framework", event_status, "", 0, 0, false);
@@ -226,6 +230,10 @@ OvmsEvents::OvmsEvents()
 
 OvmsEvents::~OvmsEvents()
   {
+#if ESP_IDF_VERSION_MAJOR >= 4
+  ESP_ERROR_CHECK(esp_event_handler_instance_unregister(ESP_EVENT_ANY_BASE, ESP_EVENT_ANY_ID, event_handler_instance));
+  ESP_ERROR_CHECK(esp_event_loop_delete_default());
+#endif
   }
 
 void OvmsEvents::EventTask()
@@ -562,6 +570,117 @@ void OvmsEvents::SignalEvent(std::string event, void* data, size_t length,
     }
   }
 
+#if ESP_IDF_VERSION_MAJOR >= 4
+/* Handler for all events */
+void OvmsEvents::ReceiveSystemEvent(void* handler_args, esp_event_base_t base, int32_t id, void* event_data)
+  {
+  OvmsEvents* e = (OvmsEvents*)handler_args;
+  // e->SignalEvent("system.event",(void*)event_data, sizeof(system_event_t)); // used for legacy mdns approach only ?
+
+  if (base == WIFI_EVENT)
+    {
+    switch (id)
+      {
+      case WIFI_EVENT_WIFI_READY:      // ESP32 WiFi ready
+        e->SignalEvent("system.wifi.ready", NULL);
+        break;
+      case WIFI_EVENT_SCAN_DONE:       // ESP32 finish scanning AP
+        e->SignalEvent("system.wifi.scan.done", event_data, sizeof(wifi_event_sta_scan_done_t));
+        break;
+      case WIFI_EVENT_STA_START:       // ESP32 station start
+        e->SignalEvent("system.wifi.sta.start", NULL);
+        break;
+      case WIFI_EVENT_STA_STOP:        // ESP32 station stop
+        e->SignalEvent("system.wifi.sta.stop", NULL);
+        break;
+      case WIFI_EVENT_STA_CONNECTED:   // ESP32 station connected to AP
+        e->SignalEvent("system.wifi.sta.connected", event_data, sizeof(wifi_event_sta_connected_t));
+        break;
+      case WIFI_EVENT_STA_DISCONNECTED:  // ESP32 station disconnected from AP
+        e->SignalEvent("system.wifi.sta.disconnected", event_data, sizeof(wifi_event_sta_disconnected_t));
+        break;
+      case WIFI_EVENT_STA_AUTHMODE_CHANGE:  // the auth mode of AP connected by ESP32 station changed
+        e->SignalEvent("system.wifi.sta.authmodechange", event_data, sizeof(wifi_event_sta_authmode_change_t));
+        break;
+      case WIFI_EVENT_STA_WPS_ER_SUCCESS:  // ESP32 station wps succeeds in enrollee mode
+        e->SignalEvent("system.wifi.sta.wpser.success", NULL);
+        break;
+      case WIFI_EVENT_STA_WPS_ER_FAILED:   // ESP32 station wps fails in enrollee mode
+        e->SignalEvent("system.wifi.sta.wpser.failed", event_data, sizeof(wifi_event_sta_wps_fail_reason_t));
+        break;
+      case WIFI_EVENT_STA_WPS_ER_TIMEOUT:  // ESP32 station wps timeout in enrollee mode
+        e->SignalEvent("system.wifi.sta.wpser.timeout", NULL);
+        break;
+      case WIFI_EVENT_STA_WPS_ER_PIN:      // ESP32 station wps pin code in enrollee mode
+        e->SignalEvent("system.wifi.sta.wpser.pin", event_data, sizeof(wifi_event_sta_wps_er_pin_t));
+        break;
+      case WIFI_EVENT_AP_START:            // ESP32 soft-AP start
+        e->SignalEvent("system.wifi.ap.start", NULL);
+        break;
+      case WIFI_EVENT_AP_STOP:             // ESP32 soft-AP stop
+        e->SignalEvent("system.wifi.ap.stop", NULL);
+        break;
+      case WIFI_EVENT_AP_STACONNECTED:     // a station connected to ESP32 soft-AP
+        e->SignalEvent("system.wifi.ap.sta.connected", event_data, sizeof(wifi_event_ap_staconnected_t));
+        break;
+      case WIFI_EVENT_AP_STADISCONNECTED:  // a station disconnected from ESP32 soft-AP
+        e->SignalEvent("system.wifi.ap.sta.disconnected", event_data, sizeof(wifi_event_ap_stadisconnected_t));
+        break;
+      case WIFI_EVENT_AP_PROBEREQRECVED:   // Receive probe request packet in soft-AP interface
+        e->SignalEvent("system.wifi.ap.proberx", event_data, sizeof(wifi_event_ap_probe_req_rx_t));
+        break;
+      default:
+       break;
+      }
+    }
+  else if (base == IP_EVENT)
+    {
+    switch (id)
+      {
+      case IP_EVENT_STA_GOT_IP:           // ESP32 station got IP from connected AP
+        e->SignalEvent("network.interface.up", NULL);
+        e->SignalEvent("system.wifi.sta.gotip", event_data, sizeof(ip_event_got_ip_t));
+        break;
+      case IP_EVENT_STA_LOST_IP:         // ESP32 station lost IP and the IP is reset to 0
+        e->SignalEvent("system.wifi.sta.lostip", NULL);
+        break;
+      case IP_EVENT_AP_STAIPASSIGNED:    // ESP32 soft-AP assigned an IP to a connected station
+        e->SignalEvent("system.wifi.ap.sta.ipassigned", NULL);
+        break;
+      case IP_EVENT_GOT_IP6:      // ESP32 station or ap interface v6IP addr is preferred
+        e->SignalEvent("system.wifi.ap.sta.gotip6", event_data, sizeof(ip_event_got_ip6_t));
+        break;
+      case IP_EVENT_ETH_GOT_IP:          // ESP32 ethernet got IP from connected AP
+        e->SignalEvent("system.eth.gotip",  event_data, sizeof(ip_event_got_ip_t));
+        break;
+      default:
+       break;
+      }
+    }
+  else if (base == ETH_EVENT)
+    {
+    switch (id)
+      {
+      case ETHERNET_EVENT_START:           // ESP32 ethernet start
+        e->SignalEvent("system.eth.start", NULL);
+        break;
+      case ETHERNET_EVENT_STOP:            // ESP32 ethernet stop
+        e->SignalEvent("system.eth.stop", NULL);
+        break;
+      case ETHERNET_EVENT_CONNECTED:       // ESP32 ethernet phy link up
+        e->SignalEvent("system.eth.connected", NULL);
+        break;
+      case ETHERNET_EVENT_DISCONNECTED:    // ESP32 ethernet phy link down
+        e->SignalEvent("system.eth.disconnected", NULL);
+        break;
+      default:
+       break;
+      }
+    }
+  }
+
+#else
+
 esp_err_t OvmsEvents::ReceiveSystemEvent(void *ctx, system_event_t *event)
   {
   OvmsEvents* e = (OvmsEvents*)ctx;
@@ -654,6 +773,8 @@ void OvmsEvents::SignalSystemEvent(system_event_t *event)
      break;
     }
   }
+
+#endif
 
 EventCallbackEntry::EventCallbackEntry(std::string caller, EventCallback callback)
   {

--- a/vehicle/OVMS.V3/main/ovms_events.h
+++ b/vehicle/OVMS.V3/main/ovms_events.h
@@ -35,7 +35,12 @@
 #include <functional>
 #include <map>
 #include <list>
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
 #include <esp_event.h>
+#else
+#include <esp_event_loop.h>
+#endif
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
@@ -107,8 +112,12 @@ class OvmsEvents
     void EventTask();
     void HandleQueueSignalEvent(event_queue_t* msg);
     void FreeQueueSignalEvent(event_queue_t* msg);
+#if ESP_IDF_VERSION_MAJOR >= 4
+    static void ReceiveSystemEvent(void* handler_args, esp_event_base_t base, int32_t id, void* event_data);
+#else
     static esp_err_t ReceiveSystemEvent(void *ctx, system_event_t *event);
     void SignalSystemEvent(system_event_t *event);
+#endif
     const EventMap& Map() { return m_map; }
 
   protected:
@@ -120,6 +129,9 @@ class OvmsEvents
     TimerList m_timers;
     TimerStatusMap m_timer_active;
     OvmsMutex m_timers_mutex;
+#if ESP_IDF_VERSION_MAJOR >= 4
+    esp_event_handler_instance_t event_handler_instance;
+#endif
 
   public:
     bool m_trace;


### PR DESCRIPTION
Starting with ESP-IDF v4+, a part of the Event Loop library is deprecated : cf https://docs.espressif.com/projects/esp-idf/en/v4.4.4/esp32/api-reference/system/esp_event_legacy.html for details of the deprecated functions and structures.

This PR rewrites this event loop with the newer esp_event library event loop.