### PR TITLE
Change definition of `INT` from `int32_t` to `int`

### DIFF
--- a/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
@@ -836,11 +836,11 @@ dbcNumber dbcSignal::Decode(CAN_frame_t* msg)
   }
 
   // Apply factor and offset
-  if (!(m_factor == 1))
+  if (!(m_factor == (uint32_t)1))
     {
     result = (result * m_factor);
     }
-  if (!(m_offset == 0))
+  if (!(m_offset == (uint32_t)0))
     {
     result = (result + m_offset);
     }

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
@@ -169,7 +169,7 @@ void OvmsVehicleKiaSoulEv::IncomingOBC(canbus* bus, uint16_t type, uint16_t pid,
  */
 void OvmsVehicleKiaSoulEv::IncomingVMCU(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain)
 	{
-	INT base;
+	int32_t base;
 	uint8_t bVal;
 
 	switch (pid)

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_types.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_types.h
@@ -32,11 +32,19 @@
 // Legacy type compatibility:
 
 typedef uint8_t UINT8;
-typedef uint32_t UINT;    // Note: fatfs defines this as 32 bit, so we stick to that
+typedef unsigned int UINT;    // Note: fatfs defines this as 32 bit, so we stick to that
+                              // Note: even if they are the same size (on 32-bit arch),
+                              // int and long are differenciated by the compiler and
+                              // are not interchangeable.
+                              // UINT is defined as `typedef unsigned int UINT` in `fatfs/src/ff.h:49`
+                              // while int32_t is defined as `unsigned long`.
+                              // Same bit size - but different type, so we cannot redefine it differently
+                              // Cf: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/gcc.html#int32-t-and-uint32-t-for-xtensa-compiler
+                              // Cf: https://github.com/espressif/esp-idf/issues/9511#issuecomment-1226251443
 typedef uint32_t UINT32;
 
 typedef int8_t INT8;
-typedef int32_t INT;      // 32 bit for consistency with UINT
+typedef int INT;      // 32 bit for consistency with UINT
 typedef int32_t INT32;
 
 

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
@@ -1001,15 +1001,15 @@ void OvmsVehicleRenaultZoe::IncomingLBC(uint16_t type, uint16_t pid, const char*
     case 0x04: {
       if (IsZoe()) {
         for(int i=2; i<36; i+=3){
-          BmsSetCellTemperature( (i-2)/3, (INT)CAN_BYTE(i)-40 );
-          //ESP_LOGD(TAG, "temp %d - %d", (i-2)/3, (INT)CAN_BYTE(i)-40);
+          BmsSetCellTemperature( (i-2)/3, (int32_t)CAN_BYTE(i)-40 );
+          //ESP_LOGD(TAG, "temp %d - %d", (i-2)/3, (int32_t)CAN_BYTE(i)-40);
         }
       }
       if (IsKangoo()) {
         int x=0;
         for(int i=2; i<12; i+=3){
-          BmsSetCellTemperature( x, (INT)CAN_BYTE(i) );
-          ESP_LOGD(TAG, "temp %d - %d", x, (INT)CAN_BYTE(i));
+          BmsSetCellTemperature( x, (int32_t)CAN_BYTE(i) );
+          ESP_LOGD(TAG, "temp %d - %d", x, (int32_t)CAN_BYTE(i));
           x++;
         }
       }


### PR DESCRIPTION
In ESP-IDF v5+, a compiler change has been made for type `int32_t` and `uint32_t` : Cf https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/gcc.html#int32-t-and-uint32-t-for-xtensa-compiler

This change forces us to update the definition of our `INT` type (which is indirectly based on the `UINT` definition in fatfs), and to update a few definitions here and there.

A distinct PR will tackle with the impact of this change on `printf` format strings.