### PR TITLE
`int32_t` format strings changes

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/can.cpp
+++ b/vehicle/OVMS.V3/components/can/src/can.cpp
@@ -228,7 +228,7 @@ void can_tx(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const
   uint32_t uv = strtoul(argv[0], &ep, 16);
   if (*ep != '\0' || uv > idmax)
     {
-    writer->printf("Error: Invalid CAN ID \"%s\" (0x%x max)\n", argv[0], idmax);
+    writer->printf("Error: Invalid CAN ID \"%s\" (0x%" PRIx32 " max)\n", argv[0], idmax);
     return;
     }
   frame.MsgID = uv;
@@ -313,7 +313,7 @@ void can_testtx(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, c
   uint32_t uv = strtoul(argv[0], &ep, 16);
   if (*ep != '\0' || uv > idmax)
     {
-    writer->printf("Error: Invalid CAN ID \"%s\" (0x%x max)\n", argv[0], idmax);
+    writer->printf("Error: Invalid CAN ID \"%s\" (0x%" PRIx32 " max)\n", argv[0], idmax);
     return;
     }
   frame.MsgID = uv;
@@ -348,22 +348,22 @@ void can_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, c
   writer->printf("Speed:     %d\n",MAP_CAN_SPEED(sbus->m_speed));
   writer->printf("DBC:       %s\n",(sbus->GetDBC())?sbus->GetDBC()->GetName().c_str():"none");
 
-  writer->printf("\nInterrupts:%20d\n",sbus->m_status.interrupts);
-  writer->printf("Rx pkt:    %20d\n",sbus->m_status.packets_rx);
+  writer->printf("\nInterrupts:%20" PRId32 "\n",sbus->m_status.interrupts);
+  writer->printf("Rx pkt:    %20" PRId32 "\n",sbus->m_status.packets_rx);
   writer->printf("Rx ovrflw: %20d\n",sbus->m_status.rxbuf_overflow);
-  writer->printf("Tx pkt:    %20d\n",sbus->m_status.packets_tx);
-  writer->printf("Tx delays: %20d\n",sbus->m_status.txbuf_delay);
+  writer->printf("Tx pkt:    %20" PRId32 "\n",sbus->m_status.packets_tx);
+  writer->printf("Tx delays: %20" PRId32 "\n",sbus->m_status.txbuf_delay);
   writer->printf("Tx ovrflw: %20d\n",sbus->m_status.txbuf_overflow);
-  writer->printf("Tx fails:  %20d\n",sbus->m_status.tx_fails);
+  writer->printf("Tx fails:  %20" PRId32 "\n",sbus->m_status.tx_fails);
 
-  writer->printf("\nErr flags: 0x%08x\n",sbus->m_status.error_flags);
+  writer->printf("\nErr flags: 0x%08" PRIx32 "\n",sbus->m_status.error_flags);
   writer->printf("Rx err:    %20d\n",sbus->m_status.errors_rx);
   writer->printf("Tx err:    %20d\n",sbus->m_status.errors_tx);
   writer->printf("Rx invalid:%20d\n",sbus->m_status.invalid_rx);
   writer->printf("Wdg Resets:%20d\n",sbus->m_status.watchdog_resets);
   if (sbus->m_watchdog_timer>0)
     {
-    writer->printf("Wdg Timer: %20d sec(s)\n",monotonictime-sbus->m_watchdog_timer);
+    writer->printf("Wdg Timer: %20" PRId32 " sec(s)\n",monotonictime-sbus->m_watchdog_timer);
     }
   writer->printf("Err Resets:%20d\n",sbus->m_status.error_resets);
   }
@@ -636,8 +636,8 @@ void canbus::LogStatus(CAN_log_type_t type)
     if (!StatusChanged())
       return;
     ESP_LOGE(TAG,
-      "%s: intr=%d rxpkt=%d txpkt=%d errflags=%#x rxerr=%d txerr=%d rxinval=%d"
-      " rxovr=%d txovr=%d txdelay=%d txfail=%d wdgreset=%d errreset=%d",
+      "%s: intr=%" PRId32 " rxpkt=%" PRId32 " txpkt=%" PRId32 " errflags=%#" PRIx32 " rxerr=%d txerr=%d rxinval=%d"
+      " rxovr=%d txovr=%d txdelay=%" PRId32 " txfail=%" PRId32 " wdgreset=%d errreset=%d",
       m_name, m_status.interrupts, m_status.packets_rx, m_status.packets_tx,
       m_status.error_flags, m_status.errors_rx, m_status.errors_tx,
       m_status.invalid_rx, m_status.rxbuf_overflow, m_status.txbuf_overflow,

--- a/vehicle/OVMS.V3/components/can/src/canformat_crtd.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_crtd.cpp
@@ -69,7 +69,7 @@ std::string canformat_crtd::get(CAN_log_message_t* message)
     {
     case CAN_LogFrame_RX:
     case CAN_LogFrame_TX:
-      snprintf(buf,sizeof(buf),"%ld.%06ld %c%c%s %0*X",
+      snprintf(buf,sizeof(buf),"%l" PRId32 ".%06ld %c%c%s %0*" PRIX32,
         message->timestamp.tv_sec, message->timestamp.tv_usec,
         busnumber,
         (message->type == CAN_LogFrame_RX) ? 'R' : 'T',
@@ -87,7 +87,7 @@ std::string canformat_crtd::get(CAN_log_message_t* message)
 
     case CAN_LogFrame_TX_Queue:
     case CAN_LogFrame_TX_Fail:
-      snprintf(buf,sizeof(buf),"%ld.%06ld %cCER %s %c%s %0*X",
+      snprintf(buf,sizeof(buf),"%l" PRId32 ".%06ld %cCER %s %c%s %0*" PRIX32,
         message->timestamp.tv_sec, message->timestamp.tv_usec,
         busnumber,
         GetCanLogTypeName(message->type),
@@ -107,8 +107,8 @@ std::string canformat_crtd::get(CAN_log_message_t* message)
     case CAN_LogStatus_Error:
     case CAN_LogStatus_Statistics:
       snprintf(buf,sizeof(buf),
-        "%ld.%06ld %c%s %s intr=%d rxpkt=%d txpkt=%d errflags=%#x rxerr=%d txerr=%d"
-        " rxinval=%d rxovr=%d txovr=%d txdelay=%d txfail=%d wdgreset=%d errreset=%d",
+        "%l" PRId32 ".%06ld %c%s %s intr=%" PRId32 " rxpkt=%" PRId32 " txpkt=%" PRId32 " errflags=%#" PRIx32 " rxerr=%d txerr=%d"
+        " rxinval=%d rxovr=%d txovr=%d txdelay=%" PRId32 " txfail=%" PRId32 " wdgreset=%d errreset=%d",
         message->timestamp.tv_sec, message->timestamp.tv_usec,
         busnumber,
         (message->type == CAN_LogStatus_Error) ? "CER" : "CST",
@@ -124,7 +124,7 @@ std::string canformat_crtd::get(CAN_log_message_t* message)
     case CAN_LogInfo_Config:
     case CAN_LogInfo_Event:
     case CAN_LogInfo_Metric:
-      snprintf(buf,sizeof(buf),"%ld.%06ld %c%s %s %s",
+      snprintf(buf,sizeof(buf),"%l" PRId32 ".%06ld %c%s %s %s",
         message->timestamp.tv_sec, message->timestamp.tv_usec,
         busnumber,
         (message->type == CAN_LogInfo_Event) ? "CEV" : (message->type == CAN_LogInfo_Metric) ? "CMT" : "CXX",
@@ -152,7 +152,7 @@ std::string canformat_crtd::getheader(struct timeval *time)
     time = &t;
     }
 
-  snprintf(buf,sizeof(buf),"%ld.%06ld CXX OVMS CRTD\n%ld.%06ld CVR 3.1\n",
+  snprintf(buf,sizeof(buf),"%l" PRId32 ".%06ld CXX OVMS CRTD\n%l" PRId32 ".%06ld CVR 3.1\n",
     time->tv_sec, time->tv_usec,
     time->tv_sec, time->tv_usec);
 

--- a/vehicle/OVMS.V3/components/can/src/canformat_gvret.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_gvret.cpp
@@ -99,7 +99,7 @@ std::string canformat_gvret_ascii::get(CAN_log_message_t* message)
 
   char busnumber = (message->origin != NULL)?message->origin->m_busnumber + '0':'0';
 
-  sprintf(buf,"%u - %x %s %c %d",
+  sprintf(buf,"%" PRIu32 " - %" PRIx32 " %s %c %d",
     (uint32_t)((message->timestamp.tv_sec * 1000000) + message->timestamp.tv_usec),
     message->frame.MsgID,
     (message->frame.FIR.B.FF == CAN_frame_std) ? "S" : "X",
@@ -275,7 +275,7 @@ size_t canformat_gvret_binary::put(CAN_log_message_t* message, uint8_t *buffer, 
             msg.FIR.B.DLC = m.body.build_can_frame.length;
             memcpy(&msg.data, &m.body.build_can_frame.data, m.body.build_can_frame.length);
 
-            ESP_LOGD(TAG,"Rx BUILD_CAN_FRAME ID=%0x",msg.MsgID);
+            ESP_LOGD(TAG,"Rx BUILD_CAN_FRAME ID=%0" PRIx32,msg.MsgID);
             *hasmore = true;  // Call us again to see if we have more frames to process
             // We have a frame to be transmitted / simulated
             switch (m_servemode)

--- a/vehicle/OVMS.V3/components/can/src/canformat_lawicel.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_lawicel.cpp
@@ -72,11 +72,11 @@ std::string canformat_lawicel::get(CAN_log_message_t* message)
 
   if (message->frame.FIR.B.FF == CAN_frame_std)
     {
-    sprintf(buf,"t%03x%01d",message->frame.MsgID, message->frame.FIR.B.DLC);
+    sprintf(buf,"t%03" PRIx32 "%01d",message->frame.MsgID, message->frame.FIR.B.DLC);
     }
   else
     {
-    sprintf(buf,"T%08x%01d",message->frame.MsgID, message->frame.FIR.B.DLC);
+    sprintf(buf,"T%08" PRIx32 "%01d",message->frame.MsgID, message->frame.FIR.B.DLC);
     }
 
   for (int k=0; k<message->frame.FIR.B.DLC; k++)

--- a/vehicle/OVMS.V3/components/can/src/canformat_pcap.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_pcap.cpp
@@ -135,7 +135,7 @@ size_t canformat_pcap::put(CAN_log_message_t* message, uint8_t *buffer, size_t l
            (magic == 0xa1b23c4d)||
            (magic == 0x4d3cb2a1))
     {
-    ESP_LOGE(TAG,"pcap format %08x not supported: Discarding",magic);
+    ESP_LOGE(TAG,"pcap format %08" PRIx32 " not supported: Discarding",magic);
     SetServeDiscarding(true);
     return consumed;
     }

--- a/vehicle/OVMS.V3/components/can/src/canlog.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog.cpp
@@ -121,7 +121,7 @@ void can_log_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int arg
     for (can::canlog_map_t::iterator it=MyCan.m_loggermap.begin(); it!=MyCan.m_loggermap.end(); ++it)
       {
       canlog* cl = it->second;
-      writer->printf("#%d: %s %s %s\n",
+      writer->printf("#%" PRId32 ": %s %s %s\n",
         it->first,
         (cl->m_isopen)?"open":"closed",
         cl->GetInfo().c_str(), cl->GetStats().c_str());
@@ -159,7 +159,7 @@ void can_log_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc,
     for (can::canlog_map_t::iterator it=MyCan.m_loggermap.begin(); it!=MyCan.m_loggermap.end(); ++it)
       {
       canlog* cl = it->second;
-      writer->printf("#%d: %s\n", it->first, cl->GetInfo().c_str());
+      writer->printf("#%" PRId32 ": %s\n", it->first, cl->GetInfo().c_str());
       }
     }
   }

--- a/vehicle/OVMS.V3/components/can/src/canplay.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canplay.cpp
@@ -99,7 +99,7 @@ void can_play_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int ar
     for (can::canplay_map_t::iterator it=MyCan.m_playermap.begin(); it!=MyCan.m_playermap.end(); ++it)
       {
       canplay* cl = it->second;
-      writer->printf("CAN player #%d: %s\n  Statistics: %s\n",
+      writer->printf("CAN player #%" PRId32 ": %s\n  Statistics: %s\n",
         it->first, cl->GetInfo().c_str(), cl->GetStats().c_str());
       }
     }
@@ -119,7 +119,7 @@ void can_play_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
     for (can::canplay_map_t::iterator it=MyCan.m_playermap.begin(); it!=MyCan.m_playermap.end(); ++it)
       {
       canplay* cl = it->second;
-      writer->printf("#%d: %s\n", it->first, cl->GetInfo().c_str());
+      writer->printf("#%" PRId32 ": %s\n", it->first, cl->GetInfo().c_str());
       }
     }
   }
@@ -154,7 +154,7 @@ void can_play_speed(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int arg
       {
       canplay* cl = it->second;
       cl->SetSpeed(atoi(argv[0]));
-      writer->printf("CAN player #%d: %s\n  Statistics: %s\n",
+      writer->printf("CAN player #%" PRId32 ": %s\n  Statistics: %s\n",
         it->first, cl->GetInfo().c_str(), cl->GetStats().c_str());
       }
     }

--- a/vehicle/OVMS.V3/components/canopen/src/canopen_shell.cpp
+++ b/vehicle/OVMS.V3/components/canopen/src/canopen_shell.cpp
@@ -187,7 +187,7 @@ void CANopen::shell_readsdo(int verbosity, OvmsWriter* writer, OvmsCommand* cmd,
     if (i == job.sdo.xfersize)
       buffer.txt[i] = 0;
     
-    writer->printf("ReadSDO #%d 0x%04x.%02x: contsize=%d xfersize=%d dec=%d hex=0x%0*x str='%s'\n",
+    writer->printf("ReadSDO #%d 0x%04x.%02x: contsize=%d xfersize=%d dec=%" PRId32 " hex=0x%0*" PRIx32 " str='%s'\n",
       nodeid, index, subindex, job.sdo.contsize, job.sdo.xfersize,
       buffer.num, MIN(job.sdo.xfersize,4)*2, buffer.num, show_txt ? buffer.txt : "(binary)");
     }
@@ -275,10 +275,10 @@ void CANopen::shell_writesdo(int verbosity, OvmsWriter* writer, OvmsCommand* cmd
   switch (buftype)
     {
     case 'H':
-      writer->printf("WriteSDO #%d 0x%04x.%02x: hex=0x%08x => ", nodeid, index, subindex, buffer.num);
+      writer->printf("WriteSDO #%d 0x%04x.%02x: hex=0x%08" PRIx32 " => ", nodeid, index, subindex, buffer.num);
       break;
     case 'D':
-      writer->printf("WriteSDO #%d 0x%04x.%02x: dec=%d => ", nodeid, index, subindex, buffer.num);
+      writer->printf("WriteSDO #%d 0x%04x.%02x: dec=%" PRId32 " => ", nodeid, index, subindex, buffer.num);
       break;
     default:
       writer->printf("WriteSDO #%d 0x%04x.%02x: len=%d str='%s' => ", nodeid, index, subindex, bufsize, buffer.txt);
@@ -345,21 +345,21 @@ int CANopen::PrintNodeInfo(int capacity, OvmsWriter* writer, canbus* bus, int no
   if (brief)
     {
     if (written < capacity) written += writer->printf(
-      "#%d: DT=%08x ER=%02x VI=%08x\n"
+      "#%d: DT=%08" PRIx32 " ER=%02x VI=%08" PRIx32 "\n"
       , nodeid, device_type, error_register, vendor_id);
     }
   else
     {
     if (written < capacity) written += writer->printf(
       "Node #%d:\n"
-      " Device type: 0x%08x\n"
+      " Device type: 0x%08" PRIx32 "\n"
       " Error state: 0x%02x\n"
-      " Vendor ID: 0x%08x\n"
+      " Vendor ID: 0x%08" PRIx32 "\n"
       , nodeid, device_type, error_register, vendor_id);
     if (written < capacity) written += writer->printf(
-      " Product: 0x%08x\n"
-      " Revision: 0x%08x\n"
-      " S/N: 0x%08x\n"
+      " Product: 0x%08" PRIx32 "\n"
+      " Revision: 0x%08" PRIx32 "\n"
+      " S/N: 0x%08" PRIx32 "\n"
       , product_code, revision_number, serial_number);
     if (written < capacity) written += writer->printf(
       " Device name: %s\n"

--- a/vehicle/OVMS.V3/components/canopen/src/canopen_worker.cpp
+++ b/vehicle/OVMS.V3/components/canopen/src/canopen_worker.cpp
@@ -136,11 +136,11 @@ void CANopenWorker::StatusReport(int verbosity, OvmsWriter* writer)
     "  %s:\n"
     "    Active clients: %d\n"
     "    Jobs waiting  : %d\n"
-    "    Jobs processed: %d\n"
-    "    - timeouts    : %d\n"
-    "    - other errors: %d\n"
-    "    NMT received  : %d\n"
-    "    EMCY received : %d\n"
+    "    Jobs processed: %" PRId32 "\n"
+    "    - timeouts    : %" PRId32 "\n"
+    "    - other errors: %" PRId32 "\n"
+    "    NMT received  : %" PRId32 "\n"
+    "    EMCY received : %" PRId32 "\n"
     , m_bus->GetName()
     , m_clientcnt
     , (int)uxQueueMessagesWaiting(m_jobqueue)
@@ -574,7 +574,7 @@ CANopenResult_t CANopenWorker::ProcessReadSDOJob()
       m_job.sdo.error = m_response.ctl.data;
     else
       m_job.sdo.error = CANopen_BusCollision;
-    ESP_LOGD(TAG, "ReadSDO #%d 0x%04x.%02x: InitUpload failed, CANopen error code 0x%08x",
+    ESP_LOGD(TAG, "ReadSDO #%d 0x%04x.%02x: InitUpload failed, CANopen error code 0x%08" PRIx32,
       m_job.sdo.nodeid, m_job.sdo.index, m_job.sdo.subindex, m_job.sdo.error);
     return COR_ERR_SDO_Access;
     }
@@ -723,7 +723,7 @@ CANopenResult_t CANopenWorker::ProcessWriteSDOJob()
       m_job.sdo.error = m_response.ctl.data;
     else
       m_job.sdo.error = CANopen_BusCollision;
-    ESP_LOGD(TAG, "WriteSDO #%d 0x%04x.%02x: InitDownload failed, CANopen error code 0x%08x",
+    ESP_LOGD(TAG, "WriteSDO #%d 0x%04x.%02x: InitDownload failed, CANopen error code 0x%08" PRIx32,
       m_job.sdo.nodeid, m_job.sdo.index, m_job.sdo.subindex, m_job.sdo.error);
     return COR_ERR_SDO_Access;
     }

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
@@ -836,11 +836,11 @@ dbcNumber dbcSignal::Decode(CAN_frame_t* msg)
   }
 
   // Apply factor and offset
-  if (!(m_factor == 1))
+  if (!(m_factor == (uint32_t)1))
     {
     result = (result * m_factor);
     }
-  if (!(m_offset == 0))
+  if (!(m_offset == (uint32_t)0))
     {
     result = (result + m_offset);
     }

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
@@ -403,7 +403,7 @@ void dbcBitTiming::WriteFile(dbcOutputCallback callback, void* param)
   if (m_baudrate != 0)
     {
     char buf[64];
-    sprintf(buf,"%u:%u,%u",m_baudrate,m_btr1,m_btr2);
+    sprintf(buf,"%" PRIu32 ":%" PRIu32 ",%" PRIu32,m_baudrate,m_btr1,m_btr2);
     callback(param, buf);
     }
   callback(param, "\n\n");
@@ -504,7 +504,7 @@ void dbcValueTable::WriteFile(dbcOutputCallback callback, void* param, const cha
        it++)
     {
     char buf[40];
-    sprintf(buf," %d \"",it->first);
+    sprintf(buf," %" PRId32 " \"",it->first);
     callback(param,buf);
     callback(param,it->second.c_str());
     callback(param,"\"");

--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -691,7 +691,7 @@ void esp32can::BusTicker10(std::string event, void* data)
   if ((m_status.error_flags >> 16 == __CAN_IRQ_ERR_WARNING) &&
       (monotonictime - m_status.error_time >= 10))
     {
-    ESP_LOGE(TAG, "%s stuck bus-off error state (errflags=0x%08x) detected - resetting bus",
+    ESP_LOGE(TAG, "%s stuck bus-off error state (errflags=0x%08" PRIx32 ") detected - resetting bus",
              m_name, m_status.error_flags);
     Reset();
     m_status.error_flags = 0;

--- a/vehicle/OVMS.V3/components/obd2ecu/src/obd2ecu.cpp
+++ b/vehicle/OVMS.V3/components/obd2ecu/src/obd2ecu.cpp
@@ -489,7 +489,7 @@ void obd2ecu::IncomingFrame(CAN_frame_t* p_frame)
   uint8_t *p_d = p_frame->data.u8;  /* Incoming frame data from HUD / Dongle */
   uint8_t *r_d = r_frame.data.u8;  /* Response frame data being sent back to HUD / Dongle */
 
-  ESP_LOGD(TAG, "Rcv %x: %x (%x %x %x %x %x %x %x %x)",
+  ESP_LOGD(TAG, "Rcv %" PRIx32 ": %x (%x %x %x %x %x %x %x %x)",
                       p_frame->MsgID,
                       p_frame->FIR.B.DLC,
                       p_d[0],p_d[1],p_d[2],p_d[3],p_d[4],p_d[5],p_d[6],p_d[7]);
@@ -504,7 +504,7 @@ void obd2ecu::IncomingFrame(CAN_frame_t* p_frame)
            return;  /* ignore it.  We just sleep for a bit instead */
          }
          /* if none of the above, no idea what it is.  Ignore */
-         ESP_LOGD(TAG, "unknown MsgID %x",p_frame->MsgID);
+         ESP_LOGD(TAG, "unknown MsgID %" PRIx32,p_frame->MsgID);
          return;
        }
 
@@ -834,7 +834,7 @@ void obd2ecu::Addpid(uint8_t pid)
 
   if(pid <= 0x20)       // PIDs 1-20
   { m_supported_01_20 |= 1 << (32-pid);
-    ESP_LOGD(TAG, "Added 0x%02x resulting 0x%08x",pid,m_supported_01_20);
+    ESP_LOGD(TAG, "Added 0x%02x resulting 0x%08" PRIx32,pid,m_supported_01_20);
     return;
   }
 

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -456,10 +456,10 @@ void modem::SupportSummary(OvmsWriter* writer, bool debug /*=FALSE*/)
     if (debug)
       {
       writer->printf("    Open Channels: %d\n", m_mux->m_openchannels);
-      writer->printf("    Framing Errors: %d\n", m_mux->m_framingerrors);
-      writer->printf("    RX frames: %d\n", m_mux->m_rxframecount);
-      writer->printf("    TX frames: %d\n", m_mux->m_txframecount);
-      writer->printf("    Last RX frame: %d sec(s) ago\n", m_mux->GoodFrameAge());
+      writer->printf("    Framing Errors: %" PRId32 "\n", m_mux->m_framingerrors);
+      writer->printf("    RX frames: %" PRId32 "\n", m_mux->m_rxframecount);
+      writer->printf("    TX frames: %" PRId32 "\n", m_mux->m_txframecount);
+      writer->printf("    Last RX frame: %" PRId32 " sec(s) ago\n", m_mux->GoodFrameAge());
       }
     }
   else

--- a/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
+++ b/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
@@ -442,7 +442,7 @@ void ota_boot(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
     switch (err)
       {
       case ESP_OK:
-        writer->printf("Boot from %s at 0x%08x (size 0x%08x)\n",p->label,p->address,p->size);
+        writer->printf("Boot from %s at 0x%08" PRIx32 " (size 0x%08" PRIx32 ")\n",p->label,p->address,p->size);
         break;
       case ESP_ERR_INVALID_ARG:
         writer->puts("Error: partition argument didn't point to a valid OTA partition of type 'app'");
@@ -580,7 +580,7 @@ void ota_copy(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
     return;
     }
 
-  writer->printf("OTA copy %s (%08x) -> %s (%08x) size %u\n",
+  writer->printf("OTA copy %s (%08" PRIu32 ") -> %s (%08" PRIx32 ") size %" PRIu32 "\n",
     fn.c_str(), from_p->address,
     tn.c_str(), to_p->address, to_p->size);
 

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duktape.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duktape.cpp
@@ -1427,7 +1427,7 @@ void OvmsDuktape::DukTapeTask()
             uint32_t ts = esp_log_timestamp();
             duk_gc(m_dukctx, 0);
             duk_gc(m_dukctx, 0);
-            ESP_LOGD(TAG, "Duktape: Compacting DukTape memory done in %u ms", esp_log_timestamp()-ts);
+            ESP_LOGD(TAG, "Duktape: Compacting DukTape memory done in %" PRIu32 " ms", esp_log_timestamp()-ts);
             }
           }
           break;
@@ -1451,7 +1451,7 @@ void OvmsDuktape::DukTapeTask()
             duk_pop_2(m_dukctx);
             ts = esp_log_timestamp() - ts;
             if (ts > 1000)
-              ESP_LOGW(TAG, "Duktape: event handling for '%s' took %u ms", msg.body.dt_event.name, ts);
+              ESP_LOGW(TAG, "Duktape: event handling for '%s' took %" PRIu32 " ms", msg.body.dt_event.name, ts);
             }
           }
           free((void*)msg.body.dt_event.name);

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -1738,7 +1738,7 @@ void OvmsServerV2::TransmitNotifyData()
     size += buffer.str().size();
     if (now - starttime >= 300 || cnt == 5 || size >= 4000)
       {
-      ESP_LOGD(TAG, "TransmitNotifyData: used %d ms for %d records, %u bytes", now - starttime, cnt, size);
+      ESP_LOGD(TAG, "TransmitNotifyData: used %" PRId32 " ms for %d records, %u bytes", now - starttime, cnt, size);
       return;
       }
     }

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_websockethandler.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_websockethandler.cpp
@@ -496,7 +496,7 @@ int WebSocketHandler::HandleEvent(int ev, void* p)
         }
         else {
           uint32_t dropcnt = m_jobqueue_overflow_dropcnt;
-          ESP_LOGW(TAG, "WebSocketHandler[%p]: job queue overflow resolved, %u drops", m_nc, dropcnt - m_jobqueue_overflow_dropcntref);
+          ESP_LOGW(TAG, "WebSocketHandler[%p]: job queue overflow resolved, %" PRIu32 " drops", m_nc, dropcnt - m_jobqueue_overflow_dropcntref);
           m_jobqueue_overflow_dropcntref = dropcnt;
         }
       }

--- a/vehicle/OVMS.V3/components/pushover/src/pushover.cpp
+++ b/vehicle/OVMS.V3/components/pushover/src/pushover.cpp
@@ -297,10 +297,10 @@ static void PushoverMongooseCallback(struct mg_connection *nc, int ev, void *p)
       MyPushoverClient.m_mgconn_mutex.Unlock();
       break;
     case MG_EV_SEND:
-      ESP_LOGD(TAG, "PushoverMongooseCallback(MG_EV_SEND) %d bytes",*(uint32_t*)p);
+      ESP_LOGD(TAG, "PushoverMongooseCallback(MG_EV_SEND) %" PRId32 " bytes",*(uint32_t*)p);
       break;
     case MG_EV_RECV:
-      ESP_LOGD(TAG, "PushoverMongooseCallback(MG_EV_RECV) %d bytes",*(uint32_t*)p);
+      ESP_LOGD(TAG, "PushoverMongooseCallback(MG_EV_RECV) %" PRId32 " bytes",*(uint32_t*)p);
       mbuf_remove(&nc->recv_mbuf, MyPushoverClient.IncomingData((uint8_t*)nc->recv_mbuf.buf, nc->recv_mbuf.len));
       break;
     case MG_EV_POLL:

--- a/vehicle/OVMS.V3/components/retools/src/retools.cpp
+++ b/vehicle/OVMS.V3/components/retools/src/retools.cpp
@@ -218,9 +218,9 @@ std::string re::GetKey(CAN_frame_t* frame)
 
   char id[9];
   if (frame->FIR.B.FF == CAN_frame_std)
-    sprintf(id,"%03x",frame->MsgID);
+    sprintf(id,"%03" PRIx32,frame->MsgID);
   else
-    sprintf(id,"%08x",frame->MsgID);
+    sprintf(id,"%08" PRIx32,frame->MsgID);
   key.append(id);
 
   if (((m_obdii_std_min>0) &&
@@ -275,7 +275,7 @@ std::string re::GetKey(CAN_frame_t* frame)
         dbcNumber muxn = s->Decode(frame);
         uint32_t mux = muxn.GetUnsignedInteger();
         char b[8];
-        sprintf(b,":%04x",mux);
+        sprintf(b,":%04" PRIx32,mux);
         key.append(b);
         }
       }
@@ -418,7 +418,7 @@ void re_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, cons
       char vbuf[48];
       char *s = vbuf;
       FormatHexDump(&s, (const char*)it->second->last.data.u8, it->second->last.FIR.B.DLC, 8);
-      writer->printf("%-20s %10d %6d %s\n",
+      writer->printf("%-20s %10" PRId32 " %6" PRId32 " %s\n",
         it->first.c_str(),it->second->rxcount,(tdiff/it->second->rxcount),vbuf);
       }
     }
@@ -446,7 +446,7 @@ void re_stream_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int arg
       {
       HighlightDump(vbuf, (const char*)it->second->last.data.u8,
         it->second->last.FIR.B.DLC, it->second->attr.dc, it->second->attr.dd, 1, &ascii);
-      writer->printf("%s[\"%s\",%d,%d,\"%s\",\"%s\"]\n",
+      writer->printf("%s[\"%s\",%" PRId32 ",%" PRId32 ",\"%s\",\"%s\"]\n",
         cnt ? "," : "",
         json_encode(it->first).c_str(), it->second->rxcount, (tdiff/it->second->rxcount),
         json_encode(std::string(vbuf)).c_str(),
@@ -477,7 +477,7 @@ void re_dbc_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
       char vbuf[48];
       char *s = vbuf;
       FormatHexDump(&s, (const char*)it->second->last.data.u8, it->second->last.FIR.B.DLC, 8);
-      writer->printf("%-20s %10d %6d %s\n",
+      writer->printf("%-20s %10" PRId32 " %6" PRId32 " %s\n",
         it->first.c_str(),it->second->rxcount,(tdiff/it->second->rxcount),vbuf);
       if (it->second->last.origin)
         {
@@ -590,7 +590,7 @@ void re_obdii_std(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc,
   MyRE->m_obdii_std_min = (uint32_t)strtol(argv[0],NULL,16);
   MyRE->m_obdii_std_max = (uint32_t)strtol(argv[1],NULL,16);
 
-  writer->printf("Set OBDII standard ID range %03x-%03x\n",MyRE->m_obdii_std_min,MyRE->m_obdii_std_max);
+  writer->printf("Set OBDII standard ID range %03" PRIx32 "-%03" PRIx32 "\n",MyRE->m_obdii_std_min,MyRE->m_obdii_std_max);
   }
 
 void re_obdii_ext(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
@@ -604,7 +604,7 @@ void re_obdii_ext(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc,
   MyRE->m_obdii_ext_min = (uint32_t)strtol(argv[0],NULL,16);
   MyRE->m_obdii_ext_max = (uint32_t)strtol(argv[1],NULL,16);
 
-  writer->printf("Set OBDII extended ID range %08x-%08x\n",MyRE->m_obdii_ext_min,MyRE->m_obdii_ext_max);
+  writer->printf("Set OBDII extended ID range %08" PRIx32 "-%08" PRIx32 "\n",MyRE->m_obdii_ext_min,MyRE->m_obdii_ext_max);
   }
 
 void re_mode_analyse(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
@@ -714,7 +714,7 @@ void re_list_changed(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int ar
         it->second->last.FIR.B.DLC, it->second->attr.dc, it->second->attr.dd);
       if ((argc==0)||(strstr(it->first.c_str(),argv[0])))
         {
-        writer->printf("%-20s %10d %6d %s\n",
+        writer->printf("%-20s %10" PRId32 " %6" PRId32 " %s\n",
           it->first.c_str(),it->second->rxcount,(tdiff/it->second->rxcount),vbuf);
         }
       }
@@ -744,7 +744,7 @@ void re_stream_changed(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int 
       {
       HighlightDump(vbuf, (const char*)it->second->last.data.u8,
         it->second->last.FIR.B.DLC, it->second->attr.dc, it->second->attr.dd, 1, &ascii);
-      writer->printf("%s[\"%s\",%d,%d,\"%s\",\"%s\"]\n",
+      writer->printf("%s[\"%s\",%" PRId32 ",%" PRId32 ",\"%s\",\"%s\"]\n",
         cnt ? "," : "",
         json_encode(it->first).c_str(), it->second->rxcount, (tdiff/it->second->rxcount),
         json_encode(std::string(vbuf)).c_str(),
@@ -777,7 +777,7 @@ void re_list_discovered(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int
         it->second->last.FIR.B.DLC, it->second->attr.dc, it->second->attr.dd);
       if ((argc==0)||(strstr(it->first.c_str(),argv[0])))
         {
-        writer->printf("%-20s %10d %6d %s\n",
+        writer->printf("%-20s %10" PRId32 " %6" PRId32 " %s\n",
           it->first.c_str(),it->second->rxcount,(tdiff/it->second->rxcount),vbuf);
         }
       }

--- a/vehicle/OVMS.V3/components/retools_pidscan/src/retools_pid.cpp
+++ b/vehicle/OVMS.V3/components/retools_pidscan/src/retools_pid.cpp
@@ -523,13 +523,13 @@ void OvmsReToolsPidScanner::IncomingPollFrame(const CAN_frame_t* frame)
         if (data[2] == UDS_RESP_NRC_RCRRP)
         {
             // ResponsePending: ignore, keep waiting
-            ESP_LOGD(TAG, "ResponsePending from %x[%x]:%x",
+            ESP_LOGD(TAG, "ResponsePending from %" PRIx16 "[%" PRIx32 "]:%x",
               m_id, frame->MsgID, m_currentPid);
         }
         else
         {
             // …other negative response code:
-            ESP_LOGD(TAG, "Negative response from %x[%x]:%x code %02x",
+            ESP_LOGD(TAG, "Negative response from %" PRIx16 "[%" PRIx32 "]:%x code %02" PRIx8,
               m_id, frame->MsgID, m_currentPid, data[2]);
             SendNextFrame();
         }
@@ -556,7 +556,7 @@ void OvmsReToolsPidScanner::IncomingPollFrame(const CAN_frame_t* frame)
         {
             ESP_LOGD(
                 TAG,
-                "Success response from %x[%x]:%x length %d (0x%02x 0x%02x 0x%02x 0x%02x%s)",
+                "Success response from %" PRIx16 "[%" PRIx32 "]:%x length %" PRId16 " (0x%02" PRIx8 " 0x%02" PRIx8 " 0x%02" PRIx8 " 0x%02" PRIx8 "%s)",
                 m_id, frame->MsgID, m_currentPid, payloadLength, payload[0], payload[1], payload[2], payload[3],
                 (frameType == 0 ? "" : " ...")
             );

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
@@ -57,7 +57,7 @@ void OvmsVehicle::PollerISOTPStart(bool fromTicker)
     m_poll_moduleid_high = 0x7ef;
     }
 
-  ESP_LOGD(TAG, "PollerISOTPStart(%d): send [bus=%d, type=%02X, pid=%X], expecting %03x/%03x-%03x",
+  ESP_LOGD(TAG, "PollerISOTPStart(%d): send [bus=%d, type=%02X, pid=%X], expecting %03" PRIx32 "/%03" PRIx32 "-%03" PRIx32,
            fromTicker, m_poll_plcur->pollbus, m_poll_type, m_poll_pid, m_poll_moduleid_sent,
            m_poll_moduleid_low, m_poll_moduleid_high);
 
@@ -182,7 +182,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
   if (!m_poll_wait || !m_poll_plist || frame->origin != m_poll_bus ||
       msgid < m_poll_moduleid_low || msgid > m_poll_moduleid_high)
     {
-    ESP_LOGD(TAG, "PollerISOTPReceive[%03X]: dropping expired poll response", msgid);
+    ESP_LOGD(TAG, "PollerISOTPReceive[%03" PRIX32 "]: dropping expired poll response", msgid);
     return false;
     }
 
@@ -245,7 +245,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
       // This is most likely an indication there is a non ISO-TP device sending
       // in our expected RX ID range, so we log the frame and abort:
       FormatHexDump(&hexdump, (const char*)frame->data.u8, 8, 8);
-      ESP_LOGW(TAG, "PollerISOTPReceive[%03X]: ignoring unknown/invalid ISO TP frame: %s",
+      ESP_LOGW(TAG, "PollerISOTPReceive[%03" PRIX32 "]: ignoring unknown/invalid ISO TP frame: %s",
                msgid, hexdump ? hexdump : "-");
       if (hexdump) free(hexdump);
       return false;
@@ -258,7 +258,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
     if (tp_fc_command > 2 || m_poll_tx_remain == 0)
       {
       FormatHexDump(&hexdump, (const char*)frame->data.u8, 8, 8);
-      ESP_LOGW(TAG, "PollerISOTPReceive[%03X]: ignoring unexpected/invalid ISO TP flow control frame: %s",
+      ESP_LOGW(TAG, "PollerISOTPReceive[%03" PRIX32 "]: ignoring unexpected/invalid ISO TP flow control frame: %s",
               msgid, hexdump ? hexdump : "-");
       if (hexdump) free(hexdump);
       return false;
@@ -360,7 +360,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
     if (m_poll_ml_remain == 0 || tp_frameindex > (m_poll_ml_frame & 0x0f))
       {
       FormatHexDump(&hexdump, (const char*)frame->data.u8, 8, 8);
-      ESP_LOGW(TAG, "PollerISOTPReceive[%03X]: unexpected/out of sequence ISO TP frame (%d vs %d), aborting poll %02X(%X): %s",
+      ESP_LOGW(TAG, "PollerISOTPReceive[%03" PRIX32 "]: unexpected/out of sequence ISO TP frame (%d vs %d), aborting poll %02X(%X): %s",
               msgid, tp_frameindex, m_poll_ml_frame & 0x0f, m_poll_type, m_poll_pid,
               hexdump ? hexdump : "-");
       if (hexdump) free(hexdump);
@@ -428,7 +428,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
     if (error_code == UDS_RESP_NRC_RCRRP)
       {
       // Info: requestCorrectlyReceived-ResponsePending (server busy processing the request)
-      ESP_LOGD(TAG, "PollerISOTPReceive[%03X]: got OBD/UDS info %02X(%X) code=%02X (pending)",
+      ESP_LOGD(TAG, "PollerISOTPReceive[%03" PRIX32 "]: got OBD/UDS info %02X(%X) code=%02X (pending)",
                msgid, m_poll_type, m_poll_pid, error_code);
       // add some wait time:
       m_poll_wait++;
@@ -437,7 +437,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
     else
       {
       // Error: forward to application:
-      ESP_LOGD(TAG, "PollerISOTPReceive[%03X]: process OBD/UDS error %02X(%X) code=%02X",
+      ESP_LOGD(TAG, "PollerISOTPReceive[%03" PRIX32 "]: process OBD/UDS error %02X(%X) code=%02X",
                msgid, m_poll_type, m_poll_pid, error_code);
       // Running single poll?
       if (m_poll_single_rxbuf)
@@ -458,7 +458,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
     {
     // Normal matching poll response, forward to application:
     m_poll_ml_remain = tp_len - tp_datalen;
-    ESP_LOGD(TAG, "PollerISOTPReceive[%03X]: process OBD/UDS response %02X(%X) frm=%u len=%u off=%u rem=%u",
+    ESP_LOGD(TAG, "PollerISOTPReceive[%03" PRIX32 "]: process OBD/UDS response %02X(%X) frm=%u len=%u off=%u rem=%u",
              msgid, m_poll_type, m_poll_pid,
              m_poll_ml_frame, response_datalen, m_poll_ml_offset, m_poll_ml_remain);
     // Running single poll?
@@ -486,7 +486,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
     {
     // This is most likely a late response to a previous poll, log & skip:
     FormatHexDump(&hexdump, (const char*)frame->data.u8, 8, 8);
-    ESP_LOGW(TAG, "PollerISOTPReceive[%03X]: OBD/UDS response type/PID mismatch, got %02X(%X) vs %02X(%X) => ignoring: %s",
+    ESP_LOGW(TAG, "PollerISOTPReceive[%03" PRIX32 "]: OBD/UDS response type/PID mismatch, got %02X(%X) vs %02X(%X) => ignoring: %s",
              msgid, response_type, response_pid, 0x40+m_poll_type, m_poll_pid, hexdump ? hexdump : "-");
     if (hexdump) free(hexdump);
     return false;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
@@ -471,7 +471,7 @@ bool OvmsVehicle::PollerVWTPReceive(CAN_frame_t* frame, uint32_t msgid)
         m_poll_vwtp.blocksize = frame->data.u8[1];
         m_poll_vwtp.acktime = (frame->data.u8[2] & 0b00111111) * timeunit[(frame->data.u8[2] & 0b11000000) >> 6];
         m_poll_vwtp.septime = (frame->data.u8[4] & 0b00111111) * timeunit[(frame->data.u8[4] & 0b11000000) >> 6];
-        ESP_LOGD(TAG, "PollerVWTPReceive[%02X]: channel params OK: bs=%d acktime=%uus septime=%uus",
+        ESP_LOGD(TAG, "PollerVWTPReceive[%02X]: channel params OK: bs=%d acktime=%" PRIu32 "us septime=%" PRIu32 "us",
           m_poll_vwtp.moduleid, m_poll_vwtp.blocksize, m_poll_vwtp.acktime, m_poll_vwtp.septime);
         // …and proceed to data transmission:
         PollerVWTPEnter(VWTP_StartPoll);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
@@ -623,7 +623,7 @@ void OvmsVehicleFactory::obdii_request(int verbosity, OvmsWriter* writer, OvmsCo
   int err = MyVehicleFactory.m_currentvehicle->PollSingleRequest(bus, txid, rxid,
     request, response, timeout_ms, protocol);
 
-  writer->printf("%x[%x] %s: ", txid, rxid, hexencode(request).c_str());
+  writer->printf("%" PRIx32 "[%" PRIx32 "] %s: ", txid, rxid, hexencode(request).c_str());
   if (err == POLLSINGLE_TXFAILURE)
     {
     writer->puts("ERROR: transmission failure (CAN bus error)");

--- a/vehicle/OVMS.V3/components/vehicle_boltev/src/va_ac_preheat.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_boltev/src/va_ac_preheat.cpp
@@ -229,7 +229,7 @@ void OvmsVehicleBoltEV::ClimateControlIncomingSWCAN(CAN_frame_t* p_frame)
     }
 
     if (unexpected_data)
-        ESP_LOGE(TAG,"IncomingFrameSWCan: Unexpected data! Id %08x: %02x %02x %02x %02x %02x %02x %02x %02x",
+        ESP_LOGE(TAG,"IncomingFrameSWCan: Unexpected data! Id %08" PRIx32 ": %02x %02x %02x %02x %02x %02x %02x %02x",
                  p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.cpp
@@ -233,15 +233,15 @@ void OvmsVehicleBoltEV::TxCallback(const CAN_frame_t* p_frame, bool success)
     const uint8_t *d = p_frame->data.u8;
     if (p_frame->MsgID == 0x7e4) {
         if (!success)
-            ESP_LOGE(TAG, "TxCallback. Error sending poll request. MsgId: 0x%x", p_frame->MsgID);
+            ESP_LOGE(TAG, "TxCallback. Error sending poll request. MsgId: 0x%" PRIx32, p_frame->MsgID);
         return;
     }
 
     if (success) {
-        ESP_LOGD(TAG,"TxCallback. Success. Frame %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]",
+        ESP_LOGD(TAG,"TxCallback. Success. Frame %08" PRIx32 ": [%02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 "]",
                  p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
     } else {
-        ESP_LOGE(TAG,"TxCallback. Failed! Frame %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]",
+        ESP_LOGE(TAG,"TxCallback. Failed! Frame %08" PRIx32 ": [%02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 "]",
                  p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
     }
 }
@@ -254,7 +254,7 @@ void OvmsVehicleBoltEV::IncomingFrameCan1(CAN_frame_t* p_frame)
 
     m_candata_timer = VA_CANDATA_TIMEOUT;
 
-    ESP_LOGV(TAG,"CAN1 message received: %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]",
+    ESP_LOGV(TAG,"CAN1 message received: %08" PRIx32 ": [%02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 "]",
              p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
 
     if ((p_frame->MsgID & 0xff8) == 0x7e8)
@@ -424,7 +424,7 @@ void OvmsVehicleBoltEV::IncomingFrameCan4(CAN_frame_t* p_frame)
 
     m_candata_timer = VA_CANDATA_TIMEOUT;
 
-    ESP_LOGV(TAG,"SW CAN message received: %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]",
+    ESP_LOGV(TAG,"SW CAN message received: %08" PRIx32 ": [%02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 "]",
              p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
 
     // Activity on the bus, so resume polling
@@ -1070,7 +1070,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleBoltEV::CommandUnlock(const char* pin)
 
 OvmsVehicle::vehicle_command_t OvmsVehicleBoltEV::CommandLights(va_light_t lights, bool turn_on)
 {
-    ESP_LOGI(TAG,"CommandLights: lights 0x%x:%d",(uint32_t)lights,turn_on);
+    ESP_LOGI(TAG,"CommandLights: lights 0x%" PRIx32 ":%d",(uint32_t)lights,turn_on);
     SendTesterPresentMessage(VA_BCM);
     vTaskDelay(200 / portTICK_PERIOD_MS);
 
@@ -1138,7 +1138,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleBoltEV::CommandLights(va_light_t light
 
     // Set the bitwise status of the lights that we control and are now ON. If any of these are set, we send periodic Tester Present messages
     m_controlled_lights = (m_controlled_lights & ~lights) | (lights*turn_on);
-    ESP_LOGI(TAG,"CommandLights: controlled_lights 0x%x",m_controlled_lights);
+    ESP_LOGI(TAG,"CommandLights: controlled_lights 0x%" PRIx32,m_controlled_lights);
     return Success;
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_can_poll.cpp
@@ -85,7 +85,7 @@ void OvmsHyundaiIoniqEv::IncomingPollReply(canbus *bus, uint16_t type, uint16_t 
       break;
 
     default:
-      ESP_LOGD(TAG, "Unknown module: %03x", m_poll_moduleid_low);
+      ESP_LOGD(TAG, "Unknown module: %03" PRIx32, m_poll_moduleid_low);
       XDISARM;
       return;
   }
@@ -103,7 +103,7 @@ void OvmsHyundaiIoniqEv::IncomingPollReply(canbus *bus, uint16_t type, uint16_t 
       obd_rxpid = pid;
       obd_frame = 0;
       rxbuf.clear();
-      ESP_LOGV(TAG, "IoniqISOTP: IPR %03x TYPE:%x PID: %03x Buffer: %d - Start",
+      ESP_LOGV(TAG, "IoniqISOTP: IPR %03" PRIx32 " TYPE:%x PID: %03x Buffer: %d - Start",
         m_poll_moduleid_low, type, pid, length + mlremain);
       rxbuf.reserve(length + mlremain);
     }
@@ -113,7 +113,7 @@ void OvmsHyundaiIoniqEv::IncomingPollReply(canbus *bus, uint16_t type, uint16_t 
         return; // Aborted
       }
       if ((obd_rxtype != type) || (obd_rxpid != pid) || (obd_module != m_poll_moduleid_low)) {
-        ESP_LOGD(TAG, "IoniqISOTP: IPR %03x TYPE:%x PID: %03x Dropped Frame",
+        ESP_LOGD(TAG, "IoniqISOTP: IPR %03" PRIx32 " TYPE:%x PID: %03x Dropped Frame",
           m_poll_moduleid_low, type, pid);
         XDISARM;
         return;
@@ -122,7 +122,7 @@ void OvmsHyundaiIoniqEv::IncomingPollReply(canbus *bus, uint16_t type, uint16_t 
       if (obd_frame != m_poll_ml_frame) {
         obd_frame = 0xffff;
         rxbuf.clear();
-        ESP_LOGD(TAG, "IoniqISOTP: IPR %03x TYPE:%x PID: %03x Skipped Frame: %d",
+        ESP_LOGD(TAG, "IoniqISOTP: IPR %03" PRIx32 " TYPE:%x PID: %03x Skipped Frame: %d",
           m_poll_moduleid_low, type, pid, obd_frame);
         XDISARM;
         return;
@@ -140,7 +140,7 @@ void OvmsHyundaiIoniqEv::IncomingPollReply(canbus *bus, uint16_t type, uint16_t 
       return;
     }
 
-    ESP_LOGD(TAG, "IoniqISOTP: IPR %03x TYPE:%x PID: %03x Frames: %d Message Size: %d",
+    ESP_LOGD(TAG, "IoniqISOTP: IPR %03" PRIx32 " TYPE:%x PID: %03x Frames: %d Message Size: %d",
       m_poll_moduleid_low, type, pid, obd_frame, rxbuf.size());
     ESP_BUFFER_LOGD(TAG, rxbuf.data(), rxbuf.size());
     switch (m_poll_moduleid_low) {
@@ -186,7 +186,7 @@ void OvmsHyundaiIoniqEv::IncomingCM_Full(canbus *bus, uint16_t type, uint16_t pi
       }
       else {
         StdMetrics.ms_v_pos_odometer->SetValue(value, GetConsoleUnits());
-        ESP_LOGD(TAG, "IoniqISOTP.CM: ODO : %d km", value);
+        ESP_LOGD(TAG, "IoniqISOTP.CM: ODO : %" PRId32 " km", value);
       }
     }
     break;
@@ -275,7 +275,7 @@ void OvmsHyundaiIoniqEv::IncomingVMCU_Full(canbus *bus, uint16_t type, uint16_t 
               iq_shift_status = IqShiftStatus::Reverse;
               break;
             default: // Other.
-              ESP_LOGI(TAG, "Unknown Gear selection %d", res & 0xf);
+              ESP_LOGI(TAG, "Unknown Gear selection %" PRId32, res & 0xf);
           }
           switch (iq_shift_status) {
             case IqShiftStatus::Park:
@@ -579,7 +579,7 @@ void OvmsHyundaiIoniqEv::IncomingBMC_Full(canbus *bus, uint16_t type, uint16_t p
             break;
           }
           BmsSetCellTemperature(5 + i, temp);
-          ESP_LOGV(TAG, "[%03d] T =%.2dC", 5 + i, temp);
+          ESP_LOGV(TAG, "[%03d] T =%.2" PRId32 "C", 5 + i, temp);
         }
       }
       break;
@@ -617,11 +617,11 @@ void OvmsHyundaiIoniqEv::IncomingBMC_Full(canbus *bus, uint16_t type, uint16_t p
         // It seems that the first 4 byte bitset indicate which cells are active.
         uint32_t present;
         if (! get_uint_buff_be<4>(data, 0, present)) {
-          ESP_LOGE(TAG, "IoniqISOTP.Battery Cells from %d : Bad Buffer", base);
+          ESP_LOGE(TAG, "IoniqISOTP.Battery Cells from %" PRId32 " : Bad Buffer", base);
 
           break; // Can't get subsequent data if this fails!!
         }
-        ESP_LOGV(TAG, "IoniqISOTP.Battery Cells Available from %d - %.8x ", base, present);
+        ESP_LOGV(TAG, "IoniqISOTP.Battery Cells Available from %" PRId32 " - %.8" PRIx32 " ", base, present);
 
         for (int32_t idx = 0; idx < 32; ++idx) {
           // Bitset is from high downto low, left to right.
@@ -634,7 +634,7 @@ void OvmsHyundaiIoniqEv::IncomingBMC_Full(canbus *bus, uint16_t type, uint16_t p
             }
 
             if (! get_uint_buff_be<1>(data, 4 + idx, value)) {
-              ESP_LOGE(TAG, "IoniqISOTP.Battery Cell %d : Bad Buffer", cellNo);
+              ESP_LOGE(TAG, "IoniqISOTP.Battery Cell %" PRId32 " : Bad Buffer", cellNo);
             }
             else {
               float voltage = (float)value * 0.02;

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
@@ -403,25 +403,25 @@ void xiq_tpms(int verbosity, OvmsWriter *writer, OvmsCommand *cmd, int argc, con
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
     const std::string &fl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", ToUser, 1);
     const std::string &fl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", ToUser, 1);
-    writer->printf("1 Front-Left  ID:%u %s %s\n", car->kia_tpms_id[0], fl_pressure.c_str(), fl_temp.c_str());
+    writer->printf("1 Front-Left  ID:%" PRIu32 " %s %s\n", car->kia_tpms_id[0], fl_pressure.c_str(), fl_temp.c_str());
   }
   // Front right
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
     const std::string &fr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", ToUser, 1);
     const std::string &fr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", ToUser, 1);
-    writer->printf("2 Front-Right ID:%u %s %s\n", car->kia_tpms_id[1], fr_pressure.c_str(), fr_temp.c_str());
+    writer->printf("2 Front-Right ID:%" PRIu32 " %s %s\n", car->kia_tpms_id[1], fr_pressure.c_str(), fr_temp.c_str());
   }
   // Rear left
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
     const std::string &rl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", ToUser, 1);
     const std::string &rl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", ToUser, 1);
-    writer->printf("3 Rear-Left ID:%u %s %s\n", car->kia_tpms_id[2], rl_pressure.c_str(), rl_temp.c_str());
+    writer->printf("3 Rear-Left ID:%" PRIu32 " %s %s\n", car->kia_tpms_id[2], rl_pressure.c_str(), rl_temp.c_str());
   }
   // Rear right
   if (StdMetrics.ms_v_tpms_pressure->IsDefined()) {
     const std::string &rr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", ToUser, 1);
     const std::string &rr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", ToUser, 1);
-    writer->printf("4 Rear-Right ID:%u %s %s\n", car->kia_tpms_id[3], rr_pressure.c_str(), rr_temp.c_str());
+    writer->printf("4 Rear-Right ID:%" PRIu32 " %s %s\n", car->kia_tpms_id[3], rr_pressure.c_str(), rr_temp.c_str());
   }
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_incoming_c_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_incoming_c_can.cpp
@@ -52,7 +52,7 @@ void OvmsHyundaiIoniqEv::IncomingFrameCan1(CAN_frame_t *p_frame)
     kia_send_can.byte[7] = d[7];
   }
   else if (kia_send_can.status == 3 && p_frame->MsgID == (kia_send_can.id + 0x08)) {
-    ESP_LOGV(TAG, "Drop: MsgID=%03x [%02x %02x %02x %02x %02x %02x %02x %02x]",
+    ESP_LOGV(TAG, "Drop: MsgID=%03" PRIx32 " [%02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 "]",
       p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]
     );
   }

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -918,10 +918,10 @@ void OvmsHyundaiIoniqEv::Ticker1(uint32_t ticker)
           m_b_aux_soc->SetValue( CalcAUXSoc(hif_aux_battery_mon.average_lastf()), Percentage );
           break;
         case OvmsBatteryState::Charging:
-          ESP_LOGD(TAG, "Aux Battery state: Charging %d", hif_aux_battery_mon.m_average_last);
+          ESP_LOGD(TAG, "Aux Battery state: Charging %" PRId32, hif_aux_battery_mon.m_average_last);
           break;
         case OvmsBatteryState::Blip: {
-          ESP_LOGD(TAG, "Aux Battery state: Blip %d", hif_aux_battery_mon.m_diff_last);
+          ESP_LOGD(TAG, "Aux Battery state: Blip %" PRId32, hif_aux_battery_mon.m_diff_last);
           if ( IsPollState_Off()) {
             ESP_LOGD(TAG, "PollState->Ping for 30 (Blip)");
             PollState_Ping(30);
@@ -929,7 +929,7 @@ void OvmsHyundaiIoniqEv::Ticker1(uint32_t ticker)
         }
         break;
         case OvmsBatteryState::Dip: {
-          ESP_LOGD(TAG, "Aux Battery state: Dip %d", hif_aux_battery_mon.m_diff_last);
+          ESP_LOGD(TAG, "Aux Battery state: Dip %" PRId32, hif_aux_battery_mon.m_diff_last);
           if ( IsPollState_Off()) {
             ESP_LOGD(TAG, "PollState->Ping for 30 (Dip)");
             PollState_Ping(30);
@@ -937,7 +937,7 @@ void OvmsHyundaiIoniqEv::Ticker1(uint32_t ticker)
         }
         break;
         case OvmsBatteryState::Low: {
-          ESP_LOGD(TAG, "Aux Battery state: Low %d", hif_aux_battery_mon.m_diff_last);
+          ESP_LOGD(TAG, "Aux Battery state: Low %" PRId32, hif_aux_battery_mon.m_diff_last);
           if (!IsPollState_Off()) {
             ESP_LOGD(TAG, "PollState->Off (Aux Battery state Low)");
             PollState_Off();

--- a/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_can_handler.cpp
@@ -111,7 +111,7 @@ void OvmsVehicleJaguarIpace::IncomingPollFrame(CAN_frame_t* frame)
 
         if (frameType == ISOTP_FT_SINGLE)
         {
-            ESP_LOGD(TAG, "IncomingPollFrame, SINGLE frame->MsgID=%d", frame->MsgID);
+            ESP_LOGD(TAG, "IncomingPollFrame, SINGLE frame->MsgID=%" PRId32, frame->MsgID);
             switch (frame->MsgID) {
                 case (becmId | rxFlag):
                     IncomingBecmPoll(responsePid, data, dataLength, 0);
@@ -163,7 +163,7 @@ void OvmsVehicleJaguarIpace::IncomingPollReply(
 {
     ESP_LOGD(
         TAG,
-        "%03x TYPE:%x PID:%02x Length:%x Data:%02x %02x %02x %02x",
+        "%03" PRIx32 " TYPE:%" PRIx16 " PID:%02" PRIx16 " Length:%" PRIx8 " Data:%02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8,
         m_poll_moduleid_low,
         type,
         pid,

--- a/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_poll_becm.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_poll_becm.cpp
@@ -134,7 +134,7 @@ void OvmsVehicleJaguarIpace::IncomingBecmPoll(uint16_t pid, uint8_t* data, uint8
             break;
         case odometerPid:
             StandardMetrics.ms_v_pos_odometer->SetValue(value24);
-            ESP_LOGD(TAG, "Odometer=%d", value24);
+            ESP_LOGD(TAG, "Odometer=%" PRId32, value24);
             break;
         case cabinTempPid:
             StandardMetrics.ms_v_env_cabintemp->SetValue(value8 - 40.0f);

--- a/vehicle/OVMS.V3/components/vehicle_kianiroev/src/kn_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kianiroev/src/kn_can_poll.cpp
@@ -81,7 +81,7 @@ void OvmsVehicleKiaNiroEv::IncomingPollReply(canbus* bus, uint16_t type, uint16_
 			break;
 
 		default:
-			ESP_LOGD(TAG, "Unknown module: %03x", m_poll_moduleid_low);
+			ESP_LOGD(TAG, "Unknown module: %03" PRIx32, m_poll_moduleid_low);
 			break;
 	  }
   }

--- a/vehicle/OVMS.V3/components/vehicle_kianiroev/src/kn_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kianiroev/src/kn_commands.cpp
@@ -371,28 +371,28 @@ void xkn_tpms(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
 		{
 		const std::string& fl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", kPa, 1);
 		const std::string& fl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", Celcius, 1);
-		writer->printf("1 ID:%u %s %s\n", car->kia_tpms_id[0], fl_pressure.c_str(), fl_temp.c_str());
+		writer->printf("1 ID:%" PRIu32 " %s %s\n", car->kia_tpms_id[0], fl_pressure.c_str(), fl_temp.c_str());
 		}
 	// Front right
 	if (StdMetrics.ms_v_tpms_pressure->IsDefined())
 		{
 		const std::string& fr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", kPa, 1);
 		const std::string& fr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", Celcius, 1);
-		writer->printf("2 ID:%u %s %s\n",car->kia_tpms_id[1], fr_pressure.c_str(), fr_temp.c_str());
+		writer->printf("2 ID:%" PRIu32 " %s %s\n",car->kia_tpms_id[1], fr_pressure.c_str(), fr_temp.c_str());
 		}
 	// Rear left
 	if (StdMetrics.ms_v_tpms_pressure->IsDefined())
 		{
 		const std::string& rl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", kPa, 1);
 		const std::string& rl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", Celcius, 1);
-		writer->printf("3 ID:%u %s %s\n",car->kia_tpms_id[2], rl_pressure.c_str(), rl_temp.c_str());
+		writer->printf("3 ID:%" PRIu32 " %s %s\n",car->kia_tpms_id[2], rl_pressure.c_str(), rl_temp.c_str());
 		}
 	// Rear right
 	if (StdMetrics.ms_v_tpms_pressure->IsDefined())
 		{
 		const std::string& rr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", kPa, 1);
 		const std::string& rr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", Celcius, 1);
-		writer->printf("4 ID:%u %s %s\n",car->kia_tpms_id[3], rr_pressure.c_str(), rr_temp.c_str());
+		writer->printf("4 ID:%" PRIu32 " %s %s\n",car->kia_tpms_id[3], rr_pressure.c_str(), rr_temp.c_str());
 		}
 	}
 

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
@@ -66,7 +66,7 @@ void OvmsVehicleKiaSoulEv::IncomingPollReply(canbus* bus, uint16_t type, uint16_
 			break;
 
 		default:
-			ESP_LOGD(TAG, "Unknown module: %03x", m_poll_moduleid_low);
+			ESP_LOGD(TAG, "Unknown module: %03" PRIx32, m_poll_moduleid_low);
 			break;
 	  }
   }

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_can_poll.cpp
@@ -169,7 +169,7 @@ void OvmsVehicleKiaSoulEv::IncomingOBC(canbus* bus, uint16_t type, uint16_t pid,
  */
 void OvmsVehicleKiaSoulEv::IncomingVMCU(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain)
 	{
-	INT base;
+	int32_t base;
 	uint8_t bVal;
 
 	switch (pid)

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_commands.cpp
@@ -322,28 +322,28 @@ void xks_tpms(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
     {
     const std::string& fl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", kPa, 1);
     const std::string& fl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FL, "-", Celcius, 1);
-    writer->printf("1 ID:%u %s %s\n", soul->kia_tpms_id[0], fl_pressure.c_str(), fl_temp.c_str());
+    writer->printf("1 ID:%" PRIu32 " %s %s\n", soul->kia_tpms_id[0], fl_pressure.c_str(), fl_temp.c_str());
     }
 	// Front right
   if (StdMetrics.ms_v_tpms_pressure->IsDefined())
     {
     const std::string& fr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", kPa, 1);
     const std::string& fr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_FR, "-", Celcius, 1);
-    writer->printf("2 ID:%u %s %s\n",soul->kia_tpms_id[1], fr_pressure.c_str(), fr_temp.c_str());
+    writer->printf("2 ID:%" PRIu32 " %s %s\n",soul->kia_tpms_id[1], fr_pressure.c_str(), fr_temp.c_str());
     }
 	// Rear left
   if (StdMetrics.ms_v_tpms_pressure->IsDefined())
     {
     const std::string& rl_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", kPa, 1);
     const std::string& rl_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RL, "-", Celcius, 1);
-    writer->printf("3 ID:%u %s %s\n",soul->kia_tpms_id[2], rl_pressure.c_str(), rl_temp.c_str());
+    writer->printf("3 ID:%" PRIu32 " %s %s\n",soul->kia_tpms_id[2], rl_pressure.c_str(), rl_temp.c_str());
     }
 	// Rear right
   if (StdMetrics.ms_v_tpms_pressure->IsDefined())
     {
     const std::string& rr_pressure = StdMetrics.ms_v_tpms_pressure->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", kPa, 1);
     const std::string& rr_temp = StdMetrics.ms_v_tpms_temp->ElemAsUnitString(MS_V_TPMS_IDX_RR, "-", Celcius, 1);
-    writer->printf("4 ID:%u %s %s\n",soul->kia_tpms_id[3], rr_pressure.c_str(), rr_temp.c_str());
+    writer->printf("4 ID:%" PRIu32 " %s %s\n",soul->kia_tpms_id[3], rr_pressure.c_str(), rr_temp.c_str());
     }
   }
 

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_incoming_c_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/ks_incoming_c_can.cpp
@@ -189,7 +189,7 @@ void OvmsVehicleKiaSoulEv::IncomingFrameCan1(CAN_frame_t* p_frame)
 
 	case 0x534:
 		{
-		ESP_LOGI(TAG, "%03x 8 %02x %02x %02x %02x %02x %02x %02x %02x",
+		ESP_LOGI(TAG, "%03" PRIx32 " 8 %02x %02x %02x %02x %02x %02x %02x %02x",
 				p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
 		if( (d[1] & 0x3) == 0 )
 			{

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_bcm.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_bcm.cpp
@@ -161,13 +161,13 @@ void OvmsVehicleMgEv::IncomingBCMAuthFrame(CAN_frame_t* frame, uint8_t serviceId
                     uint32_t seed = (data[2] << 24) | (data[3] << 16) | (data[4] << 8) | data[5];
                     if (seed == 0)
                     {
-                        ESP_LOGI(TAG, "BCM auth: seed received %08x. BCM seems to already have been authenticated", seed);
+                        ESP_LOGI(TAG, "BCM auth: seed received %08" PRIx32 ". BCM seems to already have been authenticated", seed);
                         m_bcm_task->SetValue(static_cast<int>(BCMTasks::AuthenticationDone));
                     }
                     else
                     {
                         uint32_t key = MgEvPasscode::BCMKey(seed);
-                        ESP_LOGI(TAG, "BCM auth: seed received %08x. Replying with key %08x", seed, key);
+                        ESP_LOGI(TAG, "BCM auth: seed received %08" PRIx32 ". Replying with key %08" PRIx32, seed, key);
                         nextFrame.data.u8[0] = (ISOTP_FT_SINGLE << 4) | 6;
                         nextFrame.data.u8[1] = VEHICLE_POLL_TYPE_SECACCESS;
                         nextFrame.data.u8[2] = 0x02u;

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_can_handler.cpp
@@ -191,7 +191,7 @@ void OvmsVehicleMgEv::IncomingPollReply(
 {
     ESP_LOGV(
         TAG,
-        "%03x TYPE:%x PID:%02x Length:%x Data:%02x %02x %02x %02x",
+        "%03" PRIx32 " TYPE:%" PRIx16 " PID:%02" PRIx16 " Length:%" PRIx8 " Data:%02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8,
         m_poll_moduleid_low,
         type,
         pid,

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_gwm.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_gwm.cpp
@@ -161,7 +161,7 @@ void OvmsVehicleMgEv::IncomingGWMAuthFrame(CAN_frame_t* frame, uint8_t serviceId
                     // Seed1 response
                     uint32_t seed = (data[2] << 24) | (data[3] << 16) | (data[4] << 8) | data[5];
                     uint32_t key = MgEvPasscode::GWMKey1(seed);
-                    ESP_LOGI(TAG, "GWM auth: seed1 received %08x. Replying with key1 %08x", seed, key);
+                    ESP_LOGI(TAG, "GWM auth: seed1 received %08" PRIx32 ". Replying with key1 %08" PRIx32, seed, key);
                     nextFrame.data.u8[0] = (ISOTP_FT_SINGLE << 4) | 6;
                     nextFrame.data.u8[1] = VEHICLE_POLL_TYPE_SECACCESS;            
                     nextFrame.data.u8[2] = 0x42u;
@@ -185,7 +185,7 @@ void OvmsVehicleMgEv::IncomingGWMAuthFrame(CAN_frame_t* frame, uint8_t serviceId
                     // Seed2 response
                     uint32_t seed = (data[2] << 24) | (data[3] << 16) | (data[4] << 8) | data[5];
                     uint32_t key = MgEvPasscode::GWMKey2(seed);
-                    ESP_LOGI(TAG, "GWM auth: seed2 received %08x. Replying with key2 %08x", seed, key);
+                    ESP_LOGI(TAG, "GWM auth: seed2 received %08" PRIx32 ". Replying with key2 %08" PRIx32, seed, key);
                     nextFrame.data.u8[0] = (ISOTP_FT_SINGLE << 4) | 6;
                     nextFrame.data.u8[1] = VEHICLE_POLL_TYPE_SECACCESS;            
                     nextFrame.data.u8[2] = 0x02u;

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_software_versions.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_software_versions.cpp
@@ -106,7 +106,7 @@ void OvmsVehicleMgEv::SoftwareVersions(OvmsWriter* writer)
         m_SoftwareVersionResponsesReceived = 0;
         for (size_t i = 0u; i < m_ECUCountToQuerySoftwareVersion; ++i)
         {
-            ESP_LOGV(TAG, "Sending query to %03x", ecus[i]);
+            ESP_LOGV(TAG, "Sending query to %03" PRIx32, ecus[i]);
             SendPollMessage(
                 currentBus, ecus[i], VEHICLE_POLL_TYPE_OBDIIEXTENDED, softwarePid
             );
@@ -121,7 +121,7 @@ void OvmsVehicleMgEv::SoftwareVersions(OvmsWriter* writer)
             a++;
         }
         
-        ESP_LOGI(TAG, "%d/%d ECUs responded", m_SoftwareVersionResponsesReceived, m_ECUCountToQuerySoftwareVersion);
+        ESP_LOGI(TAG, "%d/%" PRId32 " ECUs responded", m_SoftwareVersionResponsesReceived, m_ECUCountToQuerySoftwareVersion);
 
         m_GettingSoftwareVersions = false;
         //Reset GWM and BCM task back to none (incase we didn't receive a response back)
@@ -201,12 +201,12 @@ void OvmsVehicleMgEv::IncomingSoftwareVersionFrame(CAN_frame_t* frame, uint8_t f
                         { .u8 = { (ISOTP_FT_FLOWCTRL << 4 | 0), 0, 25, 0, 0, 0, 0, 0 } }
                     };
                     frame->origin->Write(&flowControl);
-                    ESP_LOGV(TAG, "First part of software version response from %03x. %d bytes expected, %d bytes received, %d bytes remaining.", frame->MsgID - rxFlag, dataLength, BytesToCopy, dataLength - BytesToCopy); 
+                    ESP_LOGV(TAG, "First part of software version response from %03" PRIx32 ". %d bytes expected, %d bytes received, %d bytes remaining.", frame->MsgID - rxFlag, dataLength, BytesToCopy, dataLength - BytesToCopy); 
                 }  
                 else
                 {
                     m_SoftwareVersionResponsesReceived++;
-                    ESP_LOGI(TAG, "(%d/%d) Received software version response from %03x", m_SoftwareVersionResponsesReceived, m_ECUCountToQuerySoftwareVersion, frame->MsgID - rxFlag); 
+                    ESP_LOGI(TAG, "(%d/%" PRId32 ") Received software version response from %03" PRIx32, m_SoftwareVersionResponsesReceived, m_ECUCountToQuerySoftwareVersion, frame->MsgID - rxFlag); 
                 }                        
             }
             break;
@@ -229,12 +229,12 @@ void OvmsVehicleMgEv::IncomingSoftwareVersionFrame(CAN_frame_t* frame, uint8_t f
                         get<1>(version).begin() + start
                     );     
                     get<2>(version) -= BytesToCopy; //Decrement bytes remaining
-                    ESP_LOGV(TAG, "Received consecutive frame (%d) of software version response from %03x. %d bytes received, %d bytes remaining.", frameNumber, frame->MsgID - rxFlag, BytesToCopy, get<2>(version));
+                    ESP_LOGV(TAG, "Received consecutive frame (%d) of software version response from %03" PRIx32 ". %d bytes received, %d bytes remaining.", frameNumber, frame->MsgID - rxFlag, BytesToCopy, get<2>(version));
                     if (get<2>(version) == 0)
                     {
                         //No more bytes remaining
                         m_SoftwareVersionResponsesReceived++;
-                        ESP_LOGI(TAG, "(%d/%d) Received software version response from %03x", m_SoftwareVersionResponsesReceived, m_ECUCountToQuerySoftwareVersion, frame->MsgID - rxFlag);
+                        ESP_LOGI(TAG, "(%d/%" PRId32 ") Received software version response from %03" PRIx32, m_SoftwareVersionResponsesReceived, m_ECUCountToQuerySoftwareVersion, frame->MsgID - rxFlag);
                         switch (frame->MsgID - rxFlag)
                         {
                             case gwmId:

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.cpp
@@ -181,7 +181,7 @@ void OvmsVehicleMgEvA::DeterminePollState(canbus* currentBus, uint32_t ticker)
 
             if (m_rxPackets != rxPackets)
             {
-                ESP_LOGV(TAG, "RX Frames Recieved, rx %i and m_rx %i and count %i ", rxPackets, m_rxPackets, m_noRxCount);
+                ESP_LOGV(TAG, "RX Frames Recieved, rx %" PRIi32 " and m_rx %" PRIi32 " and count %" PRIi32 " ", rxPackets, m_rxPackets, m_noRxCount);
                 m_rxPackets = rxPackets;
                 if (m_noRxCount != 0)
                 {
@@ -190,7 +190,7 @@ void OvmsVehicleMgEvA::DeterminePollState(canbus* currentBus, uint32_t ticker)
             }
             else
             {
-                ESP_LOGV(TAG, "No RX Frames Recieved, rx %i and m_rx %i and count %i ", rxPackets, m_rxPackets, m_noRxCount);
+                ESP_LOGV(TAG, "No RX Frames Recieved, rx %" PRIi32 " and m_rx %" PRIi32 " and count %" PRIi32 " ", rxPackets, m_rxPackets, m_noRxCount);
                 ++m_noRxCount;
                 if (m_noRxCount >= ZOMBIE_DETECT_TIMEOUT)
                 {
@@ -246,7 +246,7 @@ void OvmsVehicleMgEvA::DeterminePollState(canbus* currentBus, uint32_t ticker)
 
     if (m_afterRunTicker != (TRANSITION_TIMEOUT +1))
     {
-        ESP_LOGV(TAG, "Pollstate: %i , GWM State: %i , Rx Packet Count: %i , 12V level: %.2f.", m_poll_state, m_gwmState, rxPackets, voltage12V);
+        ESP_LOGV(TAG, "Pollstate: %i , GWM State: %i , Rx Packet Count: %" PRIi32 " , 12V level: %.2f.", m_poll_state, m_gwmState, rxPackets, voltage12V);
     }
     return;
 }
@@ -279,7 +279,7 @@ void OvmsVehicleMgEvA::ZombieMode()
     ++m_preZombieOverrideTicker;
     if (m_preZombieOverrideTicker <= ZOMBIE_TIMEOUT)
     {
-        ESP_LOGV(TAG, "Zombie Wait for %i Seconds.", m_preZombieOverrideTicker);
+        ESP_LOGV(TAG, "Zombie Wait for %" PRIi32 " Seconds.", m_preZombieOverrideTicker);
         return;
     }
     ++m_diagCount;

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_b.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_b.cpp
@@ -219,7 +219,7 @@ void OvmsVehicleMgEvB::MainStateMachine(canbus* currentBus, uint32_t ticker)
         StandardMetrics.ms_v_charge_inprogress->SetValue(false);
         if (m_afterRunTicker < TRANSITION_TIMEOUT)
         {
-            ESP_LOGV(TAG, "(%u) Waiting %us before going to sleep", m_afterRunTicker, TRANSITION_TIMEOUT);
+            ESP_LOGV(TAG, "(%" PRIu32 ") Waiting %us before going to sleep", m_afterRunTicker, TRANSITION_TIMEOUT);
             m_afterRunTicker++;
         }
         else if (m_afterRunTicker == TRANSITION_TIMEOUT)      

--- a/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/mi_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/mi_can_poll.cpp
@@ -31,7 +31,7 @@ static const char *TAGPOLL = "v-trio-poll";
  */
 void OvmsVehicleMitsubishi::IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain)
 {
-  //ESP_LOGW(TAGPOLL, "%03x TYPE:%x PID:%02x Data:%02x %02x %02x %02x %02x %02x %02x %02x LENG:%02x REM:%02x", m_poll_moduleid_low, type, pid, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], length, mlremain);
+  //ESP_LOGW(TAGPOLL, "%03" PRIx32 " TYPE:%x PID:%02x Data:%02x %02x %02x %02x %02x %02x %02x %02x LENG:%02x REM:%02x", m_poll_moduleid_low, type, pid, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], length, mlremain);
 
   	//OvmsVehicleMitsubishi* trio = (OvmsVehicleMitsubishi*) MyVehicleFactory.ActiveVehicle();
     switch (m_poll_moduleid_low)
@@ -79,7 +79,7 @@ void OvmsVehicleMitsubishi::IncomingPollReply(canbus* bus, uint16_t type, uint16
       // ****** OBC *****
       case 0x766:
       {
-        //ESP_LOGW(TAGPOLL, "%03x TYPE:%x PID:%02x Data:%02x %02x %02x %02x %02x %02x %02x %02x LENG:%02x REM:%02x", m_poll_moduleid_low, type, pid, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], length, mlremain);
+        //ESP_LOGW(TAGPOLL, "%03" PRIx32 " TYPE:%x PID:%02x Data:%02x %02x %02x %02x %02x %02x %02x %02x LENG:%02x REM:%02x", m_poll_moduleid_low, type, pid, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], length, mlremain);
         break;
       }
 
@@ -139,7 +139,7 @@ void OvmsVehicleMitsubishi::IncomingPollReply(canbus* bus, uint16_t type, uint16
       }
 
      default:
-		   ESP_LOGW(TAGPOLL, "Unknown module: %03x", m_poll_moduleid_low);
+		   ESP_LOGW(TAGPOLL, "Unknown module: %03" PRIx32, m_poll_moduleid_low);
 	  }
 
 }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -830,7 +830,7 @@ void OvmsVehicleNissanLeaf::IncomingPollReply(canbus* bus, uint16_t type, uint16
         PollReply_VIN(buf, rxbuf.size());
         break;
       default:
-        ESP_LOGI(TAG, "IncomingPollReply: unknown reply module|pid=%#x len=%d", id_pid, rxbuf.size());
+        ESP_LOGI(TAG, "IncomingPollReply: unknown reply module|pid=%#" PRIx32 " len=%d", id_pid, rxbuf.size());
         break;
       }
 

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_obd2.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_obd2.cpp
@@ -313,7 +313,7 @@ void OvmsVehicleRenaultTwizy::FormatDTC(StringWriter& buf, int i, cluster_dtc& e
                e.Ef ? " Ef" : "",
                e.Dc ? " Dc" : "",
                e.DNS ? " DNS" : "");
-    buf.printf("   @ %dkm %dkph SOC=%d%% BV=%dV TC=%d IC=%d",
+    buf.printf("   @ %" PRId32 "km %dkph SOC=%d%% BV=%dV TC=%d IC=%d",
                e.getOdometer(), e.Speed, e.BL, e.getBV(),
                e.TimeCounter, e.IgnitionCycle);
   }

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon.cpp
@@ -372,7 +372,7 @@ CANopenResult_t SevconClient::Login(bool on)
     m_drivemode.type = 1; // Twizy45
   }
   else {
-    ESP_LOGE(TAG, "Twizy type unknown: SEVCON type 0x%08x", m_sevcon_type);
+    ESP_LOGE(TAG, "Twizy type unknown: SEVCON type 0x%08" PRIx32, m_sevcon_type);
     return COR_ERR_UnknownDevice;
   }
 

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_faults.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_faults.cpp
@@ -238,7 +238,7 @@ void SevconClient::EmcyListener(string event, void* data)
     return;
 
   uint32_t fault = emcy.data[1] << 8 | emcy.data[0];
-  ESP_LOGW(TAG, "Sevcon: received fault code 0x%04x", fault);
+  ESP_LOGW(TAG, "Sevcon: received fault code 0x%04" PRIx32, fault);
   MyEvents.SignalEvent("vehicle.fault.code", (void*)fault);
 
   // button push?

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_mon.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_mon.cpp
@@ -383,7 +383,7 @@ void SevconClient::ProcessMonitoringData(CANopenJob &job)
       if (m_mon_file) {
         fprintf((FILE*)m_mon_file,
           // timestamp,kph,rpm,throttle,kickdown,brake,
-          "%u,%.1f,%d,%.0f,%u,%.0f,"
+          "%" PRIu32 ",%.1f,%d,%.0f,%u,%.0f,"
           // mot_torque_limit,mot_torque_demand,mot_torque,
           "%.1f,%.1f,%.1f,"
           // bat_voltage,bat_current,bat_power,cap_voltage,

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_shell.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_shell.cpp
@@ -108,9 +108,9 @@ struct sdo_buffer
       txt[i] = 0;
     
     if (show_txt)
-      writer->printf("dec=%d hex=0x%0*x str='%s'", num, MIN(size,4)*2, num, txt);
+      writer->printf("dec=%" PRId32 " hex=0x%0*" PRIx32 " str='%s'", num, MIN(size,4)*2, num, txt);
     else
-      writer->printf("dec=%d hex=0x%0*x", num, MIN(size,4)*2, num);
+      writer->printf("dec=%" PRId32 " hex=0x%0*" PRIx32, num, MIN(size,4)*2, num);
   }
 };
 
@@ -191,10 +191,10 @@ void SevconClient::shell_cfg_write(int verbosity, OvmsWriter* writer, OvmsComman
   switch (writeval.type)
   {
     case 'H':
-      writer->printf("Write 0x%04x.%02x: hex=0x%08x => ", index, subindex, writeval.num);
+      writer->printf("Write 0x%04x.%02x: hex=0x%08" PRIx32 " => ", index, subindex, writeval.num);
       break;
     case 'D':
-      writer->printf("Write 0x%04x.%02x: dec=%d => ", index, subindex, writeval.num);
+      writer->printf("Write 0x%04x.%02x: dec=%" PRId32 " => ", index, subindex, writeval.num);
       break;
     default:
       writer->printf("Write 0x%04x.%02x: str='%s' => ", index, subindex, writeval.txt);

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_tuning.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_tuning.cpp
@@ -520,7 +520,7 @@ CANopenResult_t SevconClient::CfgMakePowermap(void
     // Now rpm2 & rpm3 mark the start of regions 2 & 3,
     // and pt is the map index for rpm3.
     
-    ESP_LOGD(TAG, "CfgMakePowermap: pwr2=%d, rpm2=%d, pwr3=%d, rpm3=%d, pt=%d\n",
+    ESP_LOGD(TAG, "CfgMakePowermap: pwr2=%" PRId32 ", rpm2=%" PRId32 ", pwr3=%" PRId32 ", rpm3=%" PRId32 ", pt=%d\n",
       twizy_max_pwr_lo, rpm2, twizy_max_pwr_hi, rpm3, pt);
     
     // write map start point:
@@ -582,7 +582,7 @@ CANopenResult_t SevconClient::CfgMakePowermap(void
       // calculate torque at point i:
       trq = ((((uint32_t)pwr * 9549 + (rpm>>1)) / rpm) * 16 + 500) / 1000;
 
-      ESP_LOGD(TAG, "CfgMakePowermap: #%d rpm=%d trq=%.2f pwr=%d", i, rpm, trq/16.0, pwr);
+      ESP_LOGD(TAG, "CfgMakePowermap: #%d rpm=%" PRId32 " trq=%.2f pwr=%" PRId32, i, rpm, trq/16.0, pwr);
 
       // write into map:
       if ((err = sc.Write(0x4611, 0x03+(i<<1), trq)) != COR_OK)

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_types.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_types.h
@@ -32,11 +32,19 @@
 // Legacy type compatibility:
 
 typedef uint8_t UINT8;
-typedef uint32_t UINT;    // Note: fatfs defines this as 32 bit, so we stick to that
+typedef unsigned int UINT;    // Note: fatfs defines this as 32 bit, so we stick to that
+                              // Note: even if they are the same size (on 32-bit arch),
+                              // int and long are differenciated by the compiler and
+                              // are not interchangeable.
+                              // UINT is defined as `typedef unsigned int UINT` in `fatfs/src/ff.h:49`
+                              // while int32_t is defined as `unsigned long`.
+                              // Same bit size - but different type, so we cannot redefine it differently
+                              // Cf: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/gcc.html#int32-t-and-uint32-t-for-xtensa-compiler
+                              // Cf: https://github.com/espressif/esp-idf/issues/9511#issuecomment-1226251443
 typedef uint32_t UINT32;
 
 typedef int8_t INT8;
-typedef int32_t INT;      // 32 bit for consistency with UINT
+typedef int INT;      // 32 bit for consistency with UINT
 typedef int32_t INT32;
 
 

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
@@ -1001,15 +1001,15 @@ void OvmsVehicleRenaultZoe::IncomingLBC(uint16_t type, uint16_t pid, const char*
     case 0x04: {
       if (IsZoe()) {
         for(int i=2; i<36; i+=3){
-          BmsSetCellTemperature( (i-2)/3, (INT)CAN_BYTE(i)-40 );
-          //ESP_LOGD(TAG, "temp %d - %d", (i-2)/3, (INT)CAN_BYTE(i)-40);
+          BmsSetCellTemperature( (i-2)/3, (int32_t)CAN_BYTE(i)-40 );
+          //ESP_LOGD(TAG, "temp %d - %d", (i-2)/3, (int32_t)CAN_BYTE(i)-40);
         }
       }
       if (IsKangoo()) {
         int x=0;
         for(int i=2; i<12; i+=3){
-          BmsSetCellTemperature( x, (INT)CAN_BYTE(i) );
-          ESP_LOGD(TAG, "temp %d - %d", x, (INT)CAN_BYTE(i));
+          BmsSetCellTemperature( x, (int32_t)CAN_BYTE(i) );
+          ESP_LOGD(TAG, "temp %d - %d", x, (int32_t)CAN_BYTE(i));
           x++;
         }
       }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
@@ -1002,14 +1002,14 @@ void OvmsVehicleRenaultZoe::IncomingLBC(uint16_t type, uint16_t pid, const char*
       if (IsZoe()) {
         for(int i=2; i<36; i+=3){
           BmsSetCellTemperature( (i-2)/3, (int32_t)CAN_BYTE(i)-40 );
-          //ESP_LOGD(TAG, "temp %d - %d", (i-2)/3, (int32_t)CAN_BYTE(i)-40);
+          //ESP_LOGD(TAG, "temp %d - %" PRId32, (i-2)/3, (int32_t)CAN_BYTE(i)-40);
         }
       }
       if (IsKangoo()) {
         int x=0;
         for(int i=2; i<12; i+=3){
           BmsSetCellTemperature( x, (int32_t)CAN_BYTE(i) );
-          ESP_LOGD(TAG, "temp %d - %d", x, (int32_t)CAN_BYTE(i));
+          ESP_LOGD(TAG, "temp %d - %" PRId32, x, (int32_t)CAN_BYTE(i));
           x++;
         }
       }

--- a/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_commands.cpp
@@ -474,7 +474,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartED::CommandSetChargeTimer(bool ti
   vTaskDelay(50 / portTICK_PERIOD_MS);
   m_can1->Write(&frame);
   
-  ESP_LOGI(TAG, "%03x 8 %02x %02x %02x %02x %02x %02x %02x %02x", frame.MsgID, frame.data.u8[0], frame.data.u8[1], frame.data.u8[2], frame.data.u8[3], frame.data.u8[4], frame.data.u8[5], frame.data.u8[6], frame.data.u8[7]);
+  ESP_LOGI(TAG, "%03" PRIx32 " 8 %02x %02x %02x %02x %02x %02x %02x %02x", frame.MsgID, frame.data.u8[0], frame.data.u8[1], frame.data.u8[2], frame.data.u8[3], frame.data.u8[4], frame.data.u8[5], frame.data.u8[6], frame.data.u8[7]);
   return Success;
 #endif
   return NotImplemented;

--- a/vehicle/OVMS.V3/components/vehicle_teslamodels/src/vehicle_teslamodels.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_teslamodels/src/vehicle_teslamodels.cpp
@@ -475,7 +475,7 @@ bool OvmsVehicleTeslaModelS::TPMSRead(std::vector<uint32_t> *tpms)
                     ((uint32_t)m_tpms_data[offset+1] << 16) +
                     ((uint32_t)m_tpms_data[offset+2] << 8) +
                     ((uint32_t)m_tpms_data[offset+3]);
-      ESP_LOGD(TAG,"TPMS read ID %08x",id);
+      ESP_LOGD(TAG,"TPMS read ID %08" PRIx32,id);
       tpms->push_back( id );
       }
     return true;
@@ -499,7 +499,7 @@ bool OvmsVehicleTeslaModelS::TPMSWrite(std::vector<uint32_t> &tpms)
   m_tpms_pos = 0;
   for(uint32_t id : tpms)
     {
-    ESP_LOGD(TAG,"TPMS write ID %08x",id);
+    ESP_LOGD(TAG,"TPMS write ID %08" PRIx32,id);
     m_tpms_data[m_tpms_pos++] = (id>>24) & 0xff;
     m_tpms_data[m_tpms_pos++] = (id>>16) & 0xff;
     m_tpms_data[m_tpms_pos++] = (id>>8) & 0xff;

--- a/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.cpp
@@ -1274,7 +1274,7 @@ bool OvmsVehicleTeslaRoadster::TPMSRead(std::vector<uint32_t> *tpms)
                       ((uint32_t)data[offset+1] << 16) +
                       ((uint32_t)data[offset+2] << 8) +
                       ((uint32_t)data[offset+3]);
-    ESP_LOGD(TAG,"TPMS read ID %08x",id);
+    ESP_LOGD(TAG,"TPMS read ID %08" PRIx32,id);
     tpms->push_back( id );
     }
   return true;
@@ -1316,7 +1316,7 @@ bool OvmsVehicleTeslaRoadster::TPMSWrite(std::vector<uint32_t> &tpms)
   int offset = 2;
   for(uint32_t id : tpms)
     {
-    ESP_LOGD(TAG,"TPMS write ID %08x",id);
+    ESP_LOGD(TAG,"TPMS write ID %08" PRIx32,id);
     req_msg[offset++] = (id>>24) & 0xff;
     req_msg[offset++] = (id>>16) & 0xff;
     req_msg[offset++] = (id>>8) & 0xff;

--- a/vehicle/OVMS.V3/components/vehicle_voltampera/src/va_ac_preheat.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_voltampera/src/va_ac_preheat.cpp
@@ -257,7 +257,7 @@ void OvmsVehicleVoltAmpera::ClimateControlIncomingSWCAN(CAN_frame_t* p_frame)
 		}
 
 	if (unexpected_data)
-	ESP_LOGE(TAG,"IncomingFrameSWCan: Unexpected data! Id %08x: %02x %02x %02x %02x %02x %02x %02x %02x", 
+	ESP_LOGE(TAG,"IncomingFrameSWCan: Unexpected data! Id %08" PRIx32 ": %02x %02x %02x %02x %02x %02x %02x %02x", 
 	  p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
 	}
 

--- a/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.cpp
@@ -225,18 +225,18 @@ void OvmsVehicleVoltAmpera::TxCallback(const CAN_frame_t* p_frame, bool success)
   if (p_frame->MsgID == 0x7e4)
     {
     if (!success)
-      ESP_LOGE(TAG, "TxCallback. Error sending poll request. MsgId: 0x%x", p_frame->MsgID);
+      ESP_LOGE(TAG, "TxCallback. Error sending poll request. MsgId: 0x%" PRIx32, p_frame->MsgID);
     return;
     }
 
   if (success) 
     {
-    ESP_LOGD(TAG,"TxCallback. Success. Frame %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]", 
+    ESP_LOGD(TAG,"TxCallback. Success. Frame %08" PRIx32 ": [%02x %02x %02x %02x %02x %02x %02x %02x]", 
       p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
     } 
   else
     {
-    ESP_LOGE(TAG,"TxCallback. Failed! Frame %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]", 
+    ESP_LOGE(TAG,"TxCallback. Failed! Frame %08" PRIx32 ": [%02x %02x %02x %02x %02x %02x %02x %02x]", 
       p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
     }
   }
@@ -249,7 +249,7 @@ void OvmsVehicleVoltAmpera::IncomingFrameCan1(CAN_frame_t* p_frame)
 
   m_candata_timer = VA_CANDATA_TIMEOUT;
 
-  ESP_LOGV(TAG,"CAN1 message received: %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]", 
+  ESP_LOGV(TAG,"CAN1 message received: %08" PRIx32 ": [%02x %02x %02x %02x %02x %02x %02x %02x]", 
     p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
 
   if ((p_frame->MsgID & 0xff8) == 0x7e8)
@@ -427,7 +427,7 @@ void OvmsVehicleVoltAmpera::IncomingFrameCan4(CAN_frame_t* p_frame)
 
   m_candata_timer = VA_CANDATA_TIMEOUT;
 
-  ESP_LOGV(TAG,"SW CAN message received: %08x: [%02x %02x %02x %02x %02x %02x %02x %02x]", 
+  ESP_LOGV(TAG,"SW CAN message received: %08" PRIx32 ": [%02x %02x %02x %02x %02x %02x %02x %02x]", 
     p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7] );
 
   // Activity on the bus, so resume polling
@@ -1094,7 +1094,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVoltAmpera::CommandUnlock(const char* 
 
 OvmsVehicle::vehicle_command_t OvmsVehicleVoltAmpera::CommandLights(va_light_t lights, bool turn_on)
   {
-  ESP_LOGI(TAG,"CommandLights: lights 0x%x:%d",(uint32_t)lights,turn_on);
+  ESP_LOGI(TAG,"CommandLights: lights 0x%" PRIx32 ":%d",(uint32_t)lights,turn_on);
   SendTesterPresentMessage(VA_BCM);
   vTaskDelay(200 / portTICK_PERIOD_MS);  
 
@@ -1171,7 +1171,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVoltAmpera::CommandLights(va_light_t l
 
   // Set the bitwise status of the lights that we control and are now ON. If any of these are set, we send periodic Tester Present messages
   m_controlled_lights = (m_controlled_lights & ~lights) | (lights*turn_on);
-  ESP_LOGI(TAG,"CommandLights: controlled_lights 0x%x",m_controlled_lights);
+  ESP_LOGI(TAG,"CommandLights: controlled_lights 0x%" PRIx32,m_controlled_lights);
   return Success;
   }
 

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -460,7 +460,7 @@ void OvmsVehicleVWeUp::PollerStateTicker()
   if (poll_state != m_poll_state) {
     ESP_LOGD(TAG,
       "PollerStateTicker: [%s] LVPwrState=%d HVChgMode=%d SOC=%.1f%% LVAutoChg=%d "
-      "12V=%.1f DCDC_U=%.1f DCDC_I=%.1f ChgEff=%.1f BatI=%.1f BatIAge=%u => PollState %d->%d",
+      "12V=%.1f DCDC_U=%.1f DCDC_I=%.1f ChgEff=%.1f BatI=%.1f BatIAge=%" PRIu32 " => PollState %d->%d",
       car_online ? "online" : "offline", lv_pwrstate, hv_chgmode, StdMetrics.ms_v_bat_soc->AsFloat(),
       m_lv_autochg->AsInt(), StdMetrics.ms_v_bat_12v_voltage->AsFloat(),
       dcdc_voltage, StdMetrics.ms_v_charge_12v_current->AsFloat(),
@@ -1321,7 +1321,7 @@ void OvmsVehicleVWeUp::IncomingPollReply(canbus *bus, uint16_t type, uint16_t pi
       break;
 
     default:
-      VALUE_LOG(TAG, "IncomingPollReply: ECU %X/%X unhandled PID %02X %04X: %s",
+      VALUE_LOG(TAG, "IncomingPollReply: ECU %" PRIX32 "/%" PRIX32 " unhandled PID %02X %04X: %s",
         m_poll_entry.txmoduleid, m_poll_entry.rxmoduleid, type, pid, PollReply.GetHexString().c_str());
       break;
   }

--- a/vehicle/OVMS.V3/main/ovms_boot.cpp
+++ b/vehicle/OVMS.V3/main/ovms_boot.cpp
@@ -141,7 +141,7 @@ void boot_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
   struct tm* tml;
   char tb[32];
   
-  writer->printf("Last boot was %d second(s) ago\n",monotonictime);
+  writer->printf("Last boot was %" PRId32 " second(s) ago\n",monotonictime);
   
   time(&rawtime);
   rawtime = rawtime-(time_t)monotonictime;
@@ -184,19 +184,19 @@ void boot_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
         (exccause < NUM_EDESCS) ? edesc[exccause] : "Unknown", boot_data.crash_data.core_id);
       writer->printf("  Registers:\n");
       for (int i=0; i<24; i++)
-        writer->printf("  %s: 0x%08x%s", sdesc[i], boot_data.crash_data.reg[i], ((i+1)%4) ? "" : "\n");
+        writer->printf("  %s: 0x%08" PRIx32 "%s", sdesc[i], boot_data.crash_data.reg[i], ((i+1)%4) ? "" : "\n");
       }
 
     for (int core = 0; core < portNUM_PROCESSORS; core++)
       {
       if (boot_data.curr_task[core].name[0])
-        writer->printf("  Current task on core %d: %s, %u stack bytes free\n",
+        writer->printf("  Current task on core %d: %s, %" PRIu32 " stack bytes free\n",
           core, boot_data.curr_task[core].name, boot_data.curr_task[core].stackfree);
       }
 
     writer->printf("  Backtrace:\n ");
     for (int i=0; i<OVMS_BT_LEVELS && boot_data.crash_data.bt[i].pc; i++)
-      writer->printf(" 0x%08x", boot_data.crash_data.bt[i].pc);
+      writer->printf(" 0x%08" PRIx32, boot_data.crash_data.bt[i].pc);
 
     if (boot_data.curr_event_name[0])
       {
@@ -654,13 +654,13 @@ void Boot::NotifyDebugCrash()
       buf.printf(",%s,%d,",
         (exccause < NUM_EDESCS) ? edesc[exccause] : "Unknown", boot_data.crash_data.core_id);
       for (int i=0; i<24; i++)
-        buf.printf("0x%08x ", boot_data.crash_data.reg[i]);
+        buf.printf("0x%08" PRIx32 " ", boot_data.crash_data.reg[i]);
       }
 
     // backtrace:
     buf.append(",");
     for (int i=0; i<OVMS_BT_LEVELS && boot_data.crash_data.bt[i].pc; i++)
-      buf.printf("0x%08x ", boot_data.crash_data.bt[i].pc);
+      buf.printf("0x%08" PRIx32 " ", boot_data.crash_data.bt[i].pc);
 
     // Reset reason:
     buf.printf(",%d,%s", GetResetReason(), GetResetReasonName());
@@ -688,7 +688,7 @@ void Boot::NotifyDebugCrash()
       name = boot_data.curr_task[i].name;
       buf.append(",");
       buf.append(mp_encode(name));
-      buf.printf(",%u", boot_data.curr_task[i].stackfree);
+      buf.printf(",%" PRIu32, boot_data.curr_task[i].stackfree);
       }
 
     MyNotify.NotifyString("data", "debug.crash", buf.c_str());

--- a/vehicle/OVMS.V3/main/ovms_command.cpp
+++ b/vehicle/OVMS.V3/main/ovms_command.cpp
@@ -1461,9 +1461,9 @@ void OvmsCommandApp::ShowLogStatus(int verbosity, OvmsWriter* writer)
     "  Log file path    : %s\n"
     "  Current size     : %.1f kB\n"
     "  Cycle size       : %u kB\n"
-    "  Cycle count      : %u\n"
-    "  Dropped messages : %u\n"
-    "  Messages logged  : %u\n"
+    "  Cycle count      : %" PRIu32 "\n"
+    "  Dropped messages : %" PRIu32 "\n"
+    "  Messages logged  : %" PRIu32 "\n"
     "  Total fsync time : %.1f s\n"
     , m_consoles.size()
     , m_logfile ? "active" : "inactive"

--- a/vehicle/OVMS.V3/main/ovms_events.cpp
+++ b/vehicle/OVMS.V3/main/ovms_events.cpp
@@ -106,7 +106,7 @@ void event_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc,
     writer->printf("Currently dispatching:\n");
     writer->printf("  Event: %s\n",MyEvents.m_current_event.c_str());
     writer->printf("  To:    %s\n",cbe->m_caller.c_str());
-    writer->printf("  For:   %u second(s)\n",monotonictime-MyEvents.m_current_started);
+    writer->printf("  For:   %" PRIu32 " second(s)\n",monotonictime-MyEvents.m_current_started);
     }
   }
 
@@ -164,7 +164,7 @@ void event_raise(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
 
   if (delay_ms)
     {
-    writer->printf("Raising event in %u ms: %s\n", delay_ms, event.c_str());
+    writer->printf("Raising event in %" PRIu32 " ms: %s\n", delay_ms, event.c_str());
     MyEvents.SignalEvent(event, NULL, (size_t)0, delay_ms);
     }
   else
@@ -384,7 +384,7 @@ static void CheckQueueOverflow(const char* from, char* event)
   EventCallbackEntry* cbe = MyEvents.m_current_callback;
   if (cbe != NULL)
     {
-    ESP_LOGE(TAG, "%s: queue overflow (running %s->%s for %u sec), event '%s' dropped",
+    ESP_LOGE(TAG, "%s: queue overflow (running %s->%s for %" PRIu32 " sec), event '%s' dropped",
       from,
       MyEvents.m_current_event.c_str(),
       cbe->m_caller.c_str(),

--- a/vehicle/OVMS.V3/main/ovms_module.cpp
+++ b/vehicle/OVMS.V3/main/ovms_module.cpp
@@ -431,7 +431,7 @@ static void print_blocks(OvmsWriter* writer, TaskHandle_t task, bool leaks)
         break;
     if (j == numafter)
       {
-      writer->printf("- t=%.15s s=%4d a=%p\n", name.bytes,
+      writer->printf("- t=%.15s s=%4" PRId32 " a=%p\n", name.bytes,
         before[i].size, before[i].address);
       ++count;
       }
@@ -461,7 +461,7 @@ static void print_blocks(OvmsWriter* writer, TaskHandle_t task, bool leaks)
         {
         for (int pi=0; pi<32; pi++)
           pbuf[pi] = isprint(((char*)p)[pi]) ? ((char*)p)[pi] : '.';
-        writer->printf("  t=%.15s s=%4d a=%p  %08X %08X %08X %08X %08X %08X %08X %08X | %-32.32s\n",
+        writer->printf("  t=%.15s s=%4" PRId32 " a=%p  %08X %08X %08X %08X %08X %08X %08X %08X | %-32.32s\n",
           name.bytes, after[i].size, p, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], pbuf);
         }
       size += after[i].size;
@@ -497,7 +497,7 @@ static void print_blocks(OvmsWriter* writer, TaskHandle_t task, bool leaks)
         {
         for (int pi=0; pi<32; pi++)
           pbuf[pi] = isprint(((char*)p)[pi]) ? ((char*)p)[pi] : '.';
-        writer->printf("+ t=%.15s s=%4d a=%p  %08X %08X %08X %08X %08X %08X %08X %08X | %-32.32s\n",
+        writer->printf("+ t=%.15s s=%4" PRId32 " a=%p  %08X %08X %08X %08X %08X %08X %08X %08X | %-32.32s\n",
           name.bytes, after[i].size, p, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], pbuf);
         }
       size += after[i].size;
@@ -780,7 +780,7 @@ static void module_tasks(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, in
         uint32_t used = total - ((uint32_t)taskstatus[i].pxStackBase & 0xFFFF);
         int core = xTaskGetAffinity(taskstatus[i].xHandle);
         uint32_t runtime = taskstatus[i].ulRunTimeCounter - last_runtime[taskstatus[i].xTaskNumber];
-        writer->printf("%08X %4u %s %-15s %5u %5u %5u %7u%7u%7u  %c %3d %3.0f%% %3d/%2d\n",
+        writer->printf("%08" PRIX32 " %4u %s %-15s %5" PRIu32 " %5" PRIu32 " %5" PRIu32 " %7u%7u%7u  %c %3d %3.0f%% %3d/%2d\n",
           (uint32_t)taskstatus[i].xHandle,
           taskstatus[i].xTaskNumber, states[taskstatus[i].eCurrentState], taskstatus[i].pcTaskName,
           used, total - taskstatus[i].usStackHighWaterMark, total, heaptotal, heap32bit, heapspi,
@@ -796,7 +796,7 @@ static void module_tasks(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, in
             uint32_t word = *topstack++;
             if ((word & 0xFF000000) == 0x80000000)
               {
-              writer->printf("  %#x", word - 0x40000000);
+              writer->printf("  %#" PRIx32, word - 0x40000000);
               }
             }
           writer->printf("\n");
@@ -843,7 +843,7 @@ static void module_tasks_data(int verbosity, OvmsWriter* writer, OvmsCommand* cm
   uint32_t diff_totalruntime = totalruntime - last_totalruntime;
 
   // output task count & total runtime diff:
-  buf.printf("*-OVM-DebugTasks,1,86400,%u,%u", n, diff_totalruntime);
+  buf.printf("*-OVM-DebugTasks,1,86400,%u,%" PRIu32, n, diff_totalruntime);
 
   // output tasks sorted by xTaskNumber:
   num = 0;
@@ -870,7 +870,7 @@ static void module_tasks_data(int verbosity, OvmsWriter* writer, OvmsCommand* cm
         //  ,<stack_now>,<stack_max>,<stack_total>
         //  ,<heaptotal>,<heap32bit>,<heapspi>
         //  ,<runtime>
-        buf.printf(",%u,%-.15s,%s,%u,%u,%u,%u,%u,%u,%u",
+        buf.printf(",%u,%-.15s,%s,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%u,%u,%u,%" PRIu32,
           taskstatus[i].xTaskNumber, taskstatus[i].pcTaskName, states[taskstatus[i].eCurrentState],
           used, total - taskstatus[i].usStackHighWaterMark, total,
           heaptotal, heap32bit, heapspi, runtime);
@@ -1069,20 +1069,20 @@ static void module_perform_factoryreset(OvmsWriter* writer)
 
   if (writer)
     {
-    writer->printf("Store partition is at %08x size %08x\n", p->address, p->size);
+    writer->printf("Store partition is at %08" PRIx32 " size %08" PRIx32 "\n", p->address, p->size);
     writer->puts("Unmounting configuration store...");
     }
   else
     {
-    ESP_LOGI(TAG, "Store partition is at %08x size %08x", p->address, p->size);
+    ESP_LOGI(TAG, "Store partition is at %08" PRIx32 " size %08" PRIx32, p->address, p->size);
     ESP_LOGI(TAG, "Unmounting configuration store...");
     }
   MyConfig.unmount();
 
   if (writer)
-    writer->printf("Erasing %d bytes of flash...\n",p->size);
+    writer->printf("Erasing %" PRId32 " bytes of flash...\n",p->size);
   else
-    ESP_LOGI(TAG, "Erasing %d bytes of flash...", p->size);
+    ESP_LOGI(TAG, "Erasing %" PRId32 " bytes of flash...", p->size);
   spi_flash_erase_range(p->address, p->size);
 
   if (writer)

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -125,7 +125,7 @@ void network_connections(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, in
       uint32_t id = strtol(argv[0], NULL, 16);
       int cnt = MyNetManager.CloseConnection(id);
       if (cnt == 0)
-        writer->printf("ERROR: connection ID %08x not found\n", id);
+        writer->printf("ERROR: connection ID %08" PRIx32 " not found\n", id);
       else
         writer->printf("Close signal sent to %d connection(s)\n", cnt);
       }
@@ -154,7 +154,7 @@ void network_connections(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, in
       if (!MyNetManager.ExecuteJob(&job, pdMS_TO_TICKS(5000)))
         writer->puts("ERROR: job failed");
       else if (job.close.cnt == 0)
-        writer->printf("ERROR: connection ID %08x not found\n", job.close.id);
+        writer->printf("ERROR: connection ID %08" PRIx32 " not found\n", job.close.id);
       else
         writer->printf("Close signal sent to %d connection(s)\n", job.close.cnt);
       }
@@ -910,7 +910,7 @@ int OvmsNetManager::ListConnections(int verbosity, OvmsWriter* writer)
       continue;
     mg_conn_addr_to_str(c, local, sizeof(local), MG_SOCK_STRINGIFY_IP|MG_SOCK_STRINGIFY_PORT);
     mg_conn_addr_to_str(c, remote, sizeof(remote), MG_SOCK_STRINGIFY_IP|MG_SOCK_STRINGIFY_PORT|MG_SOCK_STRINGIFY_REMOTE);
-    writer->printf("%08x  %08x  %08x  %-21s  %s\n", (uint32_t)c, (uint32_t)c->flags, (uint32_t)c->user_data, local, remote);
+    writer->printf("%08" PRIx32 "  %08" PRIx32 "  %08" PRIx32 "  %-21s  %s\n", (uint32_t)c, (uint32_t)c->flags, (uint32_t)c->user_data, local, remote);
     cnt++;
     }
   return cnt;
@@ -969,7 +969,7 @@ int OvmsNetManager::CleanupConnections()
     memset(&sa, 0, sizeof(sa));
     if (getsockname(c->sock, &sa.sa, &slen) != 0)
       {
-      ESP_LOGW(TAG, "CleanupConnections: conn %08x: getsockname failed", (uint32_t)c);
+      ESP_LOGW(TAG, "CleanupConnections: conn %08" PRIx32 ": getsockname failed", (uint32_t)c);
       continue;
       }
 
@@ -984,13 +984,13 @@ int OvmsNetManager::CleanupConnections()
       }
 
     if (ni)
-      ESP_LOGD(TAG, "CleanupConnections: conn %08x -> iface %c%c%d", (uint32_t)c, ni->name[0], ni->name[1], ni->num);
+      ESP_LOGD(TAG, "CleanupConnections: conn %08" PRIx32 " -> iface %c%c%d", (uint32_t)c, ni->name[0], ni->name[1], ni->num);
     else
-      ESP_LOGD(TAG, "CleanupConnections: conn %08x -> no iface", (uint32_t)c);
+      ESP_LOGD(TAG, "CleanupConnections: conn %08" PRIx32 " -> no iface", (uint32_t)c);
 
     if (!ni || !(ni->flags & NETIF_FLAG_UP) || !(ni->flags & NETIF_FLAG_LINK_UP))
       {
-      ESP_LOGI(TAG, "CleanupConnections: closing conn %08x: interface/link down", (uint32_t)c);
+      ESP_LOGI(TAG, "CleanupConnections: closing conn %08" PRIx32 ": interface/link down", (uint32_t)c);
       c->flags |= MG_F_CLOSE_IMMEDIATELY;
       cnt++;
       continue;
@@ -1002,7 +1002,7 @@ int OvmsNetManager::CleanupConnections()
       memset(&sa, 0, sizeof(sa));
       if (getpeername(c->sock, &sa.sa, &slen) != 0)
         {
-        ESP_LOGW(TAG, "CleanupConnections: conn %08x: getpeername failed", (uint32_t)c);
+        ESP_LOGW(TAG, "CleanupConnections: conn %08" PRIx32 ": getpeername failed", (uint32_t)c);
         continue;
         }
       int i;
@@ -1014,11 +1014,11 @@ int OvmsNetManager::CleanupConnections()
 
       if (i < ap_ip_list.num)
         {
-        ESP_LOGD(TAG, "CleanupConnections: conn %08x -> AP IP " IPSTR, (uint32_t)c, IP2STR(&ap_ip_list.sta[i].ip));
+        ESP_LOGD(TAG, "CleanupConnections: conn %08" PRIx32 " -> AP IP " IPSTR, (uint32_t)c, IP2STR(&ap_ip_list.sta[i].ip));
         }
       else
         {
-        ESP_LOGI(TAG, "CleanupConnections: closing conn %08x: AP peer disconnected", (uint32_t)c);
+        ESP_LOGI(TAG, "CleanupConnections: closing conn %08" PRIx32 ": AP peer disconnected", (uint32_t)c);
         c->flags |= MG_F_CLOSE_IMMEDIATELY;
         cnt++;
         }

--- a/vehicle/OVMS.V3/main/ovms_notify.cpp
+++ b/vehicle/OVMS.V3/main/ovms_notify.cpp
@@ -94,7 +94,7 @@ void notify_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
       for (NotifyEntryMap_t::iterator ite=mt->m_entries.begin(); ite!=mt->m_entries.end(); ++ite)
         {
         OvmsNotifyEntry* e = ite->second;
-        writer->printf("    %d: [%d pending] %s\n",
+        writer->printf("    %" PRId32 ": [%d pending] %s\n",
           ite->first, e->CountPending(), e->GetValue().c_str());
         }
       }
@@ -118,7 +118,7 @@ void notify_errorcode_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, 
   {
   for (OvmsNotifyErrorCodeMap_t::iterator it=MyNotify.m_errorcodes.begin(); it!=MyNotify.m_errorcodes.end(); ++it)
     {
-    writer->printf("%u(0x%4.4x) %s raised %d, updated %d, sec(s) ago\n",
+    writer->printf("%" PRIu32 "(0x%4.4" PRIx32 ") %s raised %" PRId32 ", updated %" PRId32 ", sec(s) ago\n",
       it->first,
       it->second->lastdata,
       (it->second->active)?"active":"cleared",
@@ -370,7 +370,7 @@ void OvmsNotifyType::Cleanup(OvmsNotifyEntry* entry, NotifyEntryMap_t::iterator*
       if (next) *next = it;
       }
     if (DO_TRACE(m_name))
-      ESP_LOGD(TAG,"Cleanup type %s id %d",m_name,entry->m_id);
+      ESP_LOGD(TAG,"Cleanup type %s id %" PRId32,m_name,entry->m_id);
     delete entry;
     }
   }
@@ -786,7 +786,7 @@ void OvmsNotify::NotifyErrorCode(uint32_t code, uint32_t data, bool raised, bool
   entry->updated = monotonictime;
   if (raised)
     {
-    NotifyStringf("error", "code", "%s,%u,%u",
+    NotifyStringf("error", "code", "%s,%" PRIu32 ",%" PRIu32 ,
       MyVehicleFactory.ActiveVehicleType(),
       code,
       data);

--- a/vehicle/OVMS.V3/main/ovms_time.cpp
+++ b/vehicle/OVMS.V3/main/ovms_time.cpp
@@ -74,7 +74,7 @@ void time_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
       OvmsTimeProvider* tp = itc->second;
       time_t tim = tp->m_time + (monotonictime-tp->m_lastreport);
       struct tm* tml = gmtime(&tim);
-      writer->printf("%s%-20.20s%7d%8d %s",
+      writer->printf("%s%-20.20s%7d%8" PRId32 " %s",
         (tp==MyTime.m_current)?"*":" ",
         tp->m_provider, tp->m_stratum, monotonictime-tp->m_lastreport, asctime(tml));
       }


### PR DESCRIPTION
In ESP-IDF v5+, a compiler change has been made for type int32_t and uint32_t : Cf https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/gcc.html#int32-t-and-uint32-t-for-xtensa-compiler

This change forces us to update the `printf` format strings and use, as much as possible, the [`PRI...` portable format constants](https://en.cppreference.com/w/cpp/types/integer)
