### PR TITLE
Use ESP-NETIF instead of TCP/IP Adapter

### DIFF
--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
@@ -106,10 +106,17 @@ class esp32wifi : public pcp, public InternalRamAllocated
     uint8_t m_previous_reason;
     uint8_t m_mac_sta[6];
     uint8_t m_mac_ap[6];
+#if ESP_IDF_VERSION_MAJOR >= 4
+    esp_netif_ip_info_t m_ip_info_sta;
+    esp_netif_ip_info_t m_ip_info_ap;
+    esp_netif_ip_info_t m_ip_static_sta;
+    esp_netif_dns_info_t m_dns_static_sta;
+#else
     tcpip_adapter_ip_info_t m_ip_info_sta;
     tcpip_adapter_ip_info_t m_ip_info_ap;
     tcpip_adapter_ip_info_t m_ip_static_sta;
     tcpip_adapter_dns_info_t m_dns_static_sta;
+#endif
     wifi_init_config_t m_wifi_init_cfg;
     wifi_config_t m_wifi_ap_cfg;
     wifi_config_t m_wifi_sta_cfg;

--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
@@ -39,6 +39,14 @@
 #include "ovms.h"
 #include "ovms_events.h"
 #include "ovms_mutex.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
+#include "esp_netif.h"
+#else
+#include "tcpip_adapter.h"
+#endif
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <esp_mac.h>
+#endif
 
 typedef enum {
     ESP32WIFI_MODE_OFF = 0,   // Modem is off

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/gsmpppos.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/gsmpppos.cpp
@@ -38,6 +38,9 @@ static const char *TAG = "gsm-ppp";
 #include "ovms_command.h"
 #include "ovms_config.h"
 #include "ovms_events.h"
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <netif/ppp/pppapi.h>
+#endif
 
 static u32_t GsmPPPOS_OutputCallback(ppp_pcb *pcb, u8_t *data, u32_t len, void *ctx)
   {
@@ -214,7 +217,7 @@ void GsmPPPOS::Startup()
   {
   if (m_ppp == NULL) return;
 
-  pppapi_set_auth(m_ppp, PPPAUTHTYPE_PAP,
+  ppp_set_auth(m_ppp, PPPAUTHTYPE_PAP,
     MyConfig.GetParamValue("modem", "apn.user").c_str(),
     MyConfig.GetParamValue("modem", "apn.password").c_str());
   ppp_set_usepeerdns(m_ppp, 1); // Ask the peer for up to 2 DNS server addresses

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/gsmpppos.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/gsmpppos.h
@@ -35,7 +35,11 @@
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include "driver/uart.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
+#include "esp_netif.h"
+#else
 #include "tcpip_adapter.h"
+#endif
 extern "C"
   {
 #include "netif/ppp/pppos.h"

--- a/vehicle/OVMS.V3/main/ovms_events.cpp
+++ b/vehicle/OVMS.V3/main/ovms_events.cpp
@@ -40,6 +40,13 @@ static const char *TAG = "events";
 #include "ovms_command.h"
 #include "ovms_script.h"
 #include "ovms_boot.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
+#include <esp_netif_types.h>
+#include <esp_eth_com.h>
+#endif
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <esp_wifi_types.h>
+#endif
 
 #ifdef CONFIG_OVMS_COMP_OTA
 #include "ovms_ota.h"

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -942,7 +942,13 @@ int OvmsNetManager::CleanupConnections()
 
   struct netif *ni;
   mg_connection *c;
+#if ESP_IDF_VERSION_MAJOR >= 5
+  wifi_sta_mac_ip_list_t ap_ip_list;
+#elif ESP_IDF_VERSION_MAJOR >= 4
+  esp_netif_sta_list_t ap_ip_list;
+#else
   tcpip_adapter_sta_list_t ap_ip_list;
+#endif
   union socket_address sa;
   socklen_t slen = sizeof(sa);
   int cnt = 0;
@@ -955,7 +961,14 @@ int OvmsNetManager::CleanupConnections()
     wifi_sta_list_t sta_list;
     if (esp_wifi_ap_get_sta_list(&sta_list) != ESP_OK)
       ESP_LOGW(TAG, "CleanupConnections: can't get AP station list");
+
+#if ESP_IDF_VERSION_MAJOR >= 5
+    else if (esp_wifi_ap_get_sta_list_with_ip(&sta_list, &ap_ip_list) != ESP_OK)
+#elif ESP_IDF_VERSION_MAJOR >= 4
+    else if (esp_netif_get_sta_list(&sta_list, &ap_ip_list) != ESP_OK)
+#else
     else if (tcpip_adapter_get_sta_list(&sta_list, &ap_ip_list) != ESP_OK)
+#endif
       ESP_LOGW(TAG, "CleanupConnections: can't get AP station IP list");
     }
 #endif // #ifdef CONFIG_OVMS_COMP_WIFI

--- a/vehicle/OVMS.V3/main/ovms_netmanager.h
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.h
@@ -38,6 +38,9 @@
 #else
 #include "tcpip_adapter.h"
 #endif
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "esp_wifi_ap_get_sta_list.h"
+#endif
 extern "C"
   {
 #include "lwip/netif.h"

--- a/vehicle/OVMS.V3/main/ovms_netmanager.h
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.h
@@ -33,7 +33,11 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
+#include "esp_netif.h"
+#else
 #include "tcpip_adapter.h"
+#endif
 extern "C"
   {
 #include "lwip/netif.h"

--- a/vehicle/OVMS.V3/main/ovms_peripherals.cpp
+++ b/vehicle/OVMS.V3/main/ovms_peripherals.cpp
@@ -63,8 +63,15 @@ Peripherals::Peripherals()
         mac_addr[3], mac_addr[4], mac_addr[5]);
       }
     }
+#if ESP_IDF_VERSION_MAJOR >= 4
+  ESP_LOGI(TAG, "  ESP-NETIF");
+  ESP_ERROR_CHECK(esp_netif_init());
+  esp_netif_create_default_wifi_sta();
+  esp_netif_create_default_wifi_ap();
+#else
   ESP_LOGI(TAG, "  TCP/IP Adaptor");
   tcpip_adapter_init();
+#endif
 #endif // #if defined(CONFIG_OVMS_COMP_WIFI)||defined(CONFIG_OVMS_COMP_CELLULAR)
 
   gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
@@ -190,4 +197,7 @@ Peripherals::Peripherals()
 
 Peripherals::~Peripherals()
   {
+#if ESP_IDF_VERSION_MAJOR >= 4
+  esp_netif_deinit();
+#endif
   }


### PR DESCRIPTION
TCP/IP Adapter was the ESP-IDF network interface abstraction component used in versions <= 4.  
Starting with ESP-IDF 4, a new network interface abstraction component appears : ESP-NETIF.  
There is a [porting guide for ESP-IDF 4+](https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/network/tcpip_adapter_migration.html), and a few changes specific to ESP-IDF 5+.

This huge PR tries to stay 3.3 / 4 / 5 compatible and will need to be reviewed and tested.