### PR TITLE
ESP-IDF v4+ : remove deprecated mdns functions

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_mdns/src/ovms_mdns.cpp
+++ b/vehicle/OVMS.V3/components/ovms_mdns/src/ovms_mdns.cpp
@@ -39,11 +39,13 @@ static const char *TAG = "ovms-mdns";
 
 OvmsMDNS MyMDNS __attribute__ ((init_priority (8100)));
 
+#if ESP_IDF_VERSION_MAJOR < 4
 void OvmsMDNS::SystemEvent(std::string event, void* data)
   {
   system_event_t *ev = (system_event_t *)data;
   if (m_mdns) mdns_handle_system_event(NULL, ev);
   }
+#endif
 
 void OvmsMDNS::SystemStart(std::string event, void* data)
   {
@@ -108,7 +110,9 @@ OvmsMDNS::OvmsMDNS()
 
   using std::placeholders::_1;
   using std::placeholders::_2;
+#if ESP_IDF_VERSION_MAJOR < 4
   MyEvents.RegisterEvent(TAG,"system.event", std::bind(&OvmsMDNS::SystemEvent, this, _1, _2));
+#endif
   MyEvents.RegisterEvent(TAG,"system.start", std::bind(&OvmsMDNS::SystemStart, this, _1, _2));
   MyEvents.RegisterEvent(TAG,"system.shuttingdown",std::bind(&OvmsMDNS::EventSystemShuttingDown, this, _1, _2));
   }

--- a/vehicle/OVMS.V3/components/ovms_mdns/src/ovms_mdns.h
+++ b/vehicle/OVMS.V3/components/ovms_mdns/src/ovms_mdns.h
@@ -33,6 +33,7 @@
 
 #include "mdns.h"
 #include "ovms_events.h"
+#include "esp_idf_version.h"
 
 class OvmsMDNS
   {
@@ -41,7 +42,9 @@ class OvmsMDNS
     virtual ~OvmsMDNS();
 
   public:
+#if ESP_IDF_VERSION_MAJOR < 4
     void SystemEvent(std::string event, void* data);
+#endif
     void SystemStart(std::string event, void* data);
     void EventSystemShuttingDown(std::string event, void* data);
     void StartMDNS();


### PR DESCRIPTION
Starting with ESP-IDF v4.1+, `mdns_handle_system_event` [is deprecated](https://github.com/espressif/esp-idf/blob/349385cb645432b17a4f2148bdd0e863136324d1/components/mdns/include/mdns.h#L365)
this change is part of the new event mechanism.

The call is removed, which also removes the necessity to listen on a system event.