### PR TITLE
ESP-IDF v5+: changes to uart_config_t

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -116,7 +116,11 @@ void modem::Task()
     .stop_bits = UART_STOP_BITS_1,
     .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
     .rx_flow_ctrl_thresh = 122,
+#if ESP_IDF_VERSION_MAJOR < 5
     .use_ref_tick = 0,
+#else
+    .source_clk = UART_SCLK_DEFAULT,
+#endif
     };
   uart_param_config(m_uartnum, &uart_config);
   uart_set_pin(m_uartnum, m_txpin, m_rxpin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);

--- a/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.cpp
@@ -1232,7 +1232,11 @@ bool OvmsVehicleTeslaRoadster::TPMSRead(std::vector<uint32_t> *tpms)
     .stop_bits = UART_STOP_BITS_1,
     .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
     .rx_flow_ctrl_thresh = 122,
+#if ESP_IDF_VERSION_MAJOR < 5
     .use_ref_tick = 0,
+#else
+    .source_clk = UART_SCLK_DEFAULT,
+#endif
   };
   uart_param_config(uart, &uart_config);
   uart_set_pin(uart, 33, 32, 0, 0);
@@ -1306,7 +1310,11 @@ bool OvmsVehicleTeslaRoadster::TPMSWrite(std::vector<uint32_t> &tpms)
     .stop_bits = UART_STOP_BITS_1,
     .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
     .rx_flow_ctrl_thresh = 122,
+#if ESP_IDF_VERSION_MAJOR < 5
     .use_ref_tick = 0,
+#else
+    .source_clk = UART_SCLK_DEFAULT,
+#endif
   };
   uart_param_config(uart, &uart_config);
   uart_set_pin(uart, 33, 32, 0, 0);

--- a/vehicle/OVMS.V3/main/console_async.cpp
+++ b/vehicle/OVMS.V3/main/console_async.cpp
@@ -62,7 +62,11 @@ ConsoleAsync::ConsoleAsync()
     .stop_bits = UART_STOP_BITS_1,
     .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
     .rx_flow_ctrl_thresh = 122,
+#if ESP_IDF_VERSION_MAJOR < 5
     .use_ref_tick = 0,
+#else
+    .source_clk = UART_SCLK_DEFAULT,
+#endif
     };
   // Set UART parameters
   uart_param_config(EX_UART_NUM, &uart_config);


### PR DESCRIPTION
The field `.use_ref_tick` has been replaced by another one `.source_clk` with a different semantic.
Cf https://docs.espressif.com/projects/esp-idf/en/release-v5.0/esp32/migration-guides/release-5.x/peripherals.html#uart