### PR TITLE
ESP-IDF v5+: update WatchDogTimer initialization

### DIFF
--- a/vehicle/OVMS.V3/main/ovms.h
+++ b/vehicle/OVMS.V3/main/ovms.h
@@ -40,6 +40,7 @@
 #include <string>
 #include <sstream>
 #include "ovms_malloc.h"
+#include "esp_idf_version.h"
 
 #if ESP_IDF_VERSION_MAJOR >= 4
 #define CONFIG_CONSOLE_UART_NUM CONFIG_ESP_CONSOLE_UART_NUM
@@ -64,6 +65,25 @@
 #if !defined(FALLTHROUGH)
     #define FALLTHROUGH do {} while (0)  /* fallthrough */
 #endif
+
+#undef WDT_ALREADY_INITIALIZED
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 1)
+  #if CONFIG_ESP_TASK_WDT_INIT
+    #define WDT_ALREADY_INITIALIZED 1
+  #endif // CONFIG_ESP_TASK_WDT_INIT
+#endif // 5.0.1
+
+#if ESP_IDF_VERSION == ESP_IDF_VERSION_VAL(5, 0, 0)
+  #if CONFIG_ESP_TASK_WDT
+    #define WDT_ALREADY_INITIALIZED 1
+  #endif // CONFIG_ESP_TASK_WDT
+#endif // 5.0.0
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+  #if CONFIG_TASK_WDT
+    #define WDT_ALREADY_INITIALIZED 1
+  #endif // CONFIG_ESP_TASK_WDT_INIT
+#endif // < 5
 
 extern uint32_t monotonictime;
 

--- a/vehicle/OVMS.V3/main/ovms_main.cpp
+++ b/vehicle/OVMS.V3/main/ovms_main.cpp
@@ -35,8 +35,22 @@ static class FrameworkInit
         CONFIG_LOG_DEFAULT_LEVEL == 1 ? "ERROR" : "None");
       esp_log_level_set("*",(esp_log_level_t)CONFIG_LOG_DEFAULT_LEVEL);
 
+#if !WDT_ALREADY_INITIALIZED
       ESP_LOGI(TAG, "Initialising WATCHDOG...");
+#if ESP_IDF_VERSION_MAJOR >= 5
+      // If the TWDT was not initialized automatically on startup, manually intialize it now
+      esp_task_wdt_config_t config = {
+          .timeout_ms = 120 * 1000,
+          .idle_core_mask = 0,
+          .trigger_panic = true,
+      };
+      ESP_ERROR_CHECK(esp_task_wdt_init(&config));
+#else
       esp_task_wdt_init(120, true);
+#endif
+#else
+      ESP_LOGI(TAG, "WATCHDOG already initialized...");
+#endif // WDT_ALREADY_INITIALIZED
       }
   } fwi  __attribute__ ((init_priority (0150)));
 


### PR DESCRIPTION
We introduced the dependency on the (official) configuration item `CONFIG_ESP_TASK_WDT` to decide whether (or not) we want to initialize the WDT. In ESP-IDF v5+, it's not possible any more to (re)initialize and already initialized timer, and if `CONFIG_ESP_TASK_WDT` the WDT would have been initialized already during boot.

Note: For some reason, in ESP-IDF v5+, we need to define `CONFIG_ESP_TASK_WDT=n` otherwise it won't work as expected.