### PR TITLE
ESP-IDF v5+: dependency on ovms_tls.h / MG_ENABLE_SSL

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.cpp
+++ b/vehicle/OVMS.V3/components/ovms_netlib/src/ovms_nethttp.cpp
@@ -33,7 +33,9 @@ static const char *TAG = "ovms-net-http";
 
 #include "ovms.h"
 #include "ovms_nethttp.h"
+#ifdef CONFIG_MG_ENABLE_SSL
 #include "ovms_tls.h"
+#endif
 #include "ovms_utils.h"
 #include "ovms_buffer.h"
 

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_http.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_http.cpp
@@ -50,7 +50,9 @@ static const char *TAG = "ovms-duk-http";
 #include "console_async.h"
 #include "buffered_shell.h"
 #include "ovms_netmanager.h"
+#if CONFIG_MG_ENABLE_SSL
 #include "ovms_tls.h"
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // DuktapeHTTPRequest

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_util.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_util.cpp
@@ -47,7 +47,6 @@ static const char *TAG = "ovms-duk-util";
 #include "console_async.h"
 #include "buffered_shell.h"
 #include "ovms_netmanager.h"
-#include "ovms_tls.h"
 
 #ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE_HEAP_UMM
   #include "umm_malloc_cfg.h"

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_vfs.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_vfs.cpp
@@ -47,7 +47,6 @@ static const char *TAG = "ovms-duk-vfs";
 #include "console_async.h"
 #include "buffered_shell.h"
 #include "ovms_netmanager.h"
-#include "ovms_tls.h"
 #include "ovms_boot.h"
 #include "ovms_peripherals.h"
 

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duktape.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duktape.cpp
@@ -47,7 +47,6 @@ static const char *TAG = "ovms-duktape";
 #include "console_async.h"
 #include "buffered_shell.h"
 #include "ovms_netmanager.h"
-#include "ovms_tls.h"
 
 #ifdef CONFIG_OVMS_COMP_PLUGINS
 #include "ovms_plugins.h"

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -38,7 +38,9 @@ static const char *TAG = "ovms-server-v3";
 #include "ovms_command.h"
 #include "ovms_metrics.h"
 #include "metrics_standard.h"
+#if CONFIG_MG_ENABLE_SSL
 #include "ovms_tls.h"
+#endif
 
 OvmsServerV3 *MyOvmsServerV3 = NULL;
 size_t MyOvmsServerV3Modifier = 0;
@@ -679,8 +681,14 @@ void OvmsServerV3::Connect()
   opts.error_string = &err;
   if (m_tls)
     {
+#if CONFIG_MG_ENABLE_SSL
     opts.ssl_ca_cert = MyOvmsTLS.GetTrustedList();
     opts.ssl_server_name = m_server.c_str();
+#else
+    ESP_LOGE(TAG, "mg_connect(%s) failed: SSL support disabled", address.c_str());
+    SetStatus("Error: Connection failed (SSL support disabled)", true, Undefined);
+    return;
+#endif
     }
   if ((m_mgconn = mg_connect_opt(mgr, address.c_str(), OvmsServerV3MongooseCallback, opts)) == NULL)
     {


### PR DESCRIPTION
Undefining MG_ENABLE_SSL (which we had to do during the setup of the ESP-IDF v5 upgrade) show that some modules would not compile any more. We make them work as well as possible.