### PR TITLE
fix missing esp_timer header

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_bcm.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_bcm.cpp
@@ -31,6 +31,7 @@
 
 static const char *TAG = "v-mgev";
 
+#include <esp_timer.h>
 #include "vehicle_mgev.h"
 #include "mg_auth.h"
 

--- a/vehicle/OVMS.V3/main/ovms_command.cpp
+++ b/vehicle/OVMS.V3/main/ovms_command.cpp
@@ -40,6 +40,7 @@ static const char *TAG = "command";
 #include <sys/time.h>
 #include <sys/types.h>
 #include <dirent.h>
+#include <esp_timer.h>
 #include "freertos/FreeRTOS.h"
 #include "ovms_command.h"
 #include "ovms_config.h"

--- a/vehicle/OVMS.V3/main/test_framework.cpp
+++ b/vehicle/OVMS.V3/main/test_framework.cpp
@@ -34,6 +34,7 @@ static const char *TAG = "test";
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <esp_timer.h>
 #include "esp_system.h"
 #include "esp_event.h"
 #include "esp_sleep.h"


### PR DESCRIPTION
In ESP-IDF 4+, this will trigger a compile error so we add the header.