### PR TITLE
Valet Mode - add default valet mode with simple geofence

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_location/src/ovms_location.h
+++ b/vehicle/OVMS.V3/components/ovms_location/src/ovms_location.h
@@ -100,12 +100,23 @@ class OvmsLocations
     bool m_gpsgood;
     float m_latitude;
     float m_longitude;
+
     float m_park_latitude;
     float m_park_longitude;
     float m_park_distance;
     bool m_park_invalid;
     OvmsRecMutex m_park_lock;
+
     uint32_t m_last_alarm;
+
+    float m_valet_latitude;
+    float m_valet_longitude;
+    float m_valet_distance;
+    bool m_valet_invalid;
+    bool m_valet_enabled;
+    uint32_t m_valet_last_alarm;
+    OvmsRecMutex m_valet_lock;
+
     LocationMap m_locations;
 
   public:
@@ -114,12 +125,16 @@ class OvmsLocations
     void UpdateParkPosition();
     void CheckTheft();
 
+    void UpdateValetPosition();
+    void CheckValet();
+
   public:
     void UpdatedGpsLock(OvmsMetric* metric);
     void UpdatedGpsSQ(OvmsMetric* metric);
     void UpdatedPosition(OvmsMetric* metric);
     void UpdatedVehicleOn(OvmsMetric* metric);
     void UpdatedConfig(std::string event, void* data);
+    void UpdateValetMode(OvmsMetric* metric);
   };
 
 extern OvmsLocations MyLocations;

--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -1922,7 +1922,7 @@ void OvmsServerV2::EventListener(std::string event, void* data)
     {
     ConfigChanged((OvmsConfigParam*) data);
     }
-  else if (event == "location.alert.flatbed.moved")
+  else if (event == "location.alert.flatbed.moved" || event == "location.alert.valet.bounds")
     {
     m_now_gps = true;
     }
@@ -2146,6 +2146,7 @@ OvmsServerV2::OvmsServerV2(const char* name)
   MyEvents.RegisterEvent(TAG,"config.changed", std::bind(&OvmsServerV2::EventListener, this, _1, _2));
   MyEvents.RegisterEvent(TAG,"config.mounted", std::bind(&OvmsServerV2::EventListener, this, _1, _2));
   MyEvents.RegisterEvent(TAG,"location.alert.flatbed.moved", std::bind(&OvmsServerV2::EventListener, this, _1, _2));
+  MyEvents.RegisterEvent(TAG,"location.alert.valet.bounds", std::bind(&OvmsServerV2::EventListener, this, _1, _2));
 
   // read config:
   ConfigChanged(NULL);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -452,6 +452,7 @@ class OvmsVehicle : public InternalRamAllocated
     virtual void NotifiedVehicleGenType(const std::string& state) {}
 
   protected:
+    uint32_t m_valet_last_alarm;
     virtual void ConfigChanged(OvmsConfigParam* param);
     virtual void MetricModified(OvmsMetric* metric);
     virtual void CalculateEfficiency();
@@ -464,7 +465,7 @@ class OvmsVehicle : public InternalRamAllocated
 
   protected:
     void RegisterCanBus(int bus, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile = NULL);
-    bool PinCheck(char* pin);
+    bool PinCheck(const char* pin);
 
   public:
     virtual void RxTask();

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -269,6 +269,9 @@ MetricsStandard::MetricsStandard()
   ms_v_pos_gpsspeed = new OvmsMetricFloat(MS_V_POS_GPSSPEED, SM_STALE_MIN, Kph);
   ms_v_pos_odometer = new OvmsMetricFloat(MS_V_POS_ODOMETER, SM_STALE_MID, Kilometers, true);
   ms_v_pos_trip = new OvmsMetricFloat(MS_V_POS_TRIP, SM_STALE_MID, Kilometers, true);
+  ms_v_pos_valet_latitude = new OvmsMetricFloat(MS_V_POS_VALET_LATITUDE, SM_STALE_NONE, Other, true);
+  ms_v_pos_valet_longitude = new OvmsMetricFloat(MS_V_POS_VALET_LONGITUDE, SM_STALE_NONE, Other, true);
+  ms_v_pos_valet_distance = new OvmsMetricFloat(MS_V_POS_VALET_DISTANCE, SM_STALE_HIGH, Meters, true);
 
   //
   // TPMS: tyre monitoring metrics

--- a/vehicle/OVMS.V3/main/metrics_standard.h
+++ b/vehicle/OVMS.V3/main/metrics_standard.h
@@ -242,6 +242,9 @@
 #define MS_V_POS_GPSSPEED           "v.p.gpsspeed"
 #define MS_V_POS_ODOMETER           "v.p.odometer"
 #define MS_V_POS_TRIP               "v.p.trip"
+#define MS_V_POS_VALET_LATITUDE     "v.p.valet.latitude"
+#define MS_V_POS_VALET_LONGITUDE    "v.p.valet.longitude"
+#define MS_V_POS_VALET_DISTANCE     "v.p.valet.distance"
 
 #define MS_V_TPMS_FL_T              "v.tp.fl.t"
 #define MS_V_TPMS_FR_T              "v.tp.fr.t"
@@ -505,6 +508,9 @@ class MetricsStandard
     OvmsMetricFloat*  ms_v_pos_gpsspeed;                  // GPS speed over ground [kph]
     OvmsMetricFloat*  ms_v_pos_odometer;
     OvmsMetricFloat*  ms_v_pos_trip;
+    OvmsMetricFloat*  ms_v_pos_valet_latitude;
+    OvmsMetricFloat*  ms_v_pos_valet_longitude;
+    OvmsMetricFloat*  ms_v_pos_valet_distance;
 
     //
     // TPMS: tyre monitoring metrics


### PR DESCRIPTION
 - Simply allowing 'Valet mode' without hardware support gives door detection anyway..
 - This adds the ability to have a Valet mode geofence radius from start location.