### PR TITLE
add a missing include

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_command.cpp
+++ b/vehicle/OVMS.V3/main/ovms_command.cpp
@@ -39,6 +39,7 @@ static const char *TAG = "command";
 #include <esp_log.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <dirent.h>
 #include <esp_timer.h>
 #include "freertos/FreeRTOS.h"


### PR DESCRIPTION
`sys/stat.h` include was missing from `main/ovms_command.cpp`, and it provoked a compilation error - interestingly, only shown when `CONFIG_OVMS_COMP_CELLULAR=n`

Thanks to @jetpax for the notice !

_Cf https://github.com/openvehicles/Open-Vehicle-Monitoring-System-3/issues/810#issuecomment-1454437854_