### PR TITLE
missing math.h include in some vehicle modules

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.cpp
@@ -50,6 +50,7 @@
 static const char *TAG = "v-bmwi3";
 
 #include <stdio.h>
+#include <math.h>
 #include "vehicle_bmwi3.h"
 
 #include "../ecu_definitions/ecu_sme_defines.h"

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -48,6 +48,7 @@
 #include "ovms_log.h"
 
 #include <stdio.h>
+#include <math.h>
 #include <string.h>
 #include "pcp.h"
 #include "metrics_standard.h"

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.cpp
@@ -31,6 +31,7 @@
 static const char *TAG = "v-hyundaivfl";
 
 #include <stdio.h>
+#include <math.h>
 #include "vehicle_hyundai_ioniqvfl.h"
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -31,6 +31,7 @@
 
 static const char *TAG = "v-mgev";
 
+#include <math.h>
 #include "vehicle_mgev.h"
 #include "ovms_notify.h"
 

--- a/vehicle/OVMS.V3/components/vehicle_minise/src/vehicle_minise.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_minise/src/vehicle_minise.cpp
@@ -51,6 +51,7 @@
 static const char *TAG = "v-minise";
 
 #include <cstdio>
+#include <math.h>
 #include "vehicle_minise.h"
 
 #include "../ecu_definitions/ecu_sme_defines.h"

--- a/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.cpp
@@ -97,6 +97,7 @@
 
 #include "ovms_log.h"
 #include <stdio.h>
+#include <math.h>
 #include <string.h>
 #include "pcp.h"
 #include "vehicle_mitsubishi.h"

--- a/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_can_poll.cpp
@@ -83,6 +83,7 @@ static const char *TAG = "v-smarted";
 #include <string>
 #include <iomanip>
 #include <numeric>
+#include <math.h>
 #include "pcp.h"
 #include "ovms_events.h"
 #include "metrics_standard.h"


### PR DESCRIPTION
This would be needed for stricter compiler in ESP-IDF v5+