### PR TITLE
ESP-IDF v5+: CMakeLists.txt - fixes for mcp2515 / ovms_webserver

### DIFF
--- a/vehicle/OVMS.V3/components/mcp2515/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/mcp2515/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(srcs)
 set(include_dirs)
 
-if (CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE)
+if (CONFIG_OVMS_COMP_MCP2515)
   list(APPEND srcs "src/mcp2515.cpp")
   list(APPEND include_dirs "src")
 endif ()

--- a/vehicle/OVMS.V3/components/ovms_webserver/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/ovms_webserver/CMakeLists.txt
@@ -12,7 +12,7 @@ endif ()
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS ${include_dirs}
                        REQUIRES "pushover" "mongoose"
-                       PRIV_REQUIRES "main"
+                       PRIV_REQUIRES "main" "ovms_plugins"
                        EMBED_FILES ${embedded_files}
                        WHOLE_ARCHIVE)
 


### PR DESCRIPTION
Found 2 errors introduced in d71c03091.
Should only impact ESP-IDF v5+ builds, no impact on current ESP-IDF 3.3.4 builds.