### PR TITLE
module_perform_factoryreset : use `esp_partition_erase_range` instead of `spi_flash_erase_range`

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_module.cpp
+++ b/vehicle/OVMS.V3/main/ovms_module.cpp
@@ -1083,7 +1083,16 @@ static void module_perform_factoryreset(OvmsWriter* writer)
     writer->printf("Erasing %" PRId32 " bytes of flash...\n",p->size);
   else
     ESP_LOGI(TAG, "Erasing %" PRId32 " bytes of flash...", p->size);
-  spi_flash_erase_range(p->address, p->size);
+
+  esp_err_t err = esp_partition_erase_range(p, 0, p->size);
+  if (ESP_OK != err)
+    {
+    if (writer)
+      writer->printf("Factory reset of configuration store failed: %s\n", esp_err_to_name(err));
+    else
+      ESP_LOGE(TAG, "Factory reset of configuration store failed: %s", esp_err_to_name(err));
+    return;
+    }
 
   if (writer)
     writer->puts("Factory reset of configuration store complete and reboot now...");


### PR DESCRIPTION
On ESP-IDF v5+ `spi_flash_erase_range` is replaced with `esp_flash_erase_region`, which would need a flash chip `esp_flash_init()` call at some point.

It looks easier to use `esp_partition_erase_range`, which in addition is a little bit higher level, does bounds checking and is recommended for the main SPI Flash Chip.

Cf 
* https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/spi_flash/index.html#overview
* https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/spi_flash/index.html#_CPPv422esp_flash_erase_regionP11esp_flash_t8uint32_t8uint32_t
* https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/partition.html#_CPPv425esp_partition_erase_rangePK15esp_partition_t6size_t6size_t