### PR TITLE
Docs: replace deprecated `m2r` plugin with its successor `m2r2`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ See: [http://www.sphinx-doc.org/en/master/usage/installation.html](http://www.sp
 
 #### 3. Install Plugins
 
-`pip install m2r`
+`pip install m2r2`
 
 #### 4. Build the docs
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ author = 'Open Vehicle Developers'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-  'm2r',
+  'm2r2',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,3 @@
-m2r
+m2r2
 docutils<0.18
 mistune<2.0.0


### PR DESCRIPTION
`m2r` project is in archive mode : https://github.com/miyakogi/m2r and there is a warning during plugin installation.   
[`m2r2`](https://pypi.org/project/m2r2/#description) presents itself as a maintained fork of `m2r`:
> M2R2 is a fork of m2r which hasn't been updated for a long time and there's been
> no response from the author about a PR fixing a serious issue that broke several
> pipelines using sphinx3. Every m2r config should work out of the box.