### PR TITLE
Update tpms.rst

### DIFF
--- a/docs/source/userguide/tpms.rst
+++ b/docs/source/userguide/tpms.rst
@@ -29,6 +29,6 @@ OVMS can only read the IDs from the TPMS ECU in the car itself. You can, however
 of a large number of TPMS tools) to trigger and read these IDs from the wheels. Once your garage gives you the sensor IDs (each
 expressed as an 8 character hexadecimal ID), you can enter them into OVMS as::
 
-  OVMS# tpms set SET ID1 ID2 ID3 ID4 ...
+  OVMS# tpms set SET LF-ID RF-ID LR-ID RR-ID ...
 
-(replace SET with your own identifier for this set of wheels, and ID1.. with the hexadecimal sensor ID)
+(replace SET with your own identifier for this set of wheels, and xx-ID.. with the specific location hexadecimal sensor ID)


### PR DESCRIPTION
Nowhere except in Mark's detailed write-up of the TPMS functionality does it specify the relationship of the ID1...ID4 to the location of the specific tires, hence the suggestion to change ID1 to LF-ID, ID2 to RF-ID, ID3 to LR-ID, and ID4 to RR-ID to correspond with the IDs for the specific tire locations on the vehicle.