### PR TITLE
ESP-IDF v5+ : upgrade to mdns 1.0.9

### DIFF
--- a/vehicle/OVMS.V3/dependencies.lock
+++ b/vehicle/OVMS.V3/dependencies.lock
@@ -1,15 +1,15 @@
 dependencies:
   espressif/mdns:
-    component_hash: 57d784cbe88b55b46ec815045153d195aca368a8019bb1eba9b0eb1d7e8f2de8
+    component_hash: 3f3bf8ff67ec99dde4e935637af087ebc899b9fee396ffa1c9138d3775f1aca4
     source:
       service_url: https://api.components.espressif.com/
       type: service
-    version: 1.0.8
+    version: 1.0.9
   idf:
     component_hash: null
     source:
       type: idf
     version: 5.0.0
-manifest_hash: 5e569d4809893782de6a4e0ac316eaef3dde72761006f8c680f8271229ddb5d8
+manifest_hash: 75ba99ffdcf0badf6c931d3b664f3b152222e487b4637a1c98df91bcf29b105a
 target: esp32
 version: 1.0.0


### PR DESCRIPTION
This dependency update is only for ESP-IDF v5+ - it should not impact ESP-IDF v3.3.4 builds.

Cf: 
* https://components.espressif.com/components/espressif/mdns
* https://github.com/espressif/esp-protocols/commits/mdns-v1.0.9