### PR TITLE
[ESP-IDFv4+] Network: fix duplicate definition in new 'network ping' command

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -178,8 +178,6 @@ static void test_on_ping_end(esp_ping_handle_t hdl, void *args)
 
 void network_ping(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
-  esp_ping_config_t ping_config = ESP_PING_DEFAULT_CONFIG();
-
   // parse hostname / IP address
   struct sockaddr_in6 sock_addr6;
   ip_addr_t target_addr;


### PR DESCRIPTION
It's unfortunate but I let this error slip ; and this part was not compiled in my compilation tests.