### PR TITLE
Fix warning as errors

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -365,7 +365,7 @@ void OvmsServerV2::ProcessServerMsg()
 
     delete pm_crypto1;
     delete pm_crypto2;
-    delete d;
+    delete[] d;
     ESP_LOGI(TAG, "Decoded Paranoid Msg: %s",line.c_str());
     }
 
@@ -763,7 +763,7 @@ bool OvmsServerV2::Transmit(const std::string& message)
     strcat(s,code);
     base64encode(d, len-6, (uint8_t*)s+8);
     // The messdage is now in paranoid mode...
-    delete d;
+    delete[] d;
     delete pm_crypto1;
     delete pm_crypto2;
     }

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_faults.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_faults.cpp
@@ -471,11 +471,11 @@ CANopenResult_t SevconClient::QueryLogs(int verbosity, OvmsWriter* writer, int w
       buf.str(""); buf.clear();
       buf << "RT-ENG-LogFaults," << n << ",86400,";
       AddFaultInfo(buf, sdoval);
-      _readsdo(0x4112, 0x02); buf << "," << sdoval;
-      _readsdo(0x4112, 0x03); buf << "," << sdoval;
-      _readsdo(0x4112, 0x04); buf << "," << sdoval;
-      _readsdo(0x4112, 0x05); buf << "," << sdoval;
-      _readsdo(0x4112, 0x06); buf << "," << sdoval;
+      (void)_readsdo(0x4112, 0x02); buf << "," << sdoval;
+      (void)_readsdo(0x4112, 0x03); buf << "," << sdoval;
+      (void)_readsdo(0x4112, 0x04); buf << "," << sdoval;
+      (void)_readsdo(0x4112, 0x05); buf << "," << sdoval;
+      (void)_readsdo(0x4112, 0x06); buf << "," << sdoval;
       _output(buf);
       outcnt++;
     }
@@ -497,11 +497,11 @@ CANopenResult_t SevconClient::QueryLogs(int verbosity, OvmsWriter* writer, int w
       buf.str(""); buf.clear();
       buf << "RT-ENG-LogSystem," << n << ",86400,";
       AddFaultInfo(buf, sdoval);
-      _readsdo(0x4102, 0x02); buf << "," << sdoval;
-      _readsdo(0x4102, 0x03); buf << "," << sdoval;
-      _readsdo(0x4102, 0x04); buf << "," << sdoval;
-      _readsdo(0x4102, 0x05); buf << "," << sdoval;
-      _readsdo(0x4102, 0x06); buf << "," << sdoval;
+      (void)_readsdo(0x4102, 0x02); buf << "," << sdoval;
+      (void)_readsdo(0x4102, 0x03); buf << "," << sdoval;
+      (void)_readsdo(0x4102, 0x04); buf << "," << sdoval;
+      (void)_readsdo(0x4102, 0x05); buf << "," << sdoval;
+      (void)_readsdo(0x4102, 0x06); buf << "," << sdoval;
       _output(buf);
       outcnt++;
     }
@@ -525,11 +525,11 @@ CANopenResult_t SevconClient::QueryLogs(int verbosity, OvmsWriter* writer, int w
       buf.str(""); buf.clear();
       buf << "RT-ENG-LogCounts," << n << ",86400,";
       AddFaultInfo(buf, sdoval);
-      _readsdo(0x4201+n, 0x04); buf << "," << sdoval;
-      _readsdo(0x4201+n, 0x05); buf << "," << sdoval;
-      _readsdo(0x4201+n, 0x02); buf << "," << sdoval;
-      _readsdo(0x4201+n, 0x03); buf << "," << sdoval;
-      _readsdo(0x4201+n, 0x06); buf << "," << sdoval;
+      (void)_readsdo(0x4201+n, 0x04); buf << "," << sdoval;
+      (void)_readsdo(0x4201+n, 0x05); buf << "," << sdoval;
+      (void)_readsdo(0x4201+n, 0x02); buf << "," << sdoval;
+      (void)_readsdo(0x4201+n, 0x03); buf << "," << sdoval;
+      (void)_readsdo(0x4201+n, 0x06); buf << "," << sdoval;
       _output(buf);
       outcnt++;
     }
@@ -553,15 +553,15 @@ CANopenResult_t SevconClient::QueryLogs(int verbosity, OvmsWriter* writer, int w
       if (!_readsdo(0x4300+n, 0x02)) break;
       buf.str(""); buf.clear();
       buf << "RT-ENG-LogMinMax," << n << ",86400," << sdoval;
-      _readsdo(0x4300+n, 0x03); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x04); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x05); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x06); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x07); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x0a); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x0b); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x0c); buf << "," << (int16_t) sdoval;
-      _readsdo(0x4300+n, 0x0d); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x03); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x04); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x05); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x06); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x07); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x0a); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x0b); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x0c); buf << "," << (int16_t) sdoval;
+      (void)_readsdo(0x4300+n, 0x0d); buf << "," << (int16_t) sdoval;
       _output(buf);
       outcnt++;
     }

--- a/vehicle/OVMS.V3/main/test_framework.cpp
+++ b/vehicle/OVMS.V3/main/test_framework.cpp
@@ -171,6 +171,7 @@ void test_watchdog(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
   writer->puts("Error: We should never get here");
   }
 
+__attribute__((noreturn))
 void test_stackoverflow(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
   uint8_t data[256];


### PR DESCRIPTION
While experimenting with newer ESP-IDF releases (branches v5.0 and v5.1) I found a few more warnings turned into errors, that were easy to fix.