### PR TITLE
Fix compilation errors when compiling without javascript runtime

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -47,6 +47,8 @@
 #include "ovms_script.h"
 #endif
 
+#include "ovms_command.h"
+
 #include "ovms_log.h"
 #define TAG ((const char*)"metric")
 


### PR DESCRIPTION
I've noticed some compiler errors due to OvmsWriter not being available in ovms_metrics.h when ovms_script.h is not included because duktape is disabled.