### PR TITLE
compatibility with WolfSSH >= 1.4.12

### DIFF
--- a/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
+++ b/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
@@ -1180,6 +1180,9 @@ static void wolfssh_logger(enum wolfSSH_LogLevel level, const char* const msg)
     case WS_LOG_SFTP:
     case WS_LOG_USER:
     case WS_LOG_ERROR:
+#if LIBWOLFSSH_VERSION_HEX >= 0x01004012
+    case WS_LOG_CERTMAN:
+#endif
       ESP_LOGE(wolfssh_tag, "%s", msg);
       break;
 


### PR DESCRIPTION
Recent versions of WolfSSH define a new enum `WS_LOG_CERTMAN` that we need to handle (otherwise we are greeted with a compilation error message).