### PR TITLE
Upgrade wolfssh 1.4.13

### DIFF
--- a/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
+++ b/vehicle/OVMS.V3/components/console_ssh/src/console_ssh.cpp
@@ -1180,6 +1180,9 @@ static void wolfssh_logger(enum wolfSSH_LogLevel level, const char* const msg)
     case WS_LOG_SFTP:
     case WS_LOG_USER:
     case WS_LOG_ERROR:
+#if LIBWOLFSSH_VERSION_HEX >= 0x01004012
+    case WS_LOG_CERTMAN:
+#endif
       ESP_LOGE(wolfssh_tag, "%s", msg);
       break;
 


### PR DESCRIPTION
Now that wolfssl has been upgraded to a recent version, we can target the latest release of wolfssh.