### PR TITLE
ESP-IDF v4+: we do not have uxMutexesHeld any more

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_module.cpp
+++ b/vehicle/OVMS.V3/main/ovms_module.cpp
@@ -780,6 +780,15 @@ static void module_tasks(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, in
         uint32_t used = total - ((uint32_t)taskstatus[i].pxStackBase & 0xFFFF);
         int core = xTaskGetAffinity(taskstatus[i].xHandle);
         uint32_t runtime = taskstatus[i].ulRunTimeCounter - last_runtime[taskstatus[i].xTaskNumber];
+#if ESP_IDF_VERSION_MAJOR >= 4
+        writer->printf("%08" PRIX32 " %4u %s %-15s %5" PRIu32 " %5" PRIu32 " %5" PRIu32 " %7u%7u%7u  %c %3d %3.0f%% %3d\n",
+          (uint32_t)taskstatus[i].xHandle,
+          taskstatus[i].xTaskNumber, states[taskstatus[i].eCurrentState], taskstatus[i].pcTaskName,
+          used, total - taskstatus[i].usStackHighWaterMark, total, heaptotal, heap32bit, heapspi,
+          (core == tskNO_AFFINITY) ? '*' : '0'+core, taskstatus[i].uxCurrentPriority,
+          diff_totalruntime ? ((float) runtime / diff_totalruntime * 100) : 0.0f,
+          taskstatus[i].uxBasePriority);
+#else
         writer->printf("%08" PRIX32 " %4u %s %-15s %5" PRIu32 " %5" PRIu32 " %5" PRIu32 " %7u%7u%7u  %c %3d %3.0f%% %3d/%2d\n",
           (uint32_t)taskstatus[i].xHandle,
           taskstatus[i].xTaskNumber, states[taskstatus[i].eCurrentState], taskstatus[i].pcTaskName,
@@ -787,6 +796,7 @@ static void module_tasks(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, in
           (core == tskNO_AFFINITY) ? '*' : '0'+core, taskstatus[i].uxCurrentPriority,
           diff_totalruntime ? ((float) runtime / diff_totalruntime * 100) : 0.0f,
           taskstatus[i].uxBasePriority, taskstatus[i].uxMutexesHeld);
+#endif
         if (showStack)
           {
           uint32_t* stack = (uint32_t*)(pxTaskGetStackStart(taskstatus[i].xHandle) + total);


### PR DESCRIPTION
In ESP-IDF 3.3.x builds of OVMS, we're using a fork of ESP-IDF. In this fork, FreeRTOS has been patched with openvehicles/esp-idf@95e43fc2c4360f8126a0985bf037a293bebe3767 to add a `uxMutexesHeld` field in `TaskStatus_t`.

However, in the ESP-IDF >= 4 build we're using mainstream ESP-IDF (for the moment), which does not include this field.

So we adapt the display to handle both cases.