### PR TITLE
ESP-IDF4+ : prevent a crash at boot

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_console.cpp
+++ b/vehicle/OVMS.V3/main/ovms_console.cpp
@@ -35,6 +35,7 @@
 #include "ovms_console.h"
 #include "ovms_version.h"
 #include "log_buffers.h"
+#include "esp_idf_version.h"
 
 //static const char *TAG = "Console";
 static char CRbuf[4] = { '\r', '\033', '[', 'K' };
@@ -124,6 +125,9 @@ void OvmsConsole::Service()
 
 void OvmsConsole::Poll(portTickType ticks, QueueHandle_t queue)
   {
+#if ESP_IDF_VERSION_MAJOR >= 4
+  static
+#endif
   Event event;
 
   if (!queue)


### PR DESCRIPTION
This is more a temporary workaround, than a definitive resolution.

There is a crash at boot, when starting the console, and I was able to work around it by declaring a variable as static.
It may have to do with stack size or something like that but I did not spend the time to analyze it (yet).