### PR TITLE
fix a few issues appearing when disabling/enabling components

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_plugins/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/ovms_plugins/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(srcs)
 set(include_dirs)
 
-if (CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE AND CONFIG_OVMS_COMP_PLUGINS)
-  list(APPEND srcs "src/ovms_plugins.cpp")
+if (CONFIG_OVMS_COMP_PLUGINS)
   list(APPEND include_dirs "src")
+if (CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE)
+  list(APPEND srcs "src/ovms_plugins.cpp")
+endif ()
 endif ()
 
 # requirements can't depend on config

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
@@ -438,10 +438,11 @@ public:
   static void WebCfgFeatures(PageEntry_t &p, PageContext_t &c);
   static void WebCfgBattery(PageEntry_t &p, PageContext_t &c);
   static void WebBattMon(PageEntry_t &p, PageContext_t &c);
+#endif //CONFIG_OVMS_COMP_WEBSERVER
 
+public:
   void RangeCalcReset();
   void RangeCalcStat(OvmsWriter *writer);
-#endif //CONFIG_OVMS_COMP_WEBSERVER
 public:
   std::string BatteryMonStat()
   {

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq56/src/vehicle_me56.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq56/src/vehicle_me56.cpp
@@ -37,6 +37,7 @@ static const char *TAG = "v-maxe56";
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
 #endif
+#include "ovms_notify.h"
 #include <algorithm>
 #include "metrics_standard.h"
 


### PR DESCRIPTION
* (specific to ESP-IDF4+) : make `ovms_plugins` compilable with or without `duktape`
* `vehicle_hyundai_ioniq5` had issue when disabling webserver component
* `vehicle_maxus_euniq56` had missing header when disabling webserver component