### PR TITLE
Disable continuous metric streaming when vehicle is off

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -98,7 +98,6 @@ class OvmsServerV3 : public OvmsServer
     bool m_sendall;
     int m_msgid;
     int m_lasttx;
-    int m_lasttx_stream;
     int m_lasttx_sendall;
     int m_peers;
     int m_streaming;


### PR DESCRIPTION
When enabling the new location streaming option, OVMS continuously sends modified metric updates even when the vehicles is off. 
For a Nissan Leaf, that is 4-6 metrics every second, which quickly uses up LTE data.

Please find a change that checks the caron value, m_streaming value and takes the minimum next update time based on the other state values.
The change also makes the nested (cond)?action1:action2 code more readable.