### PR TITLE
Fix MK2 battery capacity

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mgev/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/docs/index.rst
@@ -54,8 +54,8 @@ You can follow these steps to see which variant may be suitable for your car:
 MG ZS EV (2022-) Variants
 -------------------------
 
-Currently only the Long Range (72.6kWh) variant is supported as testers only seem to have this model.
-The Short Range (51.1kWh) variant can easily be supported if BMS scans can be done.
+Currently only the Short Range (51.1kWh) variant is supported as testers only seem to have this model.
+The Long Range (72.6kWh) variant can easily be supported if BMS scans can be done.
 
 ------------------------
 MG5 (2020-2023) Variants

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mg5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mg5.cpp
@@ -379,6 +379,6 @@ OvmsVehicleMg5Init::OvmsVehicleMg5Init()
 {
     ESP_LOGI(TAG, "Registering Vehicle: MG5 (9000)");
     
-    MyVehicleFactory.RegisterVehicle<OvmsVehicleMg5>("MG5", "MG 5 (2020-2023)");
+    MyVehicleFactory.RegisterVehicle<OvmsVehicleMg5>("MG5", "MG 5 (LR) (2020-2023)");
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgzsev2.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgzsev2.cpp
@@ -327,5 +327,5 @@ OvmsVehicleMgEvDInit::OvmsVehicleMgEvDInit()
 {
     ESP_LOGI(TAG, "Registering Vehicle: MG ZS EV (2023-)");
 
-    MyVehicleFactory.RegisterVehicle<OvmsVehicleMgEvD>("MGD", "MG ZS EV (2023-)");
+    MyVehicleFactory.RegisterVehicle<OvmsVehicleMgEvD>("MGD", "MG ZS EV (SR) (2023-)");
 }

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgzsev2.hpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgzsev2.hpp
@@ -36,8 +36,8 @@
 #include "vehicle_mgev.h"
 
 #define WLTP_RANGE 320.0 //km
-#define BATT_CAPACITY 68.3 //kWh
-#define MAX_CHARGE_RATE 94 //kW
+#define BATT_CAPACITY 49.0 //kWh
+#define MAX_CHARGE_RATE 75 //kW
 #define BMSDoDUpperLimit 1000.0
 #define BMSDoDLowerLimit 36.0
 


### PR DESCRIPTION
Fix error in documentation to show MG ZS EV Mk2 Standard Range support. Fix Mk2 battery capacity. Change vehicle dropdown to be clearer