### PR TITLE
Fix handling of BMS DoD values

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_configuration.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_configuration.cpp
@@ -78,7 +78,15 @@ void OvmsVehicleMgEv::ConfigChanged(OvmsConfigParam* param)
         StandardMetrics.ms_v_charge_limit_range->SetValue(
             (float) MyConfig.GetParamValueInt("xmg", "suffrange"), Miles );
     }
+    
+    if (StandardMetrics.ms_v_type->AsString() == "MGA") {
+        int BMSVersion = MyConfig.GetParamValueInt("xmg", "bmsval", DEFAULT_BMS_VERSION);
+        m_dod_lower->SetValue(BMSDoDLimits[BMSVersion].Lower);
+        m_dod_upper->SetValue(BMSDoDLimits[BMSVersion].Upper);
+    }
+    ESP_LOGD(TAG, "BMS DoD lower = %f upper = %f", MyConfig.GetParamValueFloat("xmg","bms.dod.lower"), MyConfig.GetParamValueFloat("xmg","bms.dod.upper"));
 }
+
 
 // Called by OVMS when server requests to set feature
 bool OvmsVehicleMgEv::SetFeature(int key, const char *value) {

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_poll_bms.cpp
@@ -304,8 +304,8 @@ void OvmsVehicleMgEv::SetBmsStatus(uint8_t status)
 
 float OvmsVehicleMgEv::calculateSoc(uint16_t value)
 {
-    float lowerlimit = MyConfig.GetParamValueInt("xmg","bms.dod.lower");
-    float upperlimit = MyConfig.GetParamValueInt("xmg","bms.dod.upper");
+    float lowerlimit = m_dod_lower->AsFloat();
+    float upperlimit = m_dod_upper->AsFloat();
     ESP_LOGD(TAG, "BMS Limits: Lower = %f Upper = %f",lowerlimit,upperlimit);
     // Calculate SOC from upper and lower limits
     return (value - lowerlimit) * 100.0f / (upperlimit - lowerlimit);

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mg5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mg5.cpp
@@ -134,8 +134,8 @@ OvmsVehicleMg5::OvmsVehicleMg5()
     StandardMetrics.ms_v_bat_range_full->SetValue(WLTP_RANGE);
     m_batt_capacity->SetValue(BATT_CAPACITY);
     m_max_dc_charge_rate->SetValue(MAX_CHARGE_RATE);
-    MyConfig.SetParamValueFloat("xmg","bms.dod.lower", BMSDoDLowerLimit);
-    MyConfig.SetParamValueFloat("xmg","bms.dod.upper", BMSDoDUpperLimit);
+    m_dod_lower->SetValue(BMSDoDLowerLimit);
+    m_dod_upper->SetValue(BMSDoDUpperLimit);
 
     //Initialise GWM state to Unknown
     //m_gwm_state->SetValue(static_cast<int>(GWMStates::Unknown));

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -185,6 +185,8 @@ OvmsVehicleMgEv::OvmsVehicleMgEv()
     m_avg_consumption = MyMetrics.InitFloat("xmg.p.avg.consumption", SM_STALE_MID, 165.0, WattHoursPK);
     m_batt_capacity = MyMetrics.InitFloat("xmg.b.capacity", SM_STALE_MID, 42.5, kWh);
     m_max_dc_charge_rate = MyMetrics.InitFloat("xmg.c.max.dc.charge", SM_STALE_MID, 82.0, kW);
+    m_dod_lower = MyMetrics.InitFloat("xmg.b.dod.lower", SM_STALE_MAX, 940.0);
+    m_dod_upper = MyMetrics.InitFloat("xmg.b.dod.upper", SM_STALE_MAX, 25.0);
 
     DRLFirstFrameSentCallback = std::bind(&OvmsVehicleMgEv::DRLFirstFrameSent, this, std::placeholders::_1, std::placeholders::_2);
     

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.h
@@ -122,6 +122,8 @@ class OvmsVehicleMgEv : public OvmsVehicle
     OvmsMetricFloat *m_avg_consumption; // Average consumption
     OvmsMetricFloat *m_batt_capacity; // Battery Capacity
     OvmsMetricFloat *m_max_dc_charge_rate; // Maximum Charge Rate
+    OvmsMetricFloat *m_dod_lower; // Battery DoD lower value used to calculate SOC
+    OvmsMetricFloat *m_dod_upper; // Battery DoD upper value used to calculate SOC
 
   protected:
     void ConfigChanged(OvmsConfigParam* param) override;

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.cpp
@@ -105,8 +105,9 @@ OvmsVehicleMgEvA::OvmsVehicleMgEvA()
     // Set Max Range to WLTP Range
     StandardMetrics.ms_v_bat_range_full->SetValue(WLTP_RANGE);
     
-    MyConfig.SetParamValueFloat("xmg","bms.dod.lower", BMSDoDLowerLimit);
-    MyConfig.SetParamValueFloat("xmg","bms.dod.upper", BMSDoDUpperLimit);
+    int BMSVersion = MyConfig.GetParamValueInt("xmg", "bmsval", DEFAULT_BMS_VERSION);
+    m_dod_lower->SetValue(BMSDoDLimits[BMSVersion].Lower);
+    m_dod_upper->SetValue(BMSDoDLimits[BMSVersion].Upper);
     m_batt_capacity->SetValue(BATT_CAPACITY);
     m_max_dc_charge_rate->SetValue(MAX_CHARGE_RATE);
 

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.h
@@ -37,8 +37,6 @@
 #define WLTP_RANGE 263.0 //km
 #define BATT_CAPACITY 42.5 //kWh
 #define MAX_CHARGE_RATE 82 //kW
-#define BMSDoDUpperLimit 940.0
-#define BMSDoDLowerLimit 25.0
 
 class OvmsVehicleMgEvA : public OvmsVehicleMgEv
 {

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_b.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_b.cpp
@@ -84,8 +84,8 @@ OvmsVehicleMgEvB::OvmsVehicleMgEvB()
     StandardMetrics.ms_v_bat_range_full->SetValue(WLTP_RANGE);
     m_batt_capacity->SetValue(BATT_CAPACITY);
     m_max_dc_charge_rate->SetValue(MAX_CHARGE_RATE);
-    MyConfig.SetParamValueFloat("xmg","bms.dod.lower", BMSDoDLowerLimit);
-    MyConfig.SetParamValueFloat("xmg","bms.dod.upper", BMSDoDUpperLimit);
+    m_dod_lower->SetValue(BMSDoDLowerLimit);
+    m_dod_upper->SetValue(BMSDoDUpperLimit);
 
     //Add variant specific poll data
     ConfigurePollData(obdii_polls_b, sizeof(obdii_polls_b));

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgzsev2.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgzsev2.cpp
@@ -101,8 +101,8 @@ OvmsVehicleMgEvD::OvmsVehicleMgEvD()
     StandardMetrics.ms_v_bat_range_full->SetValue(WLTP_RANGE);
     m_batt_capacity->SetValue(BATT_CAPACITY);
     m_max_dc_charge_rate->SetValue(MAX_CHARGE_RATE);
-    MyConfig.SetParamValueFloat("xmg","bms.dod.lower", BMSDoDLowerLimit);
-    MyConfig.SetParamValueFloat("xmg","bms.dod.upper", BMSDoDUpperLimit);
+    m_dod_lower->SetValue(BMSDoDLowerLimit);
+    m_dod_upper->SetValue(BMSDoDUpperLimit);
 
     //Add variant specific poll data
     ConfigurePollData(obdii_polls_d, sizeof(obdii_polls_d));


### PR DESCRIPTION
BMS DoD limits were not being updated when Config changed in the MG ZS EV (UK/EU). Added code to fix this. Save DoD Lower and DoD Upper to MyMetrics instead of MyConfig