### PR TITLE
Metrics - add Date metrics with local/utc printing

### DIFF
--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -43,7 +43,7 @@ MetricsStandard::MetricsStandard()
   ms_m_tasks = new OvmsMetricInt(MS_M_TASKS, SM_STALE_MID);
   ms_m_freeram = new OvmsMetricInt(MS_M_FREERAM, SM_STALE_MID);
   ms_m_monotonic = new OvmsMetricInt(MS_M_MONOTONIC, SM_STALE_MIN, Seconds);
-  ms_m_timeutc = new OvmsMetricInt(MS_M_TIME_UTC, SM_STALE_MIN, Seconds);
+  ms_m_timeutc = new OvmsMetricInt(MS_M_TIME_UTC, SM_STALE_MIN, DateUTC);
 
   ms_m_net_type = new OvmsMetricString(MS_N_TYPE, SM_STALE_MAX);
   ms_m_net_sq = new OvmsMetricInt(MS_N_SQ, SM_STALE_MAX, dbm);
@@ -259,7 +259,7 @@ MetricsStandard::MetricsStandard()
   ms_v_pos_gpshdop = new OvmsMetricFloat(MS_V_POS_GPSHDOP, SM_STALE_MIN);
   ms_v_pos_satcount= new OvmsMetricInt(MS_V_POS_SATCOUNT, SM_STALE_MIN);
   ms_v_pos_gpssq = new OvmsMetricInt(MS_V_POS_GPSSQ, SM_STALE_MIN, Percentage);
-  ms_v_pos_gpstime = new OvmsMetricInt(MS_V_POS_GPSTIME, SM_STALE_MIN, Seconds);
+  ms_v_pos_gpstime = new OvmsMetricInt(MS_V_POS_GPSTIME, SM_STALE_MIN, DateLocal);
   ms_v_pos_latitude = new OvmsMetricFloat(MS_V_POS_LATITUDE, SM_STALE_MIN, Other, true);
   ms_v_pos_longitude = new OvmsMetricFloat(MS_V_POS_LONGITUDE, SM_STALE_MIN, Other, true);
   ms_v_pos_location = new OvmsMetricString(MS_V_POS_LOCATION, SM_STALE_MID);

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -109,6 +109,10 @@ typedef enum : uint8_t
   dbm           = 80,   // Signal Quality (in dBm)
   sq            = 81,   // Signal Quality (in SQ units)
 
+  DateUnix      = 85,
+  DateUTC       = 86,
+  DateLocal     = 87,
+
   Percentage    = 90,
   Permille      = 91,
 
@@ -137,8 +141,8 @@ typedef enum : uint8_t
 } metric_defined_t;
 
 // Mask for folding "Short groups" to their equivalent "Long Group"
-const uint8_t GrpFoldMask = 0x0f;
-const uint8_t GrpUnfold = 0x10;
+const uint8_t GrpFoldMask = 0x1f;
+const uint8_t GrpUnfold = 0x20;
 typedef enum : uint8_t
   {
   GrpNone = 0,
@@ -157,6 +161,7 @@ typedef enum : uint8_t
   GrpDirection = 13,
   GrpRatio = 14,
   GrpCharge = 15,
+  GrpDate = 16,
   // These are where a dimension group is split and allows
   // easily folding the 'short distances' back onto their equivalents.
   GrpDistanceShort = GrpDistance + GrpUnfold,


### PR DESCRIPTION
- Adds UnixEpoch, UTCDate and LocalDate metrics as well as a 'Date' group.
- Sets standard metrics m.time.utc to use UTCDate and v.pos.gpstime to use LocalDate
- Conversion between the different Date metrics is unity - it is simply used for displaying and storing the date value.
- JSON Dates now use the standard(ish) Java date format.