### PR TITLE
Add 62kWh option to LEAF webui

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
@@ -155,7 +155,7 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input_radio_option("socnewcar", "relative to fixed value:", "yes", socnewcar == true);
   c.input_radio_end("");
   c.input("number", NULL, "maxgids", maxgids.c_str(), "Default: " STR(GEN_1_NEW_CAR_GIDS),
-      "<p>Enter the maximum GIDS value when fully charged. Default values are " STR(GEN_1_NEW_CAR_GIDS) " (24kWh) or " STR(GEN_1_30_NEW_CAR_GIDS) " (30kWh) or " STR(GEN_2_40_NEW_CAR_GIDS) " (40kWh)</p>",
+      "<p>Enter the maximum GIDS value when fully charged. Default values are " STR(GEN_1_NEW_CAR_GIDS) " (24kWh) or " STR(GEN_1_30_NEW_CAR_GIDS) " (30kWh) or " STR(GEN_2_40_NEW_CAR_GIDS) " (40kWh) or " STR(GEN_2_62_NEW_CAR_GIDS) " (62kWh)</p>",
       "min=\"1\" step=\"1\"", "GIDS");
 
   c.input_radio_start("SOH Display", "sohnewcar");
@@ -163,7 +163,7 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input_radio_option("sohnewcar", "relative to fixed value:", "yes", sohnewcar == true);
   c.input_radio_end("");
   c.input("number", NULL, "newcarah", newcarah.c_str(), "Default: " STR(GEN_1_NEW_CAR_AH),
-      "<p>This is the usable capacity of your battery when new. Default values are " STR(GEN_1_NEW_CAR_AH) " (24kWh) or " STR(GEN_1_30_NEW_CAR_AH) " (30kWh) or " STR(GEN_2_40_NEW_CAR_AH) " (40kWh)</p>",
+      "<p>This is the usable capacity of your battery when new. Default values are " STR(GEN_1_NEW_CAR_AH) " (24kWh) or " STR(GEN_1_30_NEW_CAR_AH) " (30kWh) or " STR(GEN_2_40_NEW_CAR_AH) " (40kWh) or " STR(GEN_2_62_NEW_CAR_AH) " (62kWh)</p>",
       "min=\"1\" step=\"1\"", "Ah");
   c.input("number", "Cabin Temperature Offset", "cabintempoffset", cabintempoffset.c_str(), "Default: " STR(DEFAULT_CABINTEMP_OFFSET),
       "<p>This allows an offset adjustment to the cabin temperature sensor readings in Celcius.</p>",


### PR DESCRIPTION
Noticed while setting up OVMS for my new 62kWh battery that this option was missing from the webUI. Added it!