### PR TITLE
Date metrics doc & clarify 'Service Time' as local date

### DIFF
--- a/docs/source/userguide/metrics.rst
+++ b/docs/source/userguide/metrics.rst
@@ -85,7 +85,7 @@ m.net.wifi.sq                            -79.1dBm                 …and signal 
 m.obdc2ecu.on                            no                       Is the OBD2ECU process currently on.
 m.serial                                                          Reserved for module serial no.
 m.tasks                                  20                       Task count (use ``module tasks`` to list)
-m.time.utc                               1572590910Sec            UTC time in seconds
+m.time.utc                               2023-12-03 02:14:31 UTC  Current UTC time [DateUTC]
 m.version                                3.2.005-155-g3133466f/…  Firmware version
 m.egpio.input                            0,1,2,3,4,5,6,7,9        EGPIO input port state (ports 0…9, present=high)
 m.egpio.monitor                          8,9                      EGPIO input monitoring ports
@@ -203,7 +203,7 @@ v.e.on                                   no                       yes = Vehicle 
 v.e.parktime                             49608Sec                 Seconds parking (turned off)
 v.e.regenbrake                                                    yes = Regenerative braking active
 v.e.serv.range                           12345km                  Distance to next scheduled maintenance/service [km]
-v.e.serv.time                            1572590910Sec            Time of next scheduled maintenance/service [Seconds]
+v.e.serv.time                            2023-12-03 10:16:05 AWST Time of next scheduled maintenance/service [DateLocal]
 v.e.temp                                                          Ambient temperature
 v.e.throttle                             0%                       Drive pedal state [%]
 v.e.valet                                                         yes = Valet mode engaged
@@ -243,7 +243,7 @@ v.p.gpslock                              no                       yes = has GPS 
 v.p.gpsmode                              AA                       <GPS><GLONASS>; N/A/D/E (None/Autonomous/Differential/Estimated)
 v.p.gpssq                                80%                      GPS signal quality [%] (<30 unusable, >50 good, >80 excellent)
 v.p.gpsspeed                             0km/h                    GPS speed over ground
-v.p.gpstime                              1572590910Sec            Time (UTC) of GPS coordinates [Seconds]
+v.p.gpstime                              2023-12-03 10:16:05 AWST Time of GPS coordinates [DateLocal]
 v.p.latitude                             51.3023                  GPS latitude
 v.p.location                             Home                     Name of current location if defined
 v.p.longitude                            7.39006                  GPS longitude

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -249,7 +249,7 @@ MetricsStandard::MetricsStandard()
   ms_v_env_cabinvent = new OvmsMetricString(MS_V_ENV_CABINVENT, SM_STALE_MID);
 
   ms_v_env_service_range = new OvmsMetricInt(MS_V_ENV_SERV_RANGE, SM_STALE_MID, Kilometers);
-  ms_v_env_service_time = new OvmsMetricInt(MS_V_ENV_SERV_TIME, SM_STALE_MID, Seconds);
+  ms_v_env_service_time = new OvmsMetricInt(MS_V_ENV_SERV_TIME, SM_STALE_MID, DateLocal);
 
   //
   // Position / movement metrics

--- a/vehicle/OVMS.V3/main/metrics_standard.h
+++ b/vehicle/OVMS.V3/main/metrics_standard.h
@@ -489,7 +489,7 @@ class MetricsStandard
     OvmsMetricString* ms_v_env_cabinintake;               // Cabin intake type (fresh, recirc, etc)
     OvmsMetricString* ms_v_env_cabinvent;                 // Cabin vent type (comma-separated list of feet, face, screen, etc)
     OvmsMetricInt*    ms_v_env_service_range;             // Distance to next scheduled maintenance/service [km]
-    OvmsMetricInt*    ms_v_env_service_time;              // Time to next scheduled maintenance/service [Seconds]
+    OvmsMetricInt*    ms_v_env_service_time;              // Time of scheduled maintenance/service [DateLocal]
 
     //
     // Position / location metrics


### PR DESCRIPTION
Updates doc for m.time.utc, v.e.serv.time and v.p.gpstime to reflect their default display as date.

Changes v.e.ser.time to a DateLocal (from Seconds) metric