### PR TITLE
OBD Poller - Cleaner interface to Poll-List and retrieving next entry

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -462,6 +462,17 @@ const char* OvmsVehicle::VehicleType()
   return MyVehicleFactory.ActiveVehicleType();
   }
 
+const char *OvmsVehicle::PollerSource(OvmsVehicle::poller_source_t src)
+  {
+  switch (src)
+    {
+    case poller_source_t::Primary: return "PRI";
+    case poller_source_t::Successful: return "SRX";
+    case poller_source_t::OnceOff: return "ONE";
+    }
+    return "XXX";
+  }
+
 void OvmsVehicle::RxTask()
   {
   CAN_frame_t frame;
@@ -478,7 +489,7 @@ void OvmsVehicle::RxTask()
         {
         PollerVWTPReceive(&frame, frame.MsgID);
         }
-      else if (m_poll_wait && frame.origin == m_poll.bus && m_poll_plist)
+      else if (m_poll_wait && frame.origin == m_poll.bus && HasPollList())
         {
         uint32_t msgid;
         if (m_poll.protocol == ISOTP_EXTADR)
@@ -572,7 +583,7 @@ void OvmsVehicle::VehicleTicker1(std::string event, void* data)
   m_ticker++;
 
   PollerStateTicker();
-  PollerSend(true);
+  PollerSend(poller_source_t::Primary);
 
   Ticker1(m_ticker);
   if ((m_ticker % 10) == 0) Ticker10(m_ticker);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
@@ -42,12 +42,12 @@ static const char *TAG = "vehicle-isotp";
  */
 void OvmsVehicle::PollerISOTPStart(bool fromTicker)
   {
-  if (m_poll_plcur->rxmoduleid != 0)
+  if (m_poll.entry.rxmoduleid != 0)
     {
     // send to <moduleid>, listen to response from <rmoduleid>:
-    m_poll.moduleid_sent = m_poll_plcur->txmoduleid;
-    m_poll.moduleid_low = m_poll_plcur->rxmoduleid;
-    m_poll.moduleid_high = m_poll_plcur->rxmoduleid;
+    m_poll.moduleid_sent = m_poll.entry.txmoduleid;
+    m_poll.moduleid_low = m_poll.entry.rxmoduleid;
+    m_poll.moduleid_high = m_poll.entry.rxmoduleid;
     }
   else
     {
@@ -58,7 +58,7 @@ void OvmsVehicle::PollerISOTPStart(bool fromTicker)
     }
 
   ESP_LOGD(TAG, "PollerISOTPStart(%d): send [bus=%d, type=%02X, pid=%X], expecting %03" PRIx32 "/%03" PRIx32 "-%03" PRIx32,
-           fromTicker, m_poll_plcur->pollbus, m_poll.type, m_poll.pid, m_poll.moduleid_sent,
+           fromTicker, m_poll.entry.pollbus, m_poll.type, m_poll.pid, m_poll.moduleid_sent,
            m_poll.moduleid_low, m_poll.moduleid_high);
 
   //
@@ -75,15 +75,15 @@ void OvmsVehicle::PollerISOTPStart(bool fromTicker)
   uint16_t tx_datalen;            // Payload data length
   uint16_t tx_datasent;           // Payload data length sent with this frame
 
-  if (m_poll_plcur->xargs.tag == POLL_TXDATA)
+  if (m_poll.entry.xargs.tag == POLL_TXDATA)
     {
-    tx_data = m_poll_plcur->xargs.data;
-    tx_datalen = m_poll_plcur->xargs.datalen;
+    tx_data = m_poll.entry.xargs.data;
+    tx_datalen = m_poll.entry.xargs.datalen;
     }
   else
     {
-    tx_data = m_poll_plcur->args.data;
-    tx_datalen = m_poll_plcur->args.datalen;
+    tx_data = m_poll.entry.args.data;
+    tx_datalen = m_poll.entry.args.datalen;
     }
 
   CAN_frame_t txframe = {};
@@ -112,9 +112,9 @@ void OvmsVehicle::PollerISOTPStart(bool fromTicker)
     }
 
   // Do we need to split this request into multiple frames?
-  if (POLL_TYPE_HAS_16BIT_PID(m_poll_plcur->type))
+  if (POLL_TYPE_HAS_16BIT_PID(m_poll.entry.type))
     tp_len = 3 + tx_datalen;
-  else if (POLL_TYPE_HAS_8BIT_PID(m_poll_plcur->type))
+  else if (POLL_TYPE_HAS_8BIT_PID(m_poll.entry.type))
     tp_len = 2 + tx_datalen;
   else
     tp_len = 1 + tx_datalen;
@@ -134,7 +134,7 @@ void OvmsVehicle::PollerISOTPStart(bool fromTicker)
     }
 
   // Add TP data:
-  if (POLL_TYPE_HAS_16BIT_PID(m_poll_plcur->type))
+  if (POLL_TYPE_HAS_16BIT_PID(m_poll.entry.type))
     {
     tp_data[0] = m_poll.type;
     tp_data[1] = m_poll.pid >> 8;
@@ -142,7 +142,7 @@ void OvmsVehicle::PollerISOTPStart(bool fromTicker)
     tx_datasent = LIMIT_MAX(tx_datalen, tp_datalen - 3);
     memcpy(&tp_data[3], tx_data, tx_datasent);
     }
-  else if (POLL_TYPE_HAS_8BIT_PID(m_poll_plcur->type))
+  else if (POLL_TYPE_HAS_8BIT_PID(m_poll.entry.type))
     {
     tp_data[0] = m_poll.type;
     tp_data[1] = m_poll.pid;
@@ -567,9 +567,9 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
   // - poll throttling is unlimited or limit isn't reached yet
   if (m_poll_wait == 0 &&
       m_poll.moduleid_sent != 0x7df &&
-      (!m_poll_sequence_max || m_poll_sequence_cnt < m_poll_sequence_max))
+      CanPoll() )
     {
-    PollerSend(false);
+    PollerSend(poller_source_t::Successful);
     }
 
   return true;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
@@ -797,10 +797,9 @@ bool OvmsVehicle::PollerVWTPReceive(CAN_frame_t* frame, uint32_t msgid)
   // Immediately send the next poll for this tick if…
   // - we are not waiting for another frame
   // - poll throttling is unlimited or limit isn't reached yet
-  if (m_poll_wait == 0 &&
-      (!m_poll_sequence_max || m_poll_sequence_cnt < m_poll_sequence_max))
+  if (m_poll_wait == 0 && CanPoll())
     {
-    PollerSend(false);
+    PollerSend(poller_source_t::Successful);
     }
 
   return true;

--- a/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.cpp
@@ -783,6 +783,15 @@ void OvmsVehicleBoltEV::Ticker10(uint32_t ticker)
     }
 }
 
+void OvmsVehicleBoltEV::PollRunFinished()
+{
+  if (m_poll_state == 2) {
+      // polling complete one time for state 2. Switch to state 1.
+      PollSetState(1);
+      PollSetThrottling(VA_POLLING_NORMAL_THROTTLING);
+  }
+}
+
 void OvmsVehicleBoltEV::Ticker1(uint32_t ticker)
 {
     // Check if the car has gone to sleep
@@ -805,12 +814,6 @@ void OvmsVehicleBoltEV::Ticker1(uint32_t ticker)
                 PollSetState(2);
             }
         }
-    }
-
-    if((m_poll_state == 2) && (m_poll_plcur == m_poll_plist)) {
-        // polling complete one time for state 2. Switch to state 1.
-        PollSetState(1);
-        PollSetThrottling(VA_POLLING_NORMAL_THROTTLING);
     }
 
     PreheatWatchdog();

--- a/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.h
+++ b/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.h
@@ -110,6 +110,7 @@ protected:
     void NotifyFuel();
     void NotifyMetrics();
 
+    void PollRunFinished() override;
 protected:
     char m_vin[18];
     char m_type[6];

--- a/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_can_handler.cpp
@@ -121,7 +121,7 @@ void OvmsVehicleJaguarIpace::IncomingPollFrame(CAN_frame_t* frame)
 
     }
     // Handle multi-line version responses
-    else if (m_poll_plist == nullptr && frameType == ISOTP_FT_CONSECUTIVE)
+    else if (HasPollList() && frameType == ISOTP_FT_CONSECUTIVE)
     {
         // auto start = ((dataLength - 1) * 7) + 3;
         // for (auto& version : m_versions)

--- a/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_can_handler.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_jaguaripace/src/ipace_can_handler.cpp
@@ -121,7 +121,7 @@ void OvmsVehicleJaguarIpace::IncomingPollFrame(CAN_frame_t* frame)
 
     }
     // Handle multi-line version responses
-    else if (HasPollList() && frameType == ISOTP_FT_CONSECUTIVE)
+    else if (!HasPollList() && frameType == ISOTP_FT_CONSECUTIVE)
     {
         // auto start = ((dataLength - 1) * 7) + 3;
         // for (auto& version : m_versions)

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -554,7 +554,7 @@ void OvmsVehicleMgEv::ConfigurePollInterface(int bus)
     {
         // Already configured for that interface
         ESP_LOGI(TAG, "Already configured for interface, not re-configuring");
-        if (m_pollData && !m_poll_plist)
+        if (m_pollData && !HasPollList())
         {
             PollSetPidList(newBus, m_pollData);
         }

--- a/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.cpp
@@ -783,6 +783,16 @@ void OvmsVehicleVoltAmpera::Ticker10(uint32_t ticker)
     }
   }
 
+void OvmsVehicleVoltAmpera::PollRunFinished()
+  {
+  if(m_poll_state == 2)
+    {
+    // polling complete one time for state 2. Switch to state 1.
+    PollSetState(1);
+    PollSetThrottling(VA_POLLING_NORMAL_THROTTLING);
+    }
+  }
+
 void OvmsVehicleVoltAmpera::Ticker1(uint32_t ticker)
   {
   // Check if the car has gone to sleep
@@ -812,13 +822,6 @@ void OvmsVehicleVoltAmpera::Ticker1(uint32_t ticker)
       }
     }
   
-  if((m_poll_state == 2) && (m_poll_plcur == m_poll_plist))
-    {
-    // polling complete one time for state 2. Switch to state 1.
-    PollSetState(1);
-    PollSetThrottling(VA_POLLING_NORMAL_THROTTLING);
-    }
-
   PreheatWatchdog();
 
   if (m_controlled_lights)

--- a/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.h
+++ b/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.h
@@ -111,6 +111,7 @@ class OvmsVehicleVoltAmpera : public OvmsVehicle
     void NotifyFuel();
     void NotifyMetrics();
 
+    void PollRunFinished() override;
   protected:
     char m_vin[18];
     char m_type[6];


### PR DESCRIPTION
The aim here is to move away from vehicle implementations knowing anything about the poll-list pointers, and to move towards a system where there is a function call to 'get the next poll entry'. 
The biggest change here is that it moves a while loop from PollerSend() to a factored NextPollEntry()

-  Factor retrieving of next poll entry
-  Pass in Enum of poll call reason Primary/OnceOff/PollSuccess
-  Clean up resetting of ticker.
-  Introduce PollRunFinished() (as a safe place to check for Poll State changes.)