### PR TITLE
Implement 64bit Time storage 

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/gsmnmea.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/gsmnmea.cpp
@@ -81,7 +81,7 @@ static unsigned long JdFromYMD(int year, int month, int day)
  *   date: "ddmmyy"
  *   time: "hhmmss"
  */
-static unsigned long utc_to_timestamp(const char* date, const char* time)
+static int64_t utc_to_timestamp(const char* date, const char* time)
   {
   int day, month, year, hour, minute, second;
 
@@ -93,8 +93,8 @@ static unsigned long utc_to_timestamp(const char* date, const char* time)
   minute = (time[2]-'0')*10 + (time[3]-'0');
   second = (time[4]-'0')*10 + (time[5]-'0');
 
-  return
-    (JdFromYMD(2000+year, month, day) - JDEpoch) * (24L * 3600)
+  int64_t jd = JdFromYMD(2000+year, month, day);
+  return (jd - JDEpoch) * (24L * 3600)
       + ((hour * 60L + minute) * 60) + second;
   }
 
@@ -212,7 +212,7 @@ void GsmNMEA::IncomingLine(const std::string line)
       *StdMetrics.ms_v_pos_latitude = (float) lat;
       *StdMetrics.ms_v_pos_longitude = (float) lon;
       *StdMetrics.ms_v_pos_altitude = (float) alt;
-      *StdMetrics.ms_v_pos_gpstime = (int) time(NULL);
+      *StdMetrics.ms_v_pos_gpstime = time(NULL);
       }
 
     // upodate gpslock last, so listeners will see updated lat/lon values:
@@ -269,7 +269,7 @@ void GsmNMEA::IncomingLine(const std::string line)
 
     if (m_gpstime_enabled)
       {
-      int tm = utc_to_timestamp(date, time);
+      auto tm = utc_to_timestamp(date, time);
       if (tm < 1572735600) // 2019-11-03 00:00:00
         tm += (1024*7*86400); // Nasty kludge to workaround SIM5360 week rollover
       MyTime.Set(TAG, 2, true, tm);

--- a/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/mi_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/mi_commands.cpp
@@ -61,9 +61,9 @@ void xmi_trip_since_parked(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, 
 	
 	float distance = StdMetrics.ms_v_pos_trip->AsFloat(rangeUnit);
 	//Trip timer
-	int start = trio->ms_v_trip_park_time_start->AsInt();
-	int stop = trio->ms_v_trip_park_time_stop->AsInt();
-	int time = stop - start;
+	time_t start = trio->ms_v_trip_park_time_start->AsInt();
+	time_t stop = trio->ms_v_trip_park_time_stop->AsInt();
+	time_t time = stop - start;
 
 	int num_seconds = time;
 	int hours = num_seconds / (60 * 60);

--- a/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.h
+++ b/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.h
@@ -119,8 +119,8 @@ class OvmsVehicleMitsubishi : public OvmsVehicle
     OvmsMetricFloat*  ms_v_trip_park_ac_kwh  = MyMetrics.InitFloat("xmi.e.trip.park.ac.kwh", 10, 0, kWh);
     OvmsMetricFloat*  ms_v_trip_park_soc_start = MyMetrics.InitFloat("xmi.e.trip.park.soc.start", 10, 0, Percentage);
     OvmsMetricFloat*  ms_v_trip_park_soc_stop = MyMetrics.InitFloat("xmi.e.trip.park.soc.stop", 10, 0, Percentage);
-    OvmsMetricInt*    ms_v_trip_park_time_start = MyMetrics.InitInt("xmi.e.trip.park.time.start", 10, 0, Seconds);
-    OvmsMetricInt*    ms_v_trip_park_time_stop = MyMetrics.InitInt("xmi.e.trip.park.time.stop", 10, 0, Seconds);
+    OvmsMetricInt64*  ms_v_trip_park_time_start = MyMetrics.InitInt64("xmi.e.trip.park.time.start", 10, 0, DateLocal);
+    OvmsMetricInt64*  ms_v_trip_park_time_stop = MyMetrics.InitInt64("xmi.e.trip.park.time.stop", 10, 0, DateLocal);
 
     OvmsMetricFloat*  ms_v_pos_trip_charge = MyMetrics.InitFloat("xmi.e.trip.charge", 10, 0, Kilometers);
     OvmsMetricFloat*  ms_v_trip_charge_energy_used = MyMetrics.InitFloat("xmi.e.trip.charge.energy.used", 10, 0, kWh);
@@ -139,7 +139,7 @@ class OvmsVehicleMitsubishi : public OvmsVehicle
 
     void vehicle_mitsubishi_car_on(bool isOn);
 
-    int mi_start_time_utc;
+    time_t mi_start_time_utc;
 
     //config variables
     bool cfg_heater_old;

--- a/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.cpp
@@ -196,7 +196,8 @@ void OvmsVehicleTeslaRoadster::IncomingFrameCan1(CAN_frame_t* p_frame)
           }
         case 0x81: // Time/Date UTC
           {
-          int tm = ((int)d[7]<<24) + ((int)d[6]<<16) + ((int)d[5]<<8) + d[4];
+          // TODO: Only 32 bit time_t
+          time_t tm = ((int)d[7]<<24) + ((int)d[6]<<16) + ((int)d[5]<<8) + d[4];
           MyTime.Set(TAG, 2, true, tm);
           break;
           }

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -1215,7 +1215,7 @@ void OvmsVehicleVWeUp::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint
     case VWUP_MFD_SERV_TIME:
       if (PollReply.FromUint16("VWUP_MFD_SERV_TIME", value) && value > 0) { // excluding value of 0 seems to be necessary for now
         // Send notification?
-        int now = StdMetrics.ms_m_timeutc->AsInt();
+        time_t now = StdMetrics.ms_m_timeutc->AsInt();
         int threshold = MyConfig.GetParamValueInt("xvu", "serv_warn_days", 30);
         int old_value = ROUNDPREC((StdMetrics.ms_v_env_service_time->AsInt() - now) / 86400.0f, 0);
         if (old_value > threshold && value <= threshold) {

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -43,7 +43,7 @@ MetricsStandard::MetricsStandard()
   ms_m_tasks = new OvmsMetricInt(MS_M_TASKS, SM_STALE_MID);
   ms_m_freeram = new OvmsMetricInt(MS_M_FREERAM, SM_STALE_MID);
   ms_m_monotonic = new OvmsMetricInt(MS_M_MONOTONIC, SM_STALE_MIN, Seconds);
-  ms_m_timeutc = new OvmsMetricInt(MS_M_TIME_UTC, SM_STALE_MIN, DateUTC);
+  ms_m_timeutc = new OvmsMetricInt64(MS_M_TIME_UTC, SM_STALE_MIN, DateUTC);
 
   ms_m_net_type = new OvmsMetricString(MS_N_TYPE, SM_STALE_MAX);
   ms_m_net_sq = new OvmsMetricInt(MS_N_SQ, SM_STALE_MAX, dbm);
@@ -249,7 +249,7 @@ MetricsStandard::MetricsStandard()
   ms_v_env_cabinvent = new OvmsMetricString(MS_V_ENV_CABINVENT, SM_STALE_MID);
 
   ms_v_env_service_range = new OvmsMetricInt(MS_V_ENV_SERV_RANGE, SM_STALE_MID, Kilometers);
-  ms_v_env_service_time = new OvmsMetricInt(MS_V_ENV_SERV_TIME, SM_STALE_MID, DateLocal);
+  ms_v_env_service_time = new OvmsMetricInt64(MS_V_ENV_SERV_TIME, SM_STALE_MID, DateLocal);
 
   //
   // Position / movement metrics
@@ -259,7 +259,7 @@ MetricsStandard::MetricsStandard()
   ms_v_pos_gpshdop = new OvmsMetricFloat(MS_V_POS_GPSHDOP, SM_STALE_MIN);
   ms_v_pos_satcount= new OvmsMetricInt(MS_V_POS_SATCOUNT, SM_STALE_MIN);
   ms_v_pos_gpssq = new OvmsMetricInt(MS_V_POS_GPSSQ, SM_STALE_MIN, Percentage);
-  ms_v_pos_gpstime = new OvmsMetricInt(MS_V_POS_GPSTIME, SM_STALE_MIN, DateLocal);
+  ms_v_pos_gpstime = new OvmsMetricInt64(MS_V_POS_GPSTIME, SM_STALE_MIN, DateLocal);
   ms_v_pos_latitude = new OvmsMetricFloat(MS_V_POS_LATITUDE, SM_STALE_MIN, Other, true);
   ms_v_pos_longitude = new OvmsMetricFloat(MS_V_POS_LONGITUDE, SM_STALE_MIN, Other, true);
   ms_v_pos_location = new OvmsMetricString(MS_V_POS_LOCATION, SM_STALE_MID);

--- a/vehicle/OVMS.V3/main/metrics_standard.h
+++ b/vehicle/OVMS.V3/main/metrics_standard.h
@@ -284,7 +284,7 @@ class MetricsStandard
     OvmsMetricInt*    ms_m_tasks;
     OvmsMetricInt*    ms_m_freeram;
     OvmsMetricInt*    ms_m_monotonic;
-    OvmsMetricInt*    ms_m_timeutc;
+    OvmsMetricInt64*  ms_m_timeutc;
 
     OvmsMetricString* ms_m_net_type;                      // none, wifi, modem
     OvmsMetricInt*    ms_m_net_sq;                        // Network signal quality [dbm]
@@ -489,7 +489,7 @@ class MetricsStandard
     OvmsMetricString* ms_v_env_cabinintake;               // Cabin intake type (fresh, recirc, etc)
     OvmsMetricString* ms_v_env_cabinvent;                 // Cabin vent type (comma-separated list of feet, face, screen, etc)
     OvmsMetricInt*    ms_v_env_service_range;             // Distance to next scheduled maintenance/service [km]
-    OvmsMetricInt*    ms_v_env_service_time;              // Time of scheduled maintenance/service [DateLocal]
+    OvmsMetricInt64*  ms_v_env_service_time;            // Time of scheduled maintenance/service [DateLocal]
 
     //
     // Position / location metrics
@@ -499,7 +499,7 @@ class MetricsStandard
     OvmsMetricFloat*  ms_v_pos_gpshdop;                   // Horizontal dilution of precision (smaller=better)
     OvmsMetricInt*    ms_v_pos_satcount;
     OvmsMetricInt*    ms_v_pos_gpssq;                     // GPS signal quality [%] (<30 unusable, >50 good, >80 excellent)
-    OvmsMetricInt*    ms_v_pos_gpstime;                   // Time (UTC) of GPS coordinates [Seconds]
+    OvmsMetricInt64*  ms_v_pos_gpstime;                   // Time (UTC) of GPS coordinates [Seconds]
     OvmsMetricFloat*  ms_v_pos_latitude;
     OvmsMetricFloat*  ms_v_pos_longitude;
     OvmsMetricString* ms_v_pos_location;                  // Name of current location if defined

--- a/vehicle/OVMS.V3/main/ovms_housekeeping.cpp
+++ b/vehicle/OVMS.V3/main/ovms_housekeeping.cpp
@@ -105,7 +105,7 @@ void HousekeepingTicker1( TimerHandle_t timer )
 
   monotonictime++;
   StandardMetrics.ms_m_monotonic->SetValue((int)monotonictime);
-  StandardMetrics.ms_m_timeutc->SetValue((int)time(NULL));
+  StandardMetrics.ms_m_timeutc->SetValue(time(NULL));
 
   HousekeepingUpdate12V();
   MyEvents.SignalEvent("ticker.1", NULL);

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -1299,6 +1299,16 @@ OvmsMetricInt* OvmsMetrics::InitInt(const char* metric, uint16_t autostale, int 
   return m;
   }
 
+OvmsMetricInt64 *OvmsMetrics::InitInt64(const char* metric, uint16_t autostale, int64_t value, metric_unit_t units, bool persist)
+  {
+  OvmsMetricInt64 *m = (OvmsMetricInt64*)Find(metric);
+  if (m==NULL) m = new OvmsMetricInt64(metric, autostale, units, persist);
+
+  if (!m->IsDefined())
+    m->SetValue(value);
+  return m;
+  }
+
 OvmsMetricBool* OvmsMetrics::InitBool(const char* metric, uint16_t autostale, bool value, metric_unit_t units, bool persist)
   {
   OvmsMetricBool *m = (OvmsMetricBool*)Find(metric);
@@ -1891,6 +1901,25 @@ static time_t internal_timegm(struct tm const* t)
   return 60 * (60 * (24L * days_since_epoch + t->tm_hour) + t->tm_min) + t->tm_sec;
   }
 
+
+static int ParseTimerValue(const char *value)
+  {
+  int hours = 0, minutes = 0, seconds = 0;
+  switch (sscanf(value, "%d:%d:%d", &hours, &minutes,&seconds))
+    {
+    case 1:
+      return hours; //number by itself - treat it as number of seconds.
+      break;
+    case 2:
+      return time_unit_join(hours, minutes, 0);
+      break;
+    case 3:
+      return time_unit_join(hours, minutes, seconds);
+      break;
+    }
+  return -1;
+  }
+
 bool OvmsMetricInt::SetValue(std::string value, metric_unit_t units)
   {
   CheckTargetUnit(GetUnits(), units, false);
@@ -1902,20 +1931,9 @@ bool OvmsMetricInt::SetValue(std::string value, metric_unit_t units)
     case TimeUTC:
     case TimeLocal:
       {
-      int hours = 0, minutes = 0, seconds = 0;
-      switch (sscanf(value.c_str(), "%d:%d:%d", &hours, &minutes,&seconds))
-        {
-        case 1:
-          nvalue = hours; //number by itself - treat it as number of seconds.
-          break;
-        case 2:
-          nvalue = time_unit_join(hours, minutes, 0);
-          break;
-        case 3:
-          nvalue = time_unit_join(hours, minutes, seconds);
-          break;
-        default: return false;
-        }
+      nvalue = ParseTimerValue(value.c_str());
+      if (nvalue < 0)
+        return false;
       break;
       }
     case DateUTC:
@@ -2319,6 +2337,325 @@ bool OvmsMetricString::SetValue(std::string value, metric_unit_t units)
 void OvmsMetricString::Clear()
   {
   SetValue("");
+  OvmsMetric::Clear();
+  }
+
+OvmsMetric64::OvmsMetric64(const char* name, uint16_t autostale, metric_unit_t units, bool persist)
+  : OvmsMetric(name, autostale, units, persist)
+  {
+  m_persist = persist;
+  m_valuep_lo = nullptr;
+  m_valuep_hi = nullptr;
+  }
+ void OvmsMetric64::InitPersist()
+   {
+  if (m_persist)
+    {
+    std::string lo_name(m_name);
+    std::string hi_name = lo_name + "_hi";
+
+    persistent_values *hi_vp = pmetrics_register(hi_name);
+    persistent_values *lo_vp = pmetrics_register(lo_name);
+    if (!hi_vp || !lo_vp)
+      {
+      m_persist = false;
+      }
+    else
+      {
+      m_valuep_hi = (&hi_vp->value);
+      m_valuep_lo = (&lo_vp->value);
+      if (SetValueParts(*m_valuep_lo, *m_valuep_hi))
+        {
+        SetModified(true);
+        ESP_LOGI(TAG, "persist %s = %s", m_name, AsUnitString().c_str());
+        }
+      }
+    }
+  }
+
+bool OvmsMetric64::CheckPersist()
+  {
+  if (!m_persist || !m_valuep_lo || !m_valuep_hi || !IsDefined())
+    return true;
+  persistent_value_t lo, hi;
+  GetValueParts(lo, hi);
+  if (lo != *m_valuep_lo || hi != *m_valuep_hi)
+    {
+    ESP_LOGE(TAG, "CheckPersist: bad value for %s", m_name);
+    return false;
+    }
+  std::string lo_name(m_name);
+  std::string hi_name = lo_name + "_hi";
+
+  persistent_values *hi_vp = pmetrics_find(hi_name);
+  if (!hi_vp)
+    {
+    ESP_LOGE(TAG, "CheckPersist: can't find %s", hi_name.c_str());
+    return false;
+    }
+  persistent_values *lo_vp = pmetrics_find(lo_name);
+  if ( !lo_vp)
+    {
+    ESP_LOGE(TAG, "CheckPersist: can't find %s", lo_name.c_str());
+    return false;
+    }
+  if (m_valuep_hi != &hi_vp->value)
+    {
+    ESP_LOGE(TAG, "CheckPersist: bad address for %s",hi_name.c_str());
+    return false;
+    }
+  if (m_valuep_lo != &lo_vp->value)
+    {
+    ESP_LOGE(TAG, "CheckPersist: bad address for %s",lo_name.c_str());
+    return false;
+    }
+  return true;
+  }
+
+void OvmsMetric64::RefreshPersist()
+  {
+  if (m_persist && m_valuep_lo && m_valuep_hi && IsDefined())
+    {
+    GetValueParts(*m_valuep_lo, *m_valuep_hi);
+    }
+  }
+
+OvmsMetricInt64::OvmsMetricInt64(const char* name, uint16_t autostale, metric_unit_t units, bool persist)
+  : OvmsMetric64(name, autostale, units, persist)
+  {
+  // Initialise once GetValueParts is set.
+  InitPersist();
+  }
+
+// Get the value as low/high parts.
+void OvmsMetricInt64::GetValueParts( persistent_value_t &value_low, persistent_value_t &value_hi)
+  {
+  value_low = static_cast<persistent_value_t>( m_value & 0xffff);
+  value_hi = static_cast<persistent_value_t>(m_value >> 32);
+  }
+
+// Set the value as low/high parts. Return true on changed
+bool OvmsMetricInt64::SetValueParts( persistent_value_t value_low, persistent_value_t value_hi)
+  {
+  int64_t newval =
+    static_cast<int32_t>(value_low)|
+    (static_cast<int64_t>(value_hi)<< 32);
+  if (newval == m_value)
+    return false;
+  m_value = newval;
+  return true;
+  }
+
+std::string OvmsMetricInt64::AsString(const char* defvalue, metric_unit_t units, int precision)
+  {
+  if (IsDefined())
+    {
+    int64_t value = m_value;
+    CheckTargetUnit(GetUnits(), units, false);
+    if (units == Native)
+      units = m_units;
+    else if (units != m_units)
+    {
+    switch (units)
+      {
+      case DateUTC:
+      case DateLocal:
+        value = m_value;
+        break;
+      default:
+        value = static_cast<int64_t>(round(UnitConvert(m_units,units,static_cast<float>(m_value))));
+      }
+    }
+    std::stringstream os;
+    switch (units)
+      {
+      case TimeUTC:
+      case TimeLocal:
+        {
+        int hours, minutes, seconds;
+        time_unit_split(value, hours, minutes, seconds);
+        os << std::setfill('0')
+          << std::setw(2) << hours << ':'
+          << std::setw(2) << minutes << ':'
+          << std::setw(2) << seconds;
+        }
+        break;
+      case DateUTC:
+        {
+        time_t tvalue = value;
+        std::tm ourtime;
+        gmtime_r(&tvalue, &ourtime);
+        os << std::put_time(&ourtime, "%F %T UTC");
+        }
+        break;
+      case DateLocal:
+        {
+        time_t tvalue = value;
+        std::tm ourtime;
+        localtime_r(&tvalue, &ourtime);
+        os << std::put_time(&ourtime, "%F %T %Z");
+        }
+        break;
+      default:
+        os << value;
+        break;
+      }
+    return os.str();
+    }
+  else
+    {
+    return std::string(defvalue);
+    }
+  }
+
+std::string OvmsMetricInt64::AsJSON(const char* defvalue, metric_unit_t units, int precision)
+  {
+  if (IsDefined())
+    {
+    CheckTargetUnit(GetUnits(), units, false);
+    if (units == Native)
+      units = GetUnits();
+    switch (units)
+      {
+      case TimeUTC:
+      case TimeLocal:
+        return OvmsMetric::AsJSON(defvalue, units, precision);
+      case DateLocal:
+      case DateUTC:
+        {
+        time_t tvalue = m_value;
+        std::tm ourtime;
+        gmtime_r(&tvalue, &ourtime);
+        std::ostringstream os;
+        os << '"' << std::put_time(&ourtime, "%FT%T.000Z") << '"';
+        return os.str();
+        }
+      default: return AsString(defvalue, units, precision);
+      }
+    }
+  else
+    return std::string((defvalue && *defvalue) ? defvalue : "0");
+  }
+
+float OvmsMetricInt64::AsFloat(const float defvalue, metric_unit_t units)
+  {
+  return (float)AsInt((int64_t)defvalue, units);
+  }
+
+int64_t OvmsMetricInt64::AsInt(const int64_t defvalue, metric_unit_t units)
+  {
+  if (IsDefined())
+    {
+    if ((units != Native)&&(units != m_units))
+      {
+      switch(units)
+        {
+        case DateUTC:
+        case DateLocal:
+          return m_value;
+        default:
+          return UnitConvert(m_units,units,static_cast<float>(m_value));
+        }
+      }
+    else
+      return m_value;
+    }
+  else
+    return defvalue;
+  }
+
+#ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE
+void OvmsMetricInt64::DukPush(DukContext &dc, metric_unit_t units)
+  {
+  dc.Push(static_cast<double>(AsInt(0, units)));
+  }
+#endif
+
+bool OvmsMetricInt64::SetValue(int64_t value, metric_unit_t units)
+  {
+  int64_t nvalue = value;
+
+  if (units != m_units)
+    {
+    switch(units)
+      {
+      case Other:
+      case DateUTC:
+      case DateLocal:
+        break;
+      default:
+        nvalue=UnitConvert(units,m_units,static_cast<float>(value));
+      }
+    }
+
+  if (m_value != nvalue)
+    {
+    m_value = nvalue;
+    if (m_persist && m_valuep_hi && m_valuep_lo)
+      GetValueParts(*m_valuep_lo, *m_valuep_hi);
+    SetModified(true);
+    return true;
+    }
+  else
+    {
+    SetModified(false);
+    return false;
+    }
+  }
+
+bool OvmsMetricInt64::SetValue(std::string value, metric_unit_t units)
+  {
+  CheckTargetUnit(GetUnits(), units, false);
+  if (units == Native)
+    units = m_units;
+  int64_t nvalue;
+  switch (units)
+    {
+    case TimeUTC:
+    case TimeLocal:
+      {
+      nvalue = ParseTimerValue(value.c_str());
+      if (nvalue < 0)
+        return false;
+      break;
+      }
+    case DateUTC:
+    case DateLocal:
+      {
+      if (!value.empty() && value.find_first_not_of("0123456789") == std::string::npos)
+        {
+        // digits only... treat it as a time_t integer.
+        nvalue = atoll(value.c_str());
+        }
+      else
+        {
+        std::tm ourtime;
+        istringstream istr(value);
+        istr >> std::get_time(&ourtime,"%Y-%m-%dT%H:%M:%S");
+        if (istr.fail())
+          return false;
+        if (units==DateUTC)
+          nvalue = internal_timegm(&ourtime);
+        else
+          nvalue = mktime(&ourtime);
+        }
+      break;
+      }
+    default:
+      nvalue = atoll(value.c_str());
+      break;
+    }
+  return SetValue(nvalue, units);
+  }
+
+bool OvmsMetricInt64::SetValue(dbcNumber& value)
+  {
+  return SetValue(value.GetSignedInteger());
+  }
+
+void OvmsMetricInt64::Clear()
+  {
+  SetValue(0);
   OvmsMetric::Clear();
   }
 


### PR DESCRIPTION
These commits 
* Implement 64 bit value storage and persisting.
* Implement storing of time values as 64 bit integers and ensure all references to these values are via time_t

Although in the currently used version of  the ESP-IDF libraries time_t is a 32bit integer,  this paves the way for when later versions of ESP-IDF are used that contain 64 bit time_t.