### PR TITLE
http - Clear bad buffer if unexpected size.

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_http/src/ovms_http.cpp
+++ b/vehicle/OVMS.V3/components/ovms_http/src/ovms_http.cpp
@@ -260,7 +260,7 @@ std::string OvmsHttpClient::GetBodyAsString()
   if (filesize != expected)
     {
     ESP_LOGE(TAG, "Download file size (%d) does not match expected (%d)", filesize, expected);
-    body.empty();
+    body.clear();
     }
 
   Disconnect();


### PR DESCRIPTION
 - Was coming up as a warning in later C++ (ignored return value)