### PR TITLE
OBD Poller - Implement Pause/Resume of polling

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -280,6 +280,8 @@ OvmsVehicle::OvmsVehicle()
   m_poll_txcallback = std::bind(&OvmsVehicle::PollerTxCallback, this, _1, _2);
   m_poll_plist = NULL;
   m_poll_plcur = NULL;
+  m_poll_paused = false;
+
   m_poll_vwtp = {};
 
   m_poll.bus = NULL;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -600,8 +600,10 @@ class OvmsVehicle : public InternalRamAllocated
     OvmsRecMutex      m_poll_mutex;           // Concurrency protection for recursive calls
     uint8_t           m_poll_state;           // Current poll state
     canbus*           m_poll_bus_default;     // Bus default to poll on
-    const OvmsPoller::poll_pid_t* m_poll_plist;           // Head of poll list
   private:
+    bool              m_poll_paused;          // Processing the poll list is paused
+
+    const OvmsPoller::poll_pid_t* m_poll_plist;           // Head of poll list
     const OvmsPoller::poll_pid_t* m_poll_plcur;           // Poll list loop cursor
     // Poll state for received data.
     OvmsPoller::poll_job_t m_poll;
@@ -631,6 +633,9 @@ class OvmsVehicle : public InternalRamAllocated
 
     // Check for throttling.
     bool CanPoll();
+
+    void PausePolling();
+    void ResumePolling();
 
     // Polling Response
     virtual void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
@@ -240,6 +240,21 @@ bool OvmsVehicle::CanPoll()
   // Check Throttle
   return (!m_poll_sequence_max || m_poll_sequence_cnt < m_poll_sequence_max);
   }
+/** Pause polling - don't progress through the poll list.
+ */
+void OvmsVehicle::PausePolling()
+  {
+  OvmsRecMutexLock slock(&m_poll_single_mutex);
+  OvmsRecMutexLock lock(&m_poll_mutex);
+  m_poll_paused = true;
+  }
+/** Resume polling.
+ */
+void OvmsVehicle::ResumePolling()
+  {
+  OvmsRecMutexLock lock(&m_poll_mutex);
+  m_poll_paused = false;
+  }
 
 OvmsVehicle::OvmsNextPollResult OvmsVehicle::NextPollEntry(OvmsPoller::poll_pid_t *entry)
   {
@@ -331,6 +346,7 @@ void OvmsVehicle::PollerSend(poller_source_t source)
   // Check poll bus & list:
   if (!HasPollList()) return;
 
+  if (m_poll_paused) return;
 
   switch (NextPollEntry(&m_poll.entry))
     {

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_bcm.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_bcm.cpp
@@ -241,16 +241,13 @@ void OvmsVehicleMgEv::DRLCommand(OvmsWriter* writer, canbus* currentBus, bool Tu
           
         m_bcm_task->SetValue(static_cast<int>(BCMTasks::DRL));
         // Pause the poller so we're not being interrupted
-        {
-            OvmsRecMutexLock lock(&m_poll_mutex);
-            m_poll_plist = nullptr;
-        }             
+        PausePolling();
 
         if (currentBus->Write(&Command) == ESP_FAIL) {
             ESP_LOGE(TAG, "Error writing DRL command frame");
             m_bcm_task->SetValue(static_cast<int>(BCMTasks::None));
             // Re-start polling
-            m_poll_plist = m_pollData;        
+            ResumePolling();
             return;      
         }
 
@@ -308,7 +305,7 @@ void OvmsVehicleMgEv::DRLCommand(OvmsWriter* writer, canbus* currentBus, bool Tu
             default: {}
         }
         // Re-start polling
-        m_poll_plist = m_pollData;                
+        ResumePolling();
     }
     else
     {

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_software_versions.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/mg_software_versions.cpp
@@ -96,10 +96,7 @@ void OvmsVehicleMgEv::SoftwareVersions(OvmsWriter* writer)
         m_GettingSoftwareVersions = true;        
 
         // Pause the poller so we're not being interrupted
-        {
-            OvmsRecMutexLock lock(&m_poll_mutex);
-            m_poll_plist = nullptr;
-        }
+        PausePolling();
 
         // Send the software version requests
         m_versions.clear();
@@ -131,7 +128,7 @@ void OvmsVehicleMgEv::SoftwareVersions(OvmsWriter* writer)
             m_bcm_task->SetValue(static_cast<int>(BCMTasks::None));     
         }  
         // Re-start polling
-        m_poll_plist = m_pollData;             
+        ResumePolling();
 
         // Output responses
         for (const auto& version : m_versions)

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev.cpp
@@ -848,10 +848,7 @@ void OvmsVehicleMgEv::PollsCommandShell(int verbosity, OvmsWriter* writer, OvmsC
 bool OvmsVehicleMgEv::AuthenticateECU(vector<ECUAuth> ECUsToAuth)
 {
     // Pause the poller so we're not being interrupted
-    {
-        OvmsRecMutexLock lock(&m_poll_mutex);
-        m_poll_plist = nullptr;
-    }
+    PausePolling();
     bool AuthSucceeded = true;
     uint8_t a = 0;
     while (a < ECUsToAuth.size() && AuthSucceeded)
@@ -874,7 +871,7 @@ bool OvmsVehicleMgEv::AuthenticateECU(vector<ECUAuth> ECUsToAuth)
         a++;
     }
     // Re-start polling
-    m_poll_plist = m_pollData;
+    ResumePolling();
     return AuthSucceeded;
 }
 


### PR DESCRIPTION
This allows us to move the poller list to 'private' and away from access by vehicle implementations.
