### PR TITLE
OBD Poller - Allow variations to the polling time

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -651,8 +651,6 @@ void OvmsVehicle::VehicleTicker1(std::string event, void* data)
 
   m_ticker++;
 
-  PollerStateTicker();
-
   PollerResetThrottle();
 
   Ticker1(m_ticker);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
@@ -270,7 +270,7 @@ OvmsVehicle::OvmsNextPollResult OvmsVehicle::NextPollEntry(OvmsPoller::poll_pid_
 void OvmsVehicle::PollerNextTick(poller_source_t source)
   {
   // Completed checking all poll entries for the current m_poll_ticker
-  ESP_LOGD(TAG, "PollerSend(%s): cycle complete for ticker=%u", PollerSource(source), m_poll.ticker);
+  ESP_LOGD(TAG, "PollerNextTick(%s): cycle complete for ticker=%u", PollerSource(source), m_poll.ticker);
 
   // Allow POLL to restart.
   m_poll_plcur = NULL;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
@@ -48,7 +48,7 @@ static const char *TAG = "vehicle-poll";
 
 /**
  * PollerStateTicker: check for state changes (stub, override with vehicle implementation)
- *  This is called by VehicleTicker1() just before the next PollerSend().
+ *  This is called by PollerSend() in the RXTask on a primary tick just before it checks the queue.
  *  Implement your poller state transition logic in this method, so the changes
  *  will get applied immediately.
  */
@@ -290,7 +290,6 @@ void OvmsVehicle::PollRunFinished()
  */
 void OvmsVehicle::PollerSend(poller_source_t source)
   {
-  OvmsRecMutexLock lock(&m_poll_mutex);
 
   // ESP_LOGD(TAG, "PollerSend(%d): entry at[type=%02X, pid=%X], ticker=%u, wait=%u, cnt=%u/%u",
   //          fromTicker, m_poll_plcur->type, m_poll_plcur->pid,
@@ -308,6 +307,11 @@ void OvmsVehicle::PollerSend(poller_source_t source)
     default:
       ;
     }
+
+  if (fromPrimaryTicker)
+    PollerStateTicker();
+
+  OvmsRecMutexLock lock(&m_poll_mutex);
   if (fromPrimaryTicker)
     {
     // Only reset the list when 'from primary Ticker' and it's at the end.

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller.cpp
@@ -28,7 +28,7 @@
 ; THE SOFTWARE.
 */
 
-// #include "ovms_log.h"
+#include "ovms_log.h"
 static const char *TAG = "vehicle-poll";
 
 #include <stdio.h>
@@ -127,6 +127,8 @@ void OvmsVehicle::PollSetPidList(canbus* bus, const OvmsPoller::poll_pid_t* plis
   m_poll_plist = plist;
   m_poll.ticker = 0;
   m_poll_sequence_cnt = 0;
+
+  m_poll_subticker = 0;
   m_poll_wait = 0;
   ResetPollEntry();
   }
@@ -174,7 +176,6 @@ void OvmsVehicle::PollSetThrottling(uint8_t sequence_max)
   OvmsRecMutexLock lock(&m_poll_mutex);
   m_poll_sequence_max = sequence_max;
   }
-
 
 /**
  * PollSetResponseSeparationTime: configure ISO TP multi frame response timing
@@ -309,10 +310,7 @@ void OvmsVehicle::PollerSend(poller_source_t source)
     }
   if (fromPrimaryTicker)
     {
-    // Timer ticker call: reset throttling counter
-    PollerResetThrottle();
-
-    // Only reset the list when 'from Ticker' and it's at the end.
+    // Only reset the list when 'from primary Ticker' and it's at the end.
     if (m_poll_plcur && m_poll_plcur->txmoduleid == 0)
       {
       PollerNextTick(source);
@@ -381,7 +379,6 @@ void OvmsVehicle::PollerSend(poller_source_t source)
       }
     }
   }
-
 
 /**
  * PollerTxCallback: internal: process poll request callbacks
@@ -504,7 +501,7 @@ int OvmsVehicle::PollSingleRequest(canbus* bus, uint32_t txid, uint32_t rxid,
   PollSetPidList(bus, poll);
   m_poll_single_rxdone.Take(0);
   m_poll_single_rxbuf = &response;
-  PollerSend(poller_source_t::OnceOff);
+  Queue_PollerSend(poller_source_t::OnceOff);
   m_poll_mutex.Unlock();
 
   // wait for response:

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_isotp.cpp
@@ -569,7 +569,7 @@ bool OvmsVehicle::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
       m_poll.moduleid_sent != 0x7df &&
       CanPoll() )
     {
-    PollerSend(poller_source_t::Successful);
+    Queue_PollerSend(poller_source_t::Successful);
     }
 
   return true;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
@@ -799,7 +799,7 @@ bool OvmsVehicle::PollerVWTPReceive(CAN_frame_t* frame, uint32_t msgid)
   // - poll throttling is unlimited or limit isn't reached yet
   if (m_poll_wait == 0 && CanPoll())
     {
-    PollerSend(poller_source_t::Successful);
+    Queue_PollerSend(poller_source_t::Successful);
     }
 
   return true;


### PR DESCRIPTION
 - Allow primary and secondary poll lengths to be varied. (Time between poll attempts). 
 - Retains the 'poll on success of last poll' concept.  (This could be an option).
 - Adds Secondary ticks option (Secondary tick will attempt the next poll but will not reset to the beginning)
 - Move PollerSend() to Rx Thread.  This takes the burden of sending away from the main vehicle ticker thread.
 - Aims to Decrease latency of OBD Poll Loop ( eg for obd2ecu)
 - ResetThrottle() is done in the main ticker so its timing is not changed by the ticker time