### PR TITLE
Various fixes related to C++20 compiler

### DIFF
--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -420,7 +420,7 @@ esp_err_t esp32can::InitController()
       break;
     default:
       MODULE_ESP32CAN->BTR1.B.TSEG1=0xc;
-      __tq = ((float)1000/MyESP32can->m_speed) / 16;
+      __tq = ((float)1000/static_cast<int>(MyESP32can->m_speed)) / 16;
     }
 
   // Set baud rate prescaler

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_poller_vwtp.cpp
@@ -375,6 +375,11 @@ void OvmsVehicle::PollerVWTPTxCallback(const CAN_frame_t* frame, bool success)
     }
   }
 
+#if __cplusplus >= 202002L
+#define CAP_THIS ,this
+#else
+#define CAP_THIS
+#endif
 
 /**
  * PollerVWTPReceive: process VW-TP frame received (internal)
@@ -384,7 +389,7 @@ bool OvmsVehicle::PollerVWTPReceive(CAN_frame_t* frame, uint32_t msgid)
   OvmsRecMutexLock lock(&m_poll_mutex);
 
   // Log utility:
-  auto logFrameDump = [=](const char* msg)
+  auto logFrameDump = [= CAP_THIS](const char* msg)
     {
     char *hexdump = NULL;
     FormatHexDump(&hexdump, (const char*)frame->data.u8, frame->FIR.B.DLC, frame->FIR.B.DLC);
@@ -393,7 +398,7 @@ bool OvmsVehicle::PollerVWTPReceive(CAN_frame_t* frame, uint32_t msgid)
     };
 
   // Send channel keepalive response (0xA3 response):
-  auto sendPong = [=]()
+  auto sendPong = [= CAP_THIS]()
     {
     CAN_frame_t txframe = {};
     txframe.callback = &m_poll_txcallback;
@@ -410,7 +415,7 @@ bool OvmsVehicle::PollerVWTPReceive(CAN_frame_t* frame, uint32_t msgid)
     };
 
   // Send ACK:
-  auto sendAck = [=]()
+  auto sendAck = [= CAP_THIS]()
     {
     CAN_frame_t txframe = {};
     txframe.callback = &m_poll_txcallback;

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -1282,10 +1282,10 @@ void OvmsHyundaiIoniqEv::HandleCharging()
         && (ideal_range >= limit_range )
         && (kia_last_ideal_range < limit_range ))) {
       // ...enter state 2=topping off when we've reach the needed range / SOC:
-      SET_CHARGE_STATE("topoff", NULL);
+      SET_CHARGE_STATE("topoff");
     }
     else if (bat_soc >= 95) { // ...else set "topping off" from 94% SOC:
-      SET_CHARGE_STATE("topoff", NULL);
+      SET_CHARGE_STATE("topoff");
     }
   }
 
@@ -1349,7 +1349,7 @@ void OvmsHyundaiIoniqEv::HandleCharging()
       SET_CHARGE_STATE("heating", "scheduledstart");
     }
     else {
-      SET_CHARGE_STATE("charging", NULL);
+      SET_CHARGE_STATE("charging");
     }
   }
   StdMetrics.ms_v_charge_kwh->SetValue(StdMetrics.ms_v_bat_energy_recd_total->AsFloat(kWh) - kia_cum_charge_start, kWh); // kWh charged

--- a/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.cpp
@@ -638,21 +638,21 @@ void OvmsVehicleKiaNiroEv::HandleCharging()
 		POLLSTATE_CHARGING;
     }
   else
-  		{
-    // ******* Charging continues: *******
-    if (((BAT_SOC > 0) && (LIMIT_SOC > 0) && (BAT_SOC >= LIMIT_SOC) && (kia_last_soc < LIMIT_SOC))
-    			|| ((EST_RANGE > 0) && (LIMIT_RANGE > 0)
-    					&& (IDEAL_RANGE >= LIMIT_RANGE )
+		{
+		// ******* Charging continues: *******
+		if (((BAT_SOC > 0) && (LIMIT_SOC > 0) && (BAT_SOC >= LIMIT_SOC) && (kia_last_soc < LIMIT_SOC))
+			|| ((EST_RANGE > 0) && (LIMIT_RANGE > 0)
+					&& (IDEAL_RANGE >= LIMIT_RANGE )
 							&& (kia_last_ideal_range < LIMIT_RANGE )))
-    		{
-      // ...enter state 2=topping off when we've reach the needed range / SOC:
-  			SET_CHARGE_STATE("topoff", NULL);
-      }
-    else if (BAT_SOC >= 95) // ...else set "topping off" from 94% SOC:
-    		{
-			SET_CHARGE_STATE("topoff", NULL);
-    		}
-  		}
+			{
+			// ...enter state 2=topping off when we've reach the needed range / SOC:
+			SET_CHARGE_STATE("topoff");
+			}
+		else if (BAT_SOC >= 95) // ...else set "topping off" from 94% SOC:
+			{
+			SET_CHARGE_STATE("topoff");
+			}
+		}
 
   // Check if we have what is needed to calculate remaining minutes
   if (CHARGE_VOLTAGE > 0 && CHARGE_CURRENT > 0)
@@ -683,16 +683,16 @@ void OvmsVehicleKiaNiroEv::HandleCharging()
   		StdMetrics.ms_v_charge_duration_range->SetValue( CalcRemainingChargeMinutes(CHARGE_VOLTAGE*CHARGE_CURRENT, BAT_SOC, chargeTarget_range, kn_battery_capacity, niro_charge_steps), Minutes);
     }
   else
-  		{
-  		if( m_v_preheating->AsBool())
-  			{
-  			SET_CHARGE_STATE("heating","scheduledstart");
-  			}
-  		else
-  			{
-  			SET_CHARGE_STATE("charging",NULL);
-  			}
-  		}
+    {
+    if( m_v_preheating->AsBool())
+      {
+      SET_CHARGE_STATE("heating","scheduledstart");
+      }
+    else
+      {
+      SET_CHARGE_STATE("charging");
+      }
+    }
   StdMetrics.ms_v_charge_kwh->SetValue(CUM_CHARGE - kia_cum_charge_start, kWh); // kWh charged
   kia_last_soc = BAT_SOC;
   kia_last_battery_cum_charge = kia_battery_cum_charge;

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/kia_common.h
@@ -253,8 +253,18 @@ public:
 #define POS_ODO			StdMetrics.ms_v_pos_odometer->AsFloat(0, Kilometers)
 #define CHARGE_CURRENT	StdMetrics.ms_v_charge_current->AsFloat(0, Amps)
 #define CHARGE_VOLTAGE	StdMetrics.ms_v_charge_voltage->AsFloat(0, Volts)
-#define SET_CHARGE_STATE(n,m)		StdMetrics.ms_v_charge_state->SetValue(n); if(m!=NULL) StdMetrics.ms_v_charge_substate->SetValue(m)
 
+template<typename S>
+inline void SET_CHARGE_STATE(S state)
+{
+  StandardMetrics.ms_v_charge_state->SetValue(state);
+}
+template <typename S,typename T>
+inline void SET_CHARGE_STATE(S state, T substate)
+{
+  StandardMetrics.ms_v_charge_state->SetValue(state);
+  StandardMetrics.ms_v_charge_substate->SetValue(substate);
+}
 #define CUM_CHARGE		((float)kia_battery_cum_charge/10.0)
 #define CUM_DISCHARGE	((float)kia_battery_cum_discharge/10.0)
 #define SET_TPMS_ID(n, v)	if (v > 0) kia_tpms_id[n] = v;

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.cpp
@@ -745,11 +745,11 @@ void OvmsVehicleKiaSoulEv::HandleCharging()
 							&& (kia_last_ideal_range < LIMIT_RANGE )))
     		{
       // ...enter state 2=topping off when we've reach the needed range / SOC:
-  			SET_CHARGE_STATE("topoff", NULL);
+  			SET_CHARGE_STATE("topoff");
       }
     else if (BAT_SOC >= 95) // ...else set "topping off" from 94% SOC:
     		{
-			SET_CHARGE_STATE("topoff", NULL);
+			SET_CHARGE_STATE("topoff");
     		}
   		}
 
@@ -820,7 +820,7 @@ void OvmsVehicleKiaSoulEv::HandleCharging()
   			}
   		else
   			{
-  			SET_CHARGE_STATE("charging",NULL);
+  			SET_CHARGE_STATE("charging");
   			}
   		}
   StdMetrics.ms_v_charge_kwh->SetValue((CUM_CHARGE - kia_cum_charge_start)/10.0, kWh); // kWh charged

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_faults.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/rt_sevcon_faults.cpp
@@ -409,15 +409,24 @@ CANopenResult_t SevconClient::QueryLogs(int verbosity, OvmsWriter* writer, int w
   CANopenResult_t err = COR_OK;
   SevconJob sc(this);
   uint32_t sdoval=0;
-  #define _readsdo(idx, sub)          ((err = sc.Read(idx, sub, sdoval)) == COR_OK)
-  #define _writesdo(idx, sub, val)    ((err = sc.Write(idx, sub, val)) == COR_OK)
-  #define _output(buf) \
-    if (writer) { \
-      if (verbosity > buf.tellp()) \
-        verbosity -= writer->puts(buf.str().c_str()); \
-    } else { \
-      MyNotify.NotifyString("data", "xrt.sevcon.log", buf.str().c_str()); \
-    }
+  auto _readsdo= [&sc, &err,&sdoval](uint16_t idx, uint8_t sub)->bool {
+    err = sc.Read(idx, sub, sdoval);
+    return err == COR_OK;
+    };
+  auto _writesdo= [&sc, &err,&sdoval](uint16_t idx, uint8_t sub,uint32_t val)->bool {
+    err = sc.Write(idx, sub, val);
+    return err == COR_OK;
+    };
+  auto _output = [&writer, &verbosity](ostringstream &buf) {
+    if (writer)
+      {
+      if (verbosity > buf.tellp())
+        verbosity -= writer->puts(buf.str().c_str());
+      } else
+      {
+      MyNotify.NotifyString("data", "xrt.sevcon.log", buf.str().c_str());
+      }
+    };
 
   int n, cnt=0, outcnt=0;
   ostringstream buf;

--- a/vehicle/OVMS.V3/main/test_framework.cpp
+++ b/vehicle/OVMS.V3/main/test_framework.cpp
@@ -174,6 +174,10 @@ void test_watchdog(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
 __attribute__((noreturn))
 void test_stackoverflow(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
+  if (verbosity >= 2147483647) // Stops rescursive routine critical warning
+    while(true)
+     {;}
+
   uint8_t data[256];
   memset(data, verbosity & 255, sizeof data);
   writer->printf("Stack bytes remaining: %u\n", uxTaskGetStackHighWaterMark(NULL));


### PR DESCRIPTION
Fix warnings that have been introduced by the switch to C++20 compiler in ESP-IDF v5+.

* Infinite recursion detection
* Deprecated implicit cast of enum to float
* Transition of implicit capture of this (deprecated) to explicit capture of this
* Enhanced 'unused result' detection in macro expansion.
* A deprecated 'nullptr' conversion issue