### PR TITLE
Update README.md - update description to represent hardware version 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ module and the web frontend can be customized by plugins. The module has three b
 extended by a fourth one](https://github.com/mjuhanne/OVMS-SWCAN).
 
 The **OVMS base component** is a small hardware module that connects to the vehicle **OBD2** 
-port. The standard kit in the current version 3.3 includes a 2G/3G/4G modem to provide **GSM**, **UMTS** and
-**LTE** connectivity and **GPS**. This standard kit has been **FCC certified** and **CE certified**.
+port. The standard kit in the current version 3.3 includes a **2G/3G/4G modem** to provide cellular 
+connectivity and **GPS**. This standard kit has been **FCC certified** and **CE certified**.
 
 The module provides a **built-in Web App** user interface and remote control via native cellphone Apps 
 available for **Android** and **iOS**. It integrates into home/process automation systems via **MQTT** and 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The module provides SSH access and WebSocket streaming and can stream and inject
 module and the web frontend can be customized by plugins. The module has three builtin CAN buses and [can be 
 extended by a fourth one](https://github.com/mjuhanne/OVMS-SWCAN).
 
-The **OVMS base component** is a small and inexpensive hardware module that connects to the vehicle **OBD2** 
-port. The standard kit includes a 3G modem to provide **GSM** connectivity and **GPS**. The US kit has been
-**FCC certified**, the EU kit **CE certified**.
+The **OVMS base component** is a small hardware module that connects to the vehicle **OBD2** 
+port. The standard kit in the current version 3.3 includes a 2G/3G/4G modem to provide **GSM**, **UMTS** and
+**LTE** connectivity and **GPS**. This standard kit has been **FCC certified** and **CE certified**.
 
 The module provides a **built-in Web App** user interface and remote control via native cellphone Apps 
 available for **Android** and **iOS**. It integrates into home/process automation systems via **MQTT** and 


### PR DESCRIPTION
The current hardware version 3.3 is the one with the highest cost. Many people report on the internet that they do not get the OVMS because of the high cost. Its not that affordable for many people so just remove the comment about the price because it does not add any benefits. The people see the price at the distributor and decide on their own if they can afford it. Hardware version 3.3 have dual certification and the modem can be used worldwide. Also it supports 2g, 3g and 4g networking.