### PR TITLE
Vehicles - Explicitly mark overridden functions.

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.h
+++ b/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.h
@@ -68,8 +68,8 @@ class OvmsVehicleBMWi3 : public OvmsVehicle
     OvmsVehicleBMWi3();
     ~OvmsVehicleBMWi3();
     void CanResponder(const CAN_frame_t* p_frame);
-    void Ticker1(uint32_t ticker);
-    void Ticker10(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
 
 
 

--- a/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.h
+++ b/vehicle/OVMS.V3/components/vehicle_boltev/src/vehicle_boltev.h
@@ -51,8 +51,8 @@ public:
     ~OvmsVehicleBoltEV();
 
 public:
-    void Status(int verbosity, OvmsWriter* writer);
-    void ConfigChanged(OvmsConfigParam* param);
+    void Status(int verbosity, OvmsWriter* writer) override;
+    void ConfigChanged(OvmsConfigParam* param) override;
 
     typedef enum {
         Park = 1,
@@ -72,30 +72,30 @@ public:
         OVMS        // OVMS takes care of everything (starting, stopping, lights)
     } va_preheat_commander_t;
 
-    vehicle_command_t CommandWakeup();
-    vehicle_command_t CommandClimateControl(bool enable);
-    vehicle_command_t CommandLock(const char* pin);
-    vehicle_command_t CommandUnlock(const char* pin);
-    vehicle_command_t CommandHomelink(int button, int durationms=1000);
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandClimateControl(bool enable) override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
     vehicle_command_t CommandLights(va_light_t lights, bool turn_on);
-    vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
+    vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
     void FlashLights(va_light_t light, int interval=500, int count=1); // milliseconds
 
 protected:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-    void IncomingFrameCan3(CAN_frame_t* p_frame);
-    void IncomingFrameCan4(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan3(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan4(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     void TxCallback(const CAN_frame_t* p_frame, bool success);
     void CommandWakeupComplete(const CAN_frame_t* p_frame, bool success);
     void SendTesterPresentMessage( uint32_t id );
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker10(uint32_t ticker);
-    virtual void Ticker300(uint32_t ticker);
-    virtual void NotifiedVehicleOn();
-    virtual void NotifiedVehicleOff();
-    virtual void NotifiedVehicleAwake();
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
+    void Ticker300(uint32_t ticker) override;
+    void NotifiedVehicleOn() override;
+    void NotifiedVehicleOff() override;
+    void NotifiedVehicleAwake() override;
 
     // va_ac_preheat
     void ClimateControlInit();

--- a/vehicle/OVMS.V3/components/vehicle_cadillac_c2_cts/src/vehicle_cadillac_c2_cts.h
+++ b/vehicle/OVMS.V3/components/vehicle_cadillac_c2_cts/src/vehicle_cadillac_c2_cts.h
@@ -45,16 +45,16 @@ class OvmsVehicleCadillaccC2CTS : public OvmsVehicle
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
 
   public:
-    virtual vehicle_command_t CommandWakeup(void);
-    virtual vehicle_command_t CommandLock(const char* pin);
-    virtual vehicle_command_t CommandUnlock(const char* pin);
+    virtual vehicle_command_t CommandWakeup(void) override;
+    virtual vehicle_command_t CommandLock(const char* pin) override;
+    virtual vehicle_command_t CommandUnlock(const char* pin) override;
 
   private:
-    void Ticker10(uint32_t ticker);
+    void Ticker10(uint32_t ticker) override;
 
   protected:
     char m_vin[18];

--- a/vehicle/OVMS.V3/components/vehicle_chevrolet_c6_corvette/src/vehicle_chevrolet_c6_corvette.h
+++ b/vehicle/OVMS.V3/components/vehicle_chevrolet_c6_corvette/src/vehicle_chevrolet_c6_corvette.h
@@ -41,7 +41,7 @@ class OvmsVehicleChevroletC6Corvette : public OvmsVehicle
   public:
     OvmsVehicleChevroletC6Corvette();
     ~OvmsVehicleChevroletC6Corvette();
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
 
   protected:
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;

--- a/vehicle/OVMS.V3/components/vehicle_dbc/src/vehicle_dbc.h
+++ b/vehicle/OVMS.V3/components/vehicle_dbc/src/vehicle_dbc.h
@@ -47,9 +47,9 @@ class OvmsVehicleDBC : public OvmsVehicle
     bool RegisterCanBusDBCLoaded(int bus, CAN_mode_t mode, const char* dbcloaded);
 
   protected:
-    virtual void IncomingFrameCan1(CAN_frame_t* p_frame);
-    virtual void IncomingFrameCan2(CAN_frame_t* p_frame);
-    virtual void IncomingFrameCan3(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan3(CAN_frame_t* p_frame) override;
 
   protected:
     virtual void IncomingFrame(canbus* bus, CAN_frame_t* frame);
@@ -62,9 +62,9 @@ class OvmsVehiclePureDBC : public OvmsVehicleDBC
     ~OvmsVehiclePureDBC();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-    void IncomingFrameCan3(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan3(CAN_frame_t* p_frame) override;
   };
 
 #endif //#ifndef __VEHICLE_DBC_H__

--- a/vehicle/OVMS.V3/components/vehicle_demo/src/vehicle_demo.h
+++ b/vehicle/OVMS.V3/components/vehicle_demo/src/vehicle_demo.h
@@ -42,22 +42,22 @@ class OvmsVehicleDemo : public OvmsVehicle
     ~OvmsVehicleDemo();
 
   public:
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker10(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
 
   public:
-    virtual vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode);
-    virtual vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
-    virtual vehicle_command_t CommandStartCharge();
-    virtual vehicle_command_t CommandStopCharge();
-    virtual vehicle_command_t CommandSetChargeTimer(bool timeron, uint16_t timerstart);
-    virtual vehicle_command_t CommandCooldown(bool cooldownon);
-    virtual vehicle_command_t CommandWakeup();
-    virtual vehicle_command_t CommandLock(const char* pin);
-    virtual vehicle_command_t CommandUnlock(const char* pin);
-    virtual vehicle_command_t CommandActivateValet(const char* pin);
-    virtual vehicle_command_t CommandDeactivateValet(const char* pin);
-    virtual vehicle_command_t CommandHomelink(int button, int durationms=1000);
+    vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode) override;
+    vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
+    vehicle_command_t CommandStartCharge() override;
+    vehicle_command_t CommandStopCharge() override;
+    vehicle_command_t CommandSetChargeTimer(bool timeron, uint16_t timerstart) override;
+    vehicle_command_t CommandCooldown(bool cooldownon) override;
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
   };
 
 #endif //#ifndef __VEHICLE_DEMO_H__

--- a/vehicle/OVMS.V3/components/vehicle_fiat500/src/vehicle_fiat500e.h
+++ b/vehicle/OVMS.V3/components/vehicle_fiat500/src/vehicle_fiat500e.h
@@ -42,22 +42,22 @@ class OvmsVehicleFiat500e : public OvmsVehicle
     ~OvmsVehicleFiat500e();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-    virtual vehicle_command_t CommandWakeup();
-    virtual vehicle_command_t CommandStartCharge();
-    virtual vehicle_command_t CommandStopCharge();
-    virtual vehicle_command_t CommandLock(const char* pin);
-    virtual vehicle_command_t CommandUnlock(const char* pin);
-    virtual vehicle_command_t CommandActivateValet(const char* pin);
-    virtual vehicle_command_t CommandDeactivateValet(const char* pin);
-    virtual vehicle_command_t CommandHomelink(int button, int durationms);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandStartCharge() override;
+    vehicle_command_t CommandStopCharge() override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms) override;
 
   //public:
     //static void xse_drivemode(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
 
   protected:
-    virtual void Ticker1(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
 
     OvmsMetricFloat *mt_mb_trip_reset;        // Distance since reset
     OvmsMetricFloat *mt_mb_trip_start;        // Distance since default trip started

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
@@ -168,7 +168,7 @@ public:
   void EventListener(std::string event, void *data);
   void UpdatedAverageTemp(OvmsMetric* metric);
   void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
-  void ConfigChanged(OvmsConfigParam *param);
+  void ConfigChanged(OvmsConfigParam *param) override;
   bool SetFeature(int key, const char *value);
   const std::string GetFeature(int key);
   vehicle_command_t CommandHandler(int verbosity, OvmsWriter *writer, OvmsCommand *cmd, int argc, const char *const *argv);

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.h
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.h
@@ -44,8 +44,8 @@ class OvmsVehicleHyundaiVFL : public OvmsVehicle
     ~OvmsVehicleHyundaiVFL();
 
   public:
-    void ConfigChanged(OvmsConfigParam *param);
-    void MetricModified(OvmsMetric* metric);
+    void ConfigChanged(OvmsConfigParam *param) override;
+    void MetricModified(OvmsMetric* metric) override;
 
   protected:
     void Ticker60(uint32_t ticker);

--- a/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.h
+++ b/vehicle/OVMS.V3/components/vehicle_kianiroev/src/vehicle_kianiroev.h
@@ -77,13 +77,13 @@ class OvmsVehicleKiaNiroEv : public KiaVehicle
     ~OvmsVehicleKiaNiroEv();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void Ticker1(uint32_t ticker);
-    void Ticker10(uint32_t ticker);
-    void Ticker300(uint32_t ticker);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
+    void Ticker300(uint32_t ticker) override;
     void EventListener(std::string event, void* data);
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
-    void ConfigChanged(OvmsConfigParam* param);
+    void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
     vehicle_command_t CommandHandler(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
@@ -107,8 +107,8 @@ class OvmsVehicleKiaNiroEv : public KiaVehicle
     					uint8_t serviceId, uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4,
 						uint8_t b5, uint8_t b6, uint8_t mode );
 
-    virtual OvmsVehicle::vehicle_command_t CommandLock(const char* pin);
-    virtual OvmsVehicle::vehicle_command_t CommandUnlock(const char* pin);
+    OvmsVehicle::vehicle_command_t CommandLock(const char* pin) override;
+    OvmsVehicle::vehicle_command_t CommandUnlock(const char* pin) override;
 
     bool OpenTrunk(const char* password);
     bool ACCRelay(bool,const char *password);

--- a/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.h
+++ b/vehicle/OVMS.V3/components/vehicle_kiasoulev/src/vehicle_kiasoulev.h
@@ -77,14 +77,14 @@ class OvmsVehicleKiaSoulEv : public KiaVehicle
     ~OvmsVehicleKiaSoulEv();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-    void Ticker1(uint32_t ticker);
-    void Ticker10(uint32_t ticker);
-    void Ticker300(uint32_t ticker);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
+    void Ticker300(uint32_t ticker) override;
     void EventListener(std::string event, void* data);
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
-    void ConfigChanged(OvmsConfigParam* param);
+    void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
     vehicle_command_t CommandHandler(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
@@ -107,8 +107,8 @@ class OvmsVehicleKiaSoulEv : public KiaVehicle
     					uint8_t serviceId, uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4,
 						uint8_t b5, uint8_t b6, uint8_t mode );
 
-    virtual OvmsVehicle::vehicle_command_t CommandLock(const char* pin);
-    virtual OvmsVehicle::vehicle_command_t CommandUnlock(const char* pin);
+    OvmsVehicle::vehicle_command_t CommandLock(const char* pin) override;
+    OvmsVehicle::vehicle_command_t CommandUnlock(const char* pin) override;
 
     bool OpenTrunk(const char* password);
     bool OpenChargePort(const char* password);

--- a/vehicle/OVMS.V3/components/vehicle_maxus_edeliver3/src/vehicle_med3.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_edeliver3/src/vehicle_med3.h
@@ -73,7 +73,7 @@ class OvmsVehicleMaxed3 : public OvmsVehicle
   protected:
       void ConfigChanged(OvmsConfigParam* param) override;
       void PollerStateTicker();
-      void Ticker1(uint32_t ticker);
+      void Ticker1(uint32_t ticker) override;
       void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
       void processEnergy();
       float consumpRange;

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq56/src/vehicle_me56.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq56/src/vehicle_me56.h
@@ -73,7 +73,7 @@ class OvmsVehicleMaxe56 : public OvmsVehicle
   protected:
       void ConfigChanged(OvmsConfigParam* param) override;
       void PollerStateTicker();
-      void Ticker1(uint32_t ticker);
+      void Ticker1(uint32_t ticker) override;
       void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
       void processEnergy();
       float consumpRange;
@@ -81,7 +81,7 @@ class OvmsVehicleMaxe56 : public OvmsVehicle
       char m_vin[17];
       
   private:
-      void IncomingFrameCan1(CAN_frame_t* p_frame);
+      void IncomingFrameCan1(CAN_frame_t* p_frame) override;
       void IncomingPollFrame(CAN_frame_t* frame);
       void SetBmsStatus(uint8_t status);
       /// A temporary store for the VIN

--- a/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
+++ b/vehicle/OVMS.V3/components/vehicle_mercedesb250e/src/vehicle_mercedesb250e.h
@@ -40,7 +40,7 @@ class OvmsVehicleMercedesB250e : public OvmsVehicle
     ~OvmsVehicleMercedesB250e();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
 
   protected:
     OvmsMetricFloat *mt_mb_trip_reset;        // Distance since reset

--- a/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.h
+++ b/vehicle/OVMS.V3/components/vehicle_mgev/src/vehicle_mgev_a.h
@@ -46,7 +46,7 @@ class OvmsVehicleMgEvA : public OvmsVehicleMgEv
 
   protected:
     void Ticker1(uint32_t ticker) override;
-    vehicle_command_t CommandWakeup() override;   
+    vehicle_command_t CommandWakeup() override;
 
   private:
     void ZombieMode();

--- a/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.h
+++ b/vehicle/OVMS.V3/components/vehicle_mitsubishi/src/vehicle_mitsubishi.h
@@ -67,13 +67,13 @@ class OvmsVehicleMitsubishi : public OvmsVehicle
     ~OvmsVehicleMitsubishi();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     char m_vin[18];
 
   protected:
-    virtual void Ticker1(uint32_t ticker);
-    void ConfigChanged(OvmsConfigParam* param);
+    void Ticker1(uint32_t ticker) override;
+    void ConfigChanged(OvmsConfigParam* param) override;
 
   protected:
 
@@ -81,7 +81,7 @@ class OvmsVehicleMitsubishi : public OvmsVehicle
     std::string m_rxbuf;
 
   public:
-    virtual vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer);
+    vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer) override;
 
     OvmsMetricFloat* v_b_power_min  = MyMetrics.InitFloat("xmi.b.power.min", 10, 0, kW);
     OvmsMetricFloat* v_b_power_max  = MyMetrics.InitFloat("xmi.b.power.max", 10, 0, kW);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -112,20 +112,20 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
 
   public:
     static OvmsVehicleNissanLeaf* GetInstance(OvmsWriter* writer=NULL);
-    void ConfigChanged(OvmsConfigParam* param);
+    void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
 
   public:
     bool ObdRequest(uint16_t txid, uint16_t rxid, uint32_t request, string& response, int timeout_ms /*=3000*/, uint8_t bus);
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
-    vehicle_command_t CommandHomelink(int button, int durationms=1000);
-    vehicle_command_t CommandClimateControl(bool enable);
-    vehicle_command_t CommandLock(const char* pin);
-    vehicle_command_t CommandUnlock(const char* pin);
-    vehicle_command_t CommandWakeup();
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
+    vehicle_command_t CommandClimateControl(bool enable) override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandWakeup() override;
     void RemoteCommandTimer();
     void CcDisableTimer();
     void MITMDisableTimer();
@@ -152,8 +152,8 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     void vehicle_nissanleaf_car_on(bool isOn);
     void vehicle_nissanleaf_charger_status(ChargerStatus status);
     void SendCanMessage(uint16_t id, uint8_t length, uint8_t *data);
-    void Ticker1(uint32_t ticker);
-    void Ticker10(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
     void HandleEnergy();
     void HandleCharging();
     void HandleChargeEstimation();
@@ -162,8 +162,8 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     int  calcMinutesRemaining(float target, float charge_power_w);
     void SendCommand(RemoteCommand);
     OvmsVehicle::vehicle_command_t RemoteCommandHandler(RemoteCommand command);
-    OvmsVehicle::vehicle_command_t CommandStartCharge();
-    OvmsVehicle::vehicle_command_t CommandStopCharge();
+    OvmsVehicle::vehicle_command_t CommandStartCharge() override;
+    OvmsVehicle::vehicle_command_t CommandStopCharge() override;
     virtual int GetNotifyChargeStateDelay(const char* state);
     RemoteCommand nl_remote_command; // command to send, see RemoteCommandTimer()
     uint8_t nl_remote_command_ticker; // number remaining remote command frames to send

--- a/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaulttwizy/src/vehicle_renaulttwizy.h
@@ -98,12 +98,12 @@ class OvmsVehicleRenaultTwizy : public OvmsVehicle
   
   public:
     void CanResponder(const CAN_frame_t* p_frame);
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     void IncomingPollError(const OvmsPoller::poll_job_t &job, uint16_t code) override;
-    void Ticker1(uint32_t ticker);
-    void Ticker10(uint32_t ticker);
-    void ConfigChanged(OvmsConfigParam* param);
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
+    void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
     void EventListener(string event, void* data);
@@ -124,7 +124,7 @@ class OvmsVehicleRenaultTwizy : public OvmsVehicle
   // 
   
   public:
-    vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer);
+    vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer) override;
   
   protected:
     void UpdateMaxRange();
@@ -457,9 +457,9 @@ class OvmsVehicleRenaultTwizy : public OvmsVehicle
     void ChargeShutdown();
     vehicle_command_t CommandCA(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     vehicle_command_t MsgCommandCA(std::string &result, int command, const char* args);
-    vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode);
-    vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
-    vehicle_command_t CommandStopCharge();
+    vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode) override;
+    vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
+    vehicle_command_t CommandStopCharge() override;
     
   protected:
     OvmsCommand *cmd_ca;
@@ -489,10 +489,10 @@ class OvmsVehicleRenaultTwizy : public OvmsVehicle
     vehicle_command_t MsgCommandResetLogs(string& result, int command, const char* args);
     
   public:
-    vehicle_command_t CommandLock(const char* pin);
-    vehicle_command_t CommandUnlock(const char* pin);
-    vehicle_command_t CommandActivateValet(const char* pin);
-    vehicle_command_t CommandDeactivateValet(const char* pin);
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
 
   public:
     int               twizy_lock_speed = 6;     // if Lock mode: fix speed to this (kph)

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.h
@@ -72,7 +72,7 @@ class OvmsVehicleRenaultZoe : public OvmsVehicle {
     OvmsVehicleRenaultZoe();
     ~OvmsVehicleRenaultZoe();
 		static OvmsVehicleRenaultZoe* GetInstance(OvmsWriter* writer=NULL);
-		void IncomingFrameCan1(CAN_frame_t* p_frame);
+		void IncomingFrameCan1(CAN_frame_t* p_frame) override;
 		void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
 
 	protected:
@@ -83,8 +83,8 @@ class OvmsVehicleRenaultZoe : public OvmsVehicle {
 		void IncomingUBP(uint16_t type, uint16_t pid, const char* data, uint16_t len);
 		void IncomingPEB(uint16_t type, uint16_t pid, const char* data, uint16_t len);
 		void car_on(bool isOn);
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker10(uint32_t ticker);
+		void Ticker1(uint32_t ticker) override;
+		void Ticker10(uint32_t ticker) override;
     void HandleCharging();
     void HandleEnergy();
     int calcMinutesRemaining(float target, float charge_voltage, float charge_current);
@@ -107,20 +107,20 @@ class OvmsVehicleRenaultZoe : public OvmsVehicle {
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
 #endif
-    void ConfigChanged(OvmsConfigParam* param);
+    void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
   
   public:
     //virtual vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
     //virtual vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer);
-    virtual vehicle_command_t CommandWakeup();
-    virtual vehicle_command_t CommandClimateControl(bool enable);
-    virtual vehicle_command_t CommandLock(const char* pin);
-    virtual vehicle_command_t CommandUnlock(const char* pin);
-    virtual vehicle_command_t CommandHomelink(int button, int durationms=1000);
-    virtual vehicle_command_t CommandActivateValet(const char* pin);
-    virtual vehicle_command_t CommandDeactivateValet(const char* pin);
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandClimateControl(bool enable) override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
     virtual vehicle_command_t CommandTrip(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer);
 		void NotifyTrip();

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.h
@@ -68,9 +68,9 @@ class OvmsVehicleRenaultZoePh2OBD : public OvmsVehicle {
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
     static void WebCfgCommon(PageEntry_t& p, PageContext_t& c);
 #endif
-    void ConfigChanged(OvmsConfigParam* param);
+    void ConfigChanged(OvmsConfigParam* param) override;
     void ZoeWakeUp();
-		void IncomingFrameCan1(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
     void WebInit();
@@ -101,8 +101,8 @@ class OvmsVehicleRenaultZoePh2OBD : public OvmsVehicle {
     void ChargeStatistics();
     void EnergyStatisticsOVMS();
     void EnergyStatisticsBMS();
-    virtual void Ticker10(uint32_t ticker);//Handle charge, energy statistics
-    virtual void Ticker1(uint32_t ticker); //Handle trip counter
+    void Ticker10(uint32_t ticker) override;//Handle charge, energy statistics
+    void Ticker1(uint32_t ticker) override; //Handle trip counter
     
     		
     // Renault ZOE specific metrics

--- a/vehicle/OVMS.V3/components/vehicle_smarted/src/vehicle_smarted.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarted/src/vehicle_smarted.h
@@ -63,8 +63,8 @@ class OvmsVehicleSmartED : public OvmsVehicle
     static OvmsVehicleSmartED* GetInstance(OvmsWriter* writer=NULL);
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     void IncomingPollError(const OvmsPoller::poll_job_t &job, uint16_t code) override;
     char m_vin[18];
@@ -85,23 +85,23 @@ class OvmsVehicleSmartED : public OvmsVehicle
     static void WebCfgBmsCellCapacity(PageEntry_t& p, PageContext_t& c);
     static void WebCfgEco(PageEntry_t& p, PageContext_t& c);
 #endif
-    void ConfigChanged(OvmsConfigParam* param);
+    void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
     bool CommandSetRecu(bool on);
     bool SetRecu(int mode);
 
   public:
-    virtual vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
-    virtual vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer);
-    virtual vehicle_command_t CommandWakeup();
-    virtual vehicle_command_t CommandSetChargeTimer(bool timeron, int hours, int minutes);
-    virtual vehicle_command_t CommandClimateControl(bool enable);
-    virtual vehicle_command_t CommandLock(const char* pin);
-    virtual vehicle_command_t CommandUnlock(const char* pin);
-    virtual vehicle_command_t CommandHomelink(int button, int durationms=1000);
-    virtual vehicle_command_t CommandActivateValet(const char* pin);
-    virtual vehicle_command_t CommandDeactivateValet(const char* pin);
+    vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
+    vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer) override;
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandSetChargeTimer(bool timeron, int hours, int minutes);
+    vehicle_command_t CommandClimateControl(bool enable) override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
     virtual vehicle_command_t CommandTrip(int verbosity, OvmsWriter* writer);
     void BmsDiag(int verbosity, OvmsWriter* writer);
     void printRPTdata(int verbosity, OvmsWriter* writer);
@@ -118,17 +118,17 @@ class OvmsVehicleSmartED : public OvmsVehicle
     int m_reboot_ticker;
     uint16_t m_last_pid;
 
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker10(uint32_t ticker);
-    virtual void Ticker60(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
+    void Ticker60(uint32_t ticker) override;
     void GetDashboardConfig(DashboardConfig& cfg);
     virtual void CalculateEfficiency();
     void vehicle_smarted_car_on(bool isOn);    
     void NotifyTrip();
-    void NotifyValetEnabled();
-    void NotifyValetDisabled();
-    void NotifyValetHood();
-    void NotifyValetTrunk();
+    void NotifyValetEnabled() override;
+    void NotifyValetDisabled() override;
+    void NotifyValetHood() override;
+    void NotifyValetTrunk() override;
     void SaveStatus();
     void RestoreStatus();
     void HandleCharging();

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -56,7 +56,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     ~OvmsVehicleSmartEQ();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     void HandleEnergy();
 
@@ -67,7 +67,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
 #endif
-    void ConfigChanged(OvmsConfigParam* param);
+    void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
     uint64_t swap_uint64(uint64_t val);
@@ -77,7 +77,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     unsigned int m_candata_poll;
 
   protected:
-    virtual void Ticker1(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
     void GetDashboardConfig(DashboardConfig& cfg);
     
     void PollReply_BMS_BattVolts(const char* reply_data, uint16_t reply_len, uint16_t start);

--- a/vehicle/OVMS.V3/components/vehicle_teslamodel3/src/vehicle_teslamodel3.h
+++ b/vehicle/OVMS.V3/components/vehicle_teslamodel3/src/vehicle_teslamodel3.h
@@ -43,14 +43,14 @@ class OvmsVehicleTeslaModel3: public OvmsVehicle
     ~OvmsVehicleTeslaModel3();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-    void IncomingFrameCan3(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan3(CAN_frame_t* p_frame) override;
 
   protected:
-    virtual void Notify12vCritical();
-    virtual void Notify12vRecovered();
-    virtual void NotifyBmsAlerts();
+    void Notify12vCritical() override;
+    void Notify12vRecovered() override;
+    void NotifyBmsAlerts() override;
 
   protected:
     char m_vin[18];

--- a/vehicle/OVMS.V3/components/vehicle_teslamodels/src/vehicle_teslamodels.h
+++ b/vehicle/OVMS.V3/components/vehicle_teslamodels/src/vehicle_teslamodels.h
@@ -45,20 +45,20 @@ class OvmsVehicleTeslaModelS: public OvmsVehicle
     ~OvmsVehicleTeslaModelS();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-    void IncomingFrameCan3(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan3(CAN_frame_t* p_frame) override;
 
   protected:
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Notify12vCritical();
-    virtual void Notify12vRecovered();
-    virtual void NotifyBmsAlerts();
+    void Ticker1(uint32_t ticker) override;
+    void Notify12vCritical() override;
+    void Notify12vRecovered() override;
+    void NotifyBmsAlerts() override;
 
 #ifdef CONFIG_OVMS_COMP_TPMS
   public:
-    virtual bool TPMSRead(std::vector<uint32_t> *tpms);
-    virtual bool TPMSWrite(std::vector<uint32_t> &tpms);
+    bool TPMSRead(std::vector<uint32_t> *tpms) override;
+    bool TPMSWrite(std::vector<uint32_t> &tpms) override;
 
   protected:
     typedef enum

--- a/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.h
+++ b/vehicle/OVMS.V3/components/vehicle_teslaroadster/src/vehicle_teslaroadster.h
@@ -46,23 +46,23 @@ class OvmsVehicleTeslaRoadster : public OvmsVehicle
     void IncomingFrameCan1(CAN_frame_t* p_frame);
 
   public:
-    virtual vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode);
-    virtual vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
-    virtual vehicle_command_t CommandStartCharge();
-    virtual vehicle_command_t CommandStopCharge();
-    virtual vehicle_command_t CommandSetChargeTimer(bool timeron, uint16_t timerstart);
-    virtual vehicle_command_t CommandCooldown(bool cooldownon);
-    virtual vehicle_command_t CommandWakeup();
-    virtual vehicle_command_t CommandLock(const char* pin);
-    virtual vehicle_command_t CommandUnlock(const char* pin);
-    virtual vehicle_command_t CommandActivateValet(const char* pin);
-    virtual vehicle_command_t CommandDeactivateValet(const char* pin);
-    virtual vehicle_command_t CommandHomelink(int button, int durationms=1000);
+    vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode) override;
+    vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
+    vehicle_command_t CommandStartCharge() override;
+    vehicle_command_t CommandStopCharge() override;
+    vehicle_command_t CommandSetChargeTimer(bool timeron, uint16_t timerstart) override;
+    vehicle_command_t CommandCooldown(bool cooldownon) override;
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
 
 #ifdef CONFIG_OVMS_COMP_TPMS
   public:
-    virtual bool TPMSRead(std::vector<uint32_t> *tpms);
-    virtual bool TPMSWrite(std::vector<uint32_t> &tpms);
+    bool TPMSRead(std::vector<uint32_t> *tpms) override;
+    bool TPMSWrite(std::vector<uint32_t> &tpms) override;
 #endif // #ifdef CONFIG_OVMS_COMP_TPMS
 
   public:
@@ -91,19 +91,19 @@ class OvmsVehicleTeslaRoadster : public OvmsVehicle
     TimerHandle_t m_speedo_timer;              // Timer for digital speedo
 
   public:
-    virtual void Status(int verbosity, OvmsWriter* writer);
+    void Status(int verbosity, OvmsWriter* writer) override;
 
   protected:
-    virtual void Notify12vCritical();
-    virtual void Notify12vRecovered();
+    void Notify12vCritical() override;
+    void Notify12vRecovered() override;
 
   protected:
-    virtual int GetNotifyChargeStateDelay(const char* state);
-    virtual void NotifiedVehicleChargeStart();
-    virtual void NotifiedVehicleOn();
-    virtual void NotifiedVehicleOff();
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker60(uint32_t ticker);
+    int GetNotifyChargeStateDelay(const char* state) override;
+    void NotifiedVehicleChargeStart() override;
+    void NotifiedVehicleOn() override;
+    void NotifiedVehicleOff() override;
+    void Ticker1(uint32_t ticker) override;
+    void Ticker60(uint32_t ticker) override;
 
   protected:
     void RequestStreamStartCAC();

--- a/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.h
+++ b/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.h
@@ -45,13 +45,13 @@ class OvmsVehicleThinkCity : public OvmsVehicle
     ~OvmsVehicleThinkCity();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
  
-    vehicle_command_t CommandLock(const char* pin);
-    vehicle_command_t CommandUnlock(const char* pin);
-    vehicle_command_t CommandActivateValet(const char* pin);
-    vehicle_command_t CommandDeactivateValet(const char* pin);
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
 
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
   // --------------------------------------------------------------------------
@@ -71,8 +71,8 @@ class OvmsVehicleThinkCity : public OvmsVehicle
 #endif //CONFIG_OVMS_COMP_WEBSERVER
 
   protected:
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker10(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
 
   private:
     

--- a/vehicle/OVMS.V3/components/vehicle_toyotarav4ev/src/vehicle_toyotarav4ev.h
+++ b/vehicle/OVMS.V3/components/vehicle_toyotarav4ev/src/vehicle_toyotarav4ev.h
@@ -61,17 +61,17 @@ class OvmsVehicleToyotaRav4Ev: public OvmsVehicle
     ~OvmsVehicleToyotaRav4Ev();
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-//    void IncomingFrameCan3(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+//    void IncomingFrameCan3(CAN_frame_t* p_frame) override;
 //    void GetDashboardConfig(DashboardConfig& cfg);
 
   protected:
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker60(uint32_t ticker);
-    virtual void Notify12vCritical();
-    virtual void Notify12vRecovered();
-    virtual void NotifyBmsAlerts();
+    void Ticker1(uint32_t ticker) override;
+    void Ticker60(uint32_t ticker) override;
+    void Notify12vCritical() override;
+    void Notify12vRecovered() override;
+    void NotifyBmsAlerts() override;
 
 /*
 #ifdef CONFIG_OVMS_COMP_TPMS

--- a/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.h
+++ b/vehicle/OVMS.V3/components/vehicle_voltampera/src/vehicle_voltampera.h
@@ -50,8 +50,8 @@ class OvmsVehicleVoltAmpera : public OvmsVehicle
     ~OvmsVehicleVoltAmpera();
 
   public:
-    void Status(int verbosity, OvmsWriter* writer);
-    void ConfigChanged(OvmsConfigParam* param);
+    void Status(int verbosity, OvmsWriter* writer) override;
+    void ConfigChanged(OvmsConfigParam* param) override;
 
     typedef enum
       {
@@ -73,30 +73,30 @@ class OvmsVehicleVoltAmpera : public OvmsVehicle
         OVMS        // OVMS takes care of everything (starting, stopping, lights)
       } va_preheat_commander_t;
 
-    vehicle_command_t CommandWakeup();
-    vehicle_command_t CommandClimateControl(bool enable);
-    vehicle_command_t CommandLock(const char* pin);
-    vehicle_command_t CommandUnlock(const char* pin);
-    vehicle_command_t CommandHomelink(int button, int durationms=1000);
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandClimateControl(bool enable) override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
     vehicle_command_t CommandLights(va_light_t lights, bool turn_on);
-    vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
+    vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
     void FlashLights(va_light_t light, int interval=500, int count=1); // milliseconds
 
   protected:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    void IncomingFrameCan2(CAN_frame_t* p_frame);
-    void IncomingFrameCan3(CAN_frame_t* p_frame);
-    void IncomingFrameCan4(CAN_frame_t* p_frame);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan2(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan3(CAN_frame_t* p_frame) override;
+    void IncomingFrameCan4(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     void TxCallback(const CAN_frame_t* p_frame, bool success);
     void CommandWakeupComplete(const CAN_frame_t* p_frame, bool success);
     void SendTesterPresentMessage( uint32_t id );
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker10(uint32_t ticker);
-    virtual void Ticker300(uint32_t ticker);
-    virtual void NotifiedVehicleOn();
-    virtual void NotifiedVehicleOff();
-    virtual void NotifiedVehicleAwake();
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
+    void Ticker300(uint32_t ticker) override;
+    void NotifiedVehicleOn() override;
+    void NotifiedVehicleOff() override;
+    void NotifiedVehicleAwake() override;
 
     // va_ac_preheat
     void ClimateControlInit();

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.h
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vehicle_vweup.h
@@ -138,7 +138,7 @@ public:
   static OvmsVehicleVWeUp *GetInstance(OvmsWriter *writer = NULL);
 
 public:
-  void ConfigChanged(OvmsConfigParam *param);
+  void ConfigChanged(OvmsConfigParam *param) override;
   void MetricModified(OvmsMetric* metric);
   bool SetFeature(int key, const char *value);
   const std::string GetFeature(int key);
@@ -146,21 +146,21 @@ public:
   vehicle_command_t MsgCommandCA(std::string &result, int command, const char* args);
 
 protected:
-  void Ticker1(uint32_t ticker);
-  void Ticker10(uint32_t ticker);
-  void Ticker60(uint32_t ticker);
+  void Ticker1(uint32_t ticker) override;
+  void Ticker10(uint32_t ticker) override;
+  void Ticker60(uint32_t ticker) override;
 
 public:
-  vehicle_command_t CommandHomelink(int button, int durationms = 1000);
-  vehicle_command_t CommandClimateControl(bool enable);
-  vehicle_command_t CommandLock(const char *pin);
-  vehicle_command_t CommandUnlock(const char *pin);
-  vehicle_command_t CommandStartCharge();
-  vehicle_command_t CommandStopCharge();
-  vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
-  vehicle_command_t CommandActivateValet(const char *pin);
-  vehicle_command_t CommandDeactivateValet(const char *pin);
-  vehicle_command_t CommandWakeup();
+  vehicle_command_t CommandHomelink(int button, int durationms = 1000) override;
+  vehicle_command_t CommandClimateControl(bool enable) override;
+  vehicle_command_t CommandLock(const char *pin) override;
+  vehicle_command_t CommandUnlock(const char *pin) override;
+  vehicle_command_t CommandStartCharge() override;
+  vehicle_command_t CommandStopCharge() override;
+  vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
+  vehicle_command_t CommandActivateValet(const char *pin) override;
+  vehicle_command_t CommandDeactivateValet(const char *pin) override;
+  vehicle_command_t CommandWakeup() override;
 
 protected:
   int GetNotifyChargeStateDelay(const char *state);
@@ -281,7 +281,7 @@ protected:
   void T26Ticker1(uint32_t ticker);
 
 protected:
-  void IncomingFrameCan3(CAN_frame_t *p_frame);
+  void IncomingFrameCan3(CAN_frame_t *p_frame) override;
 
 public:
   void SendOcuHeartbeat();

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.h
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.h
@@ -72,7 +72,7 @@ class OvmsVehicleVWeUpAll : public OvmsVehicle
     void IncomingFrameCan3(CAN_frame_t* p_frame);
 
   protected:
-    virtual void Ticker1(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
     char m_vin[18];
 
   public:

--- a/vehicle/OVMS.V3/components/vehicle_zeva/src/vehicle_zeva.h
+++ b/vehicle/OVMS.V3/components/vehicle_zeva/src/vehicle_zeva.h
@@ -40,23 +40,23 @@ class OvmsVehicleZeva : public OvmsVehicle
     ~OvmsVehicleZeva();
 
   public:
-    virtual void Ticker1(uint32_t ticker);
-    virtual void Ticker10(uint32_t ticker);
+    void Ticker1(uint32_t ticker) override;
+    void Ticker10(uint32_t ticker) override;
 
   public:
-    void IncomingFrameCan1(CAN_frame_t* p_frame);
-    virtual vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode);
-    virtual vehicle_command_t CommandSetChargeCurrent(uint16_t limit);
-    virtual vehicle_command_t CommandStartCharge();
-    virtual vehicle_command_t CommandStopCharge();
-    virtual vehicle_command_t CommandSetChargeTimer(bool timeron, uint16_t timerstart);
-    virtual vehicle_command_t CommandCooldown(bool cooldownon);
-    virtual vehicle_command_t CommandWakeup();
-    virtual vehicle_command_t CommandLock(const char* pin);
-    virtual vehicle_command_t CommandUnlock(const char* pin);
-    virtual vehicle_command_t CommandActivateValet(const char* pin);
-    virtual vehicle_command_t CommandDeactivateValet(const char* pin);
-    virtual vehicle_command_t CommandHomelink(int button, int durationms=1000);
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+    vehicle_command_t CommandSetChargeMode(vehicle_mode_t mode) override;
+    vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;
+    vehicle_command_t CommandStartCharge() override;
+    vehicle_command_t CommandStopCharge() override;
+    vehicle_command_t CommandSetChargeTimer(bool timeron, uint16_t timerstart) override;
+    vehicle_command_t CommandCooldown(bool cooldownon) override;
+    vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandLock(const char* pin) override;
+    vehicle_command_t CommandUnlock(const char* pin) override;
+    vehicle_command_t CommandActivateValet(const char* pin) override;
+    vehicle_command_t CommandDeactivateValet(const char* pin) override;
+    vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
   };
 
 #endif //#ifndef __VEHICLE_ZEVA_H__


### PR DESCRIPTION
 - Also remove 'virtual' when they are actually overrides.

Being clear about which methods are overrides helps when reading the code - but also makes sure that when your overridden function is actually overriding the function,