### PR TITLE
Vehicle - Make sure RX functions are being called from a Task

### DIFF
--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -999,6 +999,7 @@ void OvmsPollers::PollerTask()
         ESP_LOGV(TAG, "Pollers: FrameRx(bus=%d)", GetBusNo(entry.entry_FrameRxTx.frame.origin));
         if (poller)
           poller->Incoming(entry.entry_FrameRxTx.frame, entry.entry_FrameRxTx.success);
+        PollerFrameRx(entry.entry_FrameRxTx.frame);
         }
         break;
       case OvmsPoller::OvmsPollEntryType::FrameTx:

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -704,7 +704,10 @@ class OvmsPollers : public InternalRamAllocated {
     void RegisterPollStateTicker(const std::string &name, PollCallback fn) { m_pollstateticker_callback.Register(name, fn);}
     void DeregisterPollStateTicker(const std::string &name) { m_pollstateticker_callback.Deregister(name);}
 
-    void RegisterFrameRx(const std::string &name, FrameCallback fn) { m_framerx_callback.Register(name, fn);}
+    void RegisterFrameRx(const std::string &name, FrameCallback fn) {
+      m_framerx_callback.Register(name, fn);
+      CheckStartPollTask(true);
+    }
     void DeregisterFrameRx(const std::string &name) { m_framerx_callback.Deregister(name);}
   private:
     void PollRunFinished(canbus *bus)

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -694,13 +694,18 @@ class OvmsPollers : public InternalRamAllocated {
     void SetUserPauseStatus(bool paused, int verbosity, OvmsWriter* writer);
   public:
     typedef std::function<void(canbus*, void *)> PollCallback;
+    typedef std::function<void(const CAN_frame_t &)> FrameCallback;
   private:
     ovms_callback_register_t<PollCallback> m_runfinished_callback, m_pollstateticker_callback;
+    ovms_callback_register_t<FrameCallback> m_framerx_callback;
   public:
     void RegisterRunFinished(const std::string &name, PollCallback fn) { m_runfinished_callback.Register(name, fn);}
     void DeregisterRunFinished(const std::string &name) { m_runfinished_callback.Deregister(name);}
     void RegisterPollStateTicker(const std::string &name, PollCallback fn) { m_pollstateticker_callback.Register(name, fn);}
     void DeregisterPollStateTicker(const std::string &name) { m_pollstateticker_callback.Deregister(name);}
+
+    void RegisterFrameRx(const std::string &name, FrameCallback fn) { m_framerx_callback.Register(name, fn);}
+    void DeregisterFrameRx(const std::string &name) { m_framerx_callback.Deregister(name);}
   private:
     void PollRunFinished(canbus *bus)
       {
@@ -716,6 +721,14 @@ class OvmsPollers : public InternalRamAllocated {
         [bus](const std::string &name, const PollCallback &cb)
           {
           cb(bus, nullptr);
+          });
+      }
+    void PollerFrameRx(CAN_frame_t &frame)
+      {
+      m_framerx_callback.Call(
+        [frame](const std::string &name, FrameCallback cb)
+          {
+          cb(frame);
           });
       }
 

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -240,8 +240,6 @@ const char* OvmsVehicleFactory::ActiveVehicleShortName()
   return m_currentvehicle ? m_currentvehicle->VehicleShortName() : "";
   }
 
-static const char *PollerRegister="Vehicle Listener";
-
 OvmsVehicle::OvmsVehicle()
   {
 
@@ -366,7 +364,17 @@ OvmsVehicle::OvmsVehicle()
   VehicleConfigChanged("config.mounted", NULL);
 
   MyMetrics.RegisterListener(TAG, "*", std::bind(&OvmsVehicle::MetricModified, this, _1));
-  MyCan.RegisterCallback(PollerRegister, std::bind(&OvmsVehicle::IncomingPollRxFrame, this, _1, _2));
+
+#ifdef CONFIG_OVMS_COMP_POLLER
+
+  MyPollers.RegisterFrameRx(TAG, std::bind(&OvmsVehicle::IncomingRxFrame, this, _1));
+#else
+
+  m_vqueue = xQueueCreate(CONFIG_OVMS_VEHICLE_CAN_RX_QUEUE_SIZE,sizeof(CAN_frame_t));
+  xTaskCreatePinnedToCore(OvmsVehicleTask, "OVMS Vehicle Poll",
+      CONFIG_OVMS_VEHICLE_RXTASK_STACK, (void*)this, 10, &m_vtask, CORE(1));
+  MyCan.RegisterListener(m_vqueue);
+#endif
   }
 
 OvmsVehicle::~OvmsVehicle()
@@ -424,6 +432,12 @@ OvmsVehicle::~OvmsVehicle()
     delete [] m_bms_talerts;
     m_bms_talerts = NULL;
     }
+#ifndef CONFIG_OVMS_COMP_POLLER
+  vTaskDelete(m_vtask);
+  m_vtask = nullptr;
+  vQueueDelete(m_vqueue);
+  m_vqueue = nullptr;
+#endif
   }
 
 void OvmsVehicle::StartingUp()
@@ -444,6 +458,7 @@ void OvmsVehicle::ShuttingDown()
   MyPollers.ShuttingDownVehicle();
   MyPollers.DeregisterRunFinished(TAG);
   MyPollers.DeregisterPollStateTicker(TAG);
+  MyPollers.DeregisterFrameRx(TAG);
 
   if (m_pollsignal)
     delete m_pollsignal;
@@ -452,10 +467,12 @@ void OvmsVehicle::ShuttingDown()
   if (m_can2) m_can2->SetPowerMode(Off);
   if (m_can3) m_can3->SetPowerMode(Off);
   if (m_can4) m_can4->SetPowerMode(Off);
+
+  MyCan.DeregisterListener(m_vqueue);
 #endif
   MyEvents.DeregisterEvent(TAG);
   MyMetrics.DeregisterListener(TAG);
-  MyCan.DeregisterCallback(PollerRegister);
+  MyCan.DeregisterCallback(TAG);
   }
 
 const char* OvmsVehicle::VehicleShortName()
@@ -2416,15 +2433,34 @@ void OvmsVehicle::IncomingPollTxCallback(const OvmsPoller::poll_job_t &job, bool
   {
   }
 
-/**
- * IncomingPollerRxFrame: the Poller's Rx Frame callback.
- */
-void IncomingPollerRxFrame(const CAN_frame_t *frame, bool success)
+#endif
+
+#ifdef CONFIG_OVMS_COMP_POLLER
+void OvmsVehicle::IncomingRxFrame(const CAN_frame_t &frame)
   {
+  SendIncomingFrame(&frame);
+  }
+#else
+void OvmsVehicle::OvmsVehicleTask(void *pvParameters)
+  {
+  OvmsVehicle *me = (OvmsVehicle*)pvParameters;
+  me->VehicleTask();
+  }
+
+void OvmsVehicle::VehicleTask()
+  {
+
+  CAN_frame_t entry;
+  while (!m_is_shutdown)
+    {
+    if (xQueueReceive(m_vqueue, &entry, (portTickType)portMAX_DELAY)!=pdTRUE)
+      continue;
+    SendIncomingFrame(&entry);
+    }
   }
 #endif
 
-void OvmsVehicle::IncomingPollRxFrame(const CAN_frame_t *frame, bool success)
+void OvmsVehicle::SendIncomingFrame(const CAN_frame_t *frame)
   {
   if (!m_ready)
     return;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -554,8 +554,15 @@ class OvmsVehicle : public InternalRamAllocated
     uint8_t           m_poll_state;           // Current poll state
     void PollRequest(canbus* bus, const std::string &name, const std::shared_ptr<OvmsPoller::PollSeriesEntry> &series);
     void RemovePollRequest(canbus* bus, const std::string &name);
+    void IncomingRxFrame(const CAN_frame_t &frame);
+#else
+    // These are required in lieu of using the OvmsPoller queue.
+    static void OvmsVehicleTask(void *pvParameters);
+    void VehicleTask();
+    QueueHandle_t m_vqueue;
+    TaskHandle_t  m_vtask;
 #endif
-    void IncomingPollRxFrame(const CAN_frame_t *frame, bool success);
+    void SendIncomingFrame(const CAN_frame_t *frame);
 
   // BMS helpers
   protected:

--- a/vehicle/OVMS.V3/main/Kconfig
+++ b/vehicle/OVMS.V3/main/Kconfig
@@ -601,6 +601,23 @@ config OVMS_VEHICLE_BYD_ATTO3
     help
         Enable support for BYD Atto 3
 
+config OVMS_VEHICLE_RXTASK_STACK
+    int "Stack size for ISOTP Poller RX task"
+    default 6144
+    depends on OVMS
+    help
+        Stack size for the ISOTP Poller CAN RX task ("Vrx Task").
+        The RX task triggers events and metrics updates so needs to be
+        able to process the attached event/metrics listeners.
+        Standard stack usage of this task is currently around 1400 bytes.
+
+config OVMS_VEHICLE_CAN_RX_QUEUE_SIZE
+    int "Poller CAN queue size"
+    default 40
+    depends on OVMS
+    help
+        The size of the CAN bus RX queue (at the ISOTP Poller component).
+
 endmenu # Vehicle Support
 
 
@@ -847,23 +864,6 @@ menuconfig OVMS_COMP_POLLER
         The ISOTP Poller framework provides a client API for ISOTP/VWTP
         protocol address polling.
         It provides some simple shell commands for status.
-
-config OVMS_VEHICLE_RXTASK_STACK
-    int "Stack size for ISOTP Poller RX task"
-    default 6144
-    depends on OVMS_COMP_POLLER
-    help
-        Stack size for the ISOTP Poller CAN RX task ("Vrx Task").
-        The RX task triggers events and metrics updates so needs to be
-        able to process the attached event/metrics listeners.
-        Standard stack usage of this task is currently around 1400 bytes.
-
-config OVMS_VEHICLE_CAN_RX_QUEUE_SIZE
-    int "Poller CAN queue size"
-    default 40
-    depends on OVMS_COMP_POLLER
-    help
-        The size of the CAN bus RX queue (at the ISOTP Poller component).
 
 config OVMS_COMP_PLUGINS
     bool "Include support for PLUGINS"


### PR DESCRIPTION
Makes sure that the Frame RX functions are either being called fromthe Poller task or from a separate vehicle task if there is no poller