### PR TITLE
NL: Avoid flipflop of 12v charging metric

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1796,7 +1796,7 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
   HandleCharging();
   HandleChargeEstimation();
   HandleExporting();
-  if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 13)
+  if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
     {
     StandardMetrics.ms_v_env_charging12v->SetValue(true);  
     }


### PR DESCRIPTION
Float charging can be as low as 12.9V and create nuisance logging going between 12.9 and 13V