### PR TITLE
Poller reduce logging noise

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -6,7 +6,7 @@ Open Vehicle Monitor System v3 - Change log
     poller status
     poller pause
     poller resume
-    poller trace on|off                 -- Control verbose logging
+    poller trace on|txrx|all|off       -- Control verbose logging
 - Duktape support for Metric Age / Stale
   New Duktape methods
     OvmsMetrics.IsStale

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -6,7 +6,7 @@ Open Vehicle Monitor System v3 - Change log
     poller status
     poller pause
     poller resume
-    poller trace on|txrx|all|off       -- Control verbose logging
+    poller trace on|txrx|all|off|status-- Control verbose logging
 - Duktape support for Metric Age / Stale
   New Duktape methods
     OvmsMetrics.IsStale

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -1447,7 +1447,7 @@ void OvmsPollers::Queue_PollerFrame(const CAN_frame_t &frame, bool success, bool
   if (xQueueSend(m_pollqueue, &entry, 0) != pdPASS)
     {
     volatile uint32_t &count = m_overflow_count[istx ? 1 : 0];
-    Atomic_Increment(count);
+    Atomic_Increment(count, 1U);
     }
   }
 

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -793,6 +793,7 @@ OvmsPollers::OvmsPollers()
   cmd_trace->RegisterCommand("txrx","Turn verbose logging ON for txrx queuing",vehicle_poller_trace);
   cmd_trace->RegisterCommand("all","Turn verbose logging ON",vehicle_poller_trace);
   cmd_trace->RegisterCommand("off","Turn verbose logging OFF",vehicle_poller_trace);
+  cmd_trace->RegisterCommand("status","Show status for poller loop logging",vehicle_poller_trace);
   }
 
 OvmsPollers::~OvmsPollers()
@@ -1573,15 +1574,19 @@ void OvmsPollers::vehicle_pause_off(int verbosity, OvmsWriter* writer, OvmsComma
 void OvmsPollers::vehicle_poller_trace(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
   if (strcmp(cmd->GetName(), "on") == 0)
-    MyPollers.m_trace = trace_Poller;
+    MyPollers.m_trace |= trace_Poller;
   else if (strcmp(cmd->GetName(), "txrx") == 0)
-    MyPollers.m_trace = trace_TXRX;
+    MyPollers.m_trace |= trace_TXRX;
   else if (strcmp(cmd->GetName(), "all") == 0)
-    MyPollers.m_trace = trace_All;
+    MyPollers.m_trace |= trace_All;
   else if (strcmp(cmd->GetName(), "off") == 0)
-    MyPollers.m_trace = trace_Off;
+    MyPollers.m_trace &= ~trace_All;
+  //"status" falls through here.
 
-  writer->printf("Vehicle OBD poller tracing is now %s\n", cmd->GetName());
+  writer->printf("Vehicle OBD poller tracing: %s%s%s\n",
+      (MyPollers.m_trace & trace_Poller) ? "+poll" : "",
+      (MyPollers.m_trace & trace_TXRX) ? "+txrx" : "",
+      (MyPollers.m_trace & trace_All) ? "" : "off");
   }
 
 static const char *PollResStr( OvmsPoller::OvmsNextPollResult res)

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -50,9 +50,8 @@ using namespace std::placeholders;
 
 OvmsPollers MyPollers __attribute__ ((init_priority (7000)));
 
-// Runtime control for verbose logging:
-#undef ESP_LOGV
-#define ESP_LOGV( tag, format, ... ) if (MyPollers.m_trace) esp_log_write(ESP_LOG_VERBOSE, tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag, ##__VA_ARGS__)
+// Runtime control for logging:
+#define IFTRACE(x) if (MyPollers.m_trace &  OvmsPollers::tracetype_t::trace_##x)
 
 OvmsPoller::OvmsPoller(canbus* can, uint8_t can_number, OvmsPollers *parent,
     const CanFrameCallback &polltxcallback)
@@ -102,12 +101,12 @@ void OvmsPoller::Incoming(CAN_frame_t &frame, bool success)
     {
     if (m_poll.entry.txmoduleid == 0)
       {
-      ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Incoming - dropped (no poll entry)", m_poll.bus_no);
+      IFTRACE(TXRX) ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Incoming - dropped (no poll entry)", m_poll.bus_no);
       return;
       }
     if (!m_poll_wait)
       {
-      ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Incoming - timed out", m_poll.bus_no);
+      IFTRACE(TXRX) ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Incoming - timed out", m_poll.bus_no);
       return;
       }
     uint32_t msgid;
@@ -115,7 +114,7 @@ void OvmsPoller::Incoming(CAN_frame_t &frame, bool success)
       msgid = frame.MsgID << 8 | frame.data.u8[0];
     else
       msgid = frame.MsgID;
-    ESP_LOGV(TAG, "[%" PRIu8 "]Poller: FrameRx(bus=%s, msg=%" PRIx32 " )", m_poll.bus_no, frame.origin == m_poll.bus ? "Self" : "Other", msgid );
+    IFTRACE(TXRX) ESP_LOGV(TAG, "[%" PRIu8 "]Poller: FrameRx(bus=%s, msg=%" PRIx32 " )", m_poll.bus_no, frame.origin == m_poll.bus ? "Self" : "Other", msgid );
     if (msgid >= m_poll.moduleid_low && msgid <= m_poll.moduleid_high)
       {
       PollerISOTPReceive(&frame, msgid);
@@ -290,7 +289,7 @@ void OvmsPoller::PollerNextTick(poller_source_t source)
   {
   // Completed checking all poll entries for the current m_poll.ticker
 
-  ESP_LOGD(TAG, "[%" PRIu8 "]PollerNextTick(%s): cycle complete for ticker=%u", m_poll.bus_no, PollerSource(source), m_poll.ticker);
+  IFTRACE(Poller) ESP_LOGD(TAG, "[%" PRIu8 "]PollerNextTick(%s): cycle complete for ticker=%u", m_poll.bus_no, PollerSource(source), m_poll.ticker);
   m_poll_ticked = false;
 
   if (source == poller_source_t::Primary)
@@ -366,7 +365,7 @@ void OvmsPoller::PollerSend(poller_source_t source)
 
   if (m_poll_wait > 0)
     {
-    ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Waiting %" PRIu8, m_poll.bus_no, m_poll_wait);
+    IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Waiting %" PRIu8, m_poll.bus_no, m_poll_wait);
     return;
     }
 
@@ -374,7 +373,7 @@ void OvmsPoller::PollerSend(poller_source_t source)
     {
     if (!m_poll_run_finished && m_poll_repeat_count > 0)
       {
-      ESP_LOGD(TAG, "Poller finished primary run");
+      IFTRACE(Poller) ESP_LOGD(TAG, "Poller finished primary run");
       m_poll_run_finished = true;
       }
     m_poll_ticked = false;
@@ -392,13 +391,13 @@ void OvmsPoller::PollerSend(poller_source_t source)
   // Check poll bus & list:
   if (!HasPollList())
     {
-    ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Empty", m_poll.bus_no);
+    IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Empty", m_poll.bus_no);
     return;
     }
 
   if (! CanPoll())
     {
-    ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Throttled", m_poll.bus_no);
+    IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Throttled", m_poll.bus_no);
     return;
     }
 
@@ -412,19 +411,19 @@ void OvmsPoller::PollerSend(poller_source_t source)
     ++m_poll_repeat_count;
     if (m_poll_repeat_count > max_poll_repeat)
       {
-      ESP_LOGD(TAG, "[%" PRIu8 "]Poller Retry Exceeded - Finishing", m_poll.bus_no);
+      IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]Poller Retry Exceeded - Finishing", m_poll.bus_no);
       m_poll_run_finished = true;
       res = OvmsNextPollResult::StillAtEnd;
       }
     else
       {
-      ESP_LOGV(TAG, "[%" PRIu8 "]Poller Reset for Repeat (%s)", m_poll.bus_no, OvmsPoller::PollerSource(source));
+      IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]Poller Reset for Repeat (%s)", m_poll.bus_no, OvmsPoller::PollerSource(source));
       m_polls.RestartPoll(OvmsPoller::ResetMode::LoopReset);
       // If this poll is from a ISOTP success, don't overwhelm the ECU,
       // wait until a Secondary tick.
       if (source == poller_source_t::Successful)
         {
-        ESP_LOGV(TAG, "[%" PRIu8 "]Poller Restart: Wait for secondary", m_poll.bus_no);
+        IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]Poller Restart: Wait for secondary", m_poll.bus_no);
         return;
         }
       res = m_polls.NextPollEntry(m_poll.entry, m_poll.bus_no, m_poll.ticker, m_poll_state);
@@ -433,24 +432,24 @@ void OvmsPoller::PollerSend(poller_source_t source)
   switch (res)
     {
     case OvmsNextPollResult::Ignore:
-      ESP_LOGD(TAG, "[%" PRIu8 "]PollerSend: Ignore", m_poll.bus_no);
+      IFTRACE(Poller) ESP_LOGD(TAG, "[%" PRIu8 "]PollerSend: Ignore", m_poll.bus_no);
       break;
     case OvmsNextPollResult::NotReady:
       {
-      ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Poller Not Ready", m_poll.bus_no);
+      IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Poller Not Ready", m_poll.bus_no);
       m_poll_run_finished = true;
       break;
       }
     case OvmsNextPollResult::ReachedEnd:
       {
-      ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Poller Reached End", m_poll.bus_no);
+      IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Poller Reached End", m_poll.bus_no);
       m_poll_run_finished = true;
       break;
       }
     case OvmsNextPollResult::StillAtEnd:
       if (!m_poll_run_finished)
         {
-        ESP_LOGD(TAG, "[%" PRIu8 "Poller Reached End(!)", m_poll.bus_no);
+        IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "Poller Reached End(!)", m_poll.bus_no);
         m_poll_run_finished = true;
         }
       break;
@@ -579,13 +578,13 @@ int OvmsPoller::PollSingleRequest(uint32_t txid, uint32_t rxid,
     m_polls.SetEntry("!v.single", poller, true);
     }
 
-  ESP_LOGV(TAG, "[%" PRIu8 "]Single Request Sending", m_poll.bus_no);
+  IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]Single Request Sending", m_poll.bus_no);
   Queue_PollerSend(poller_source_t::OnceOff);
 
   // wait for response:
-  ESP_LOGV(TAG, "[%" PRIu8 "]Single Request Waiting for response", m_poll.bus_no);
+  IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]Single Request Waiting for response", m_poll.bus_no);
   bool rxok = single_rxdone.Take(pdMS_TO_TICKS(timeout_ms));
-  ESP_LOGV(TAG, "[%" PRIu8 "]PollSingleRequest: Response done ", m_poll.bus_no);
+  IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]PollSingleRequest: Response done ", m_poll.bus_no);
   // Make sure if it is still sticking around that it's not accessing
   // stack objects!
   poller->Finished();
@@ -765,7 +764,7 @@ OvmsPollers::OvmsPollers()
     m_ready(false),
     m_paused(false),
     m_user_paused(false),
-    m_trace(false)
+    m_trace(trace_Off)
   {
   ESP_LOGI(TAG, "Initialising Poller (7000)");
   for (int idx = 0; idx < VEHICLE_MAXBUSSES; ++idx)
@@ -774,6 +773,9 @@ OvmsPollers::OvmsPollers()
     m_canbusses[idx].can = nullptr;
     m_canbusses[idx].from_vehicle = false;
     }
+
+  m_overflow_count[0] = 0;
+  m_overflow_count[1] = 0;
 
   m_poll_txcallback = std::bind(&OvmsPollers::PollerTxCallback, this, _1, _2);
 
@@ -787,7 +789,9 @@ OvmsPollers::OvmsPollers()
   cmd_poller->RegisterCommand("resume","Resume OBD Polling",vehicle_pause_off);
 
   OvmsCommand* cmd_trace = cmd_poller->RegisterCommand("trace","OBD Poller Verbose Logging");
-  cmd_trace->RegisterCommand("on","Turn verbose logging ON",vehicle_poller_trace);
+  cmd_trace->RegisterCommand("on","Turn verbose logging ON for poller loop",vehicle_poller_trace);
+  cmd_trace->RegisterCommand("txrx","Turn verbose logging ON for txrx queuing",vehicle_poller_trace);
+  cmd_trace->RegisterCommand("all","Turn verbose logging ON",vehicle_poller_trace);
   cmd_trace->RegisterCommand("off","Turn verbose logging OFF",vehicle_poller_trace);
   }
 
@@ -1043,6 +1047,17 @@ void OvmsPollers::PollerTask()
     {
     if (xQueueReceive(m_pollqueue, &entry, (portTickType)portMAX_DELAY)!=pdTRUE)
       continue;
+
+    for (int istx = 0; istx < 2; ++istx)
+      {
+      uint32_t ovf_count = m_overflow_count[istx];
+      if (ovf_count > 0)
+        {
+        ESP_LOGI(TAG, "Poller[Frame]: %s Task Queue Overflow Run %" PRIu32, ( istx ? "TX" : "RX"), ovf_count);
+        Atomic_Subtract( m_overflow_count[istx], ovf_count);
+        }
+      }
+
     if ( (entry.entry_type == OvmsPoller::OvmsPollEntryType::Command)
       &&  (entry.entry_Command.cmd == OvmsPoller::OvmsPollCommand::Shutdown))
       {
@@ -1056,7 +1071,7 @@ void OvmsPollers::PollerTask()
       case OvmsPoller::OvmsPollEntryType::FrameRx:
         {
         auto poller = GetPoller(entry.entry_FrameRxTx.frame.origin);
-        ESP_LOGV(TAG, "Pollers: FrameRx(bus=%d)", GetBusNo(entry.entry_FrameRxTx.frame.origin));
+        IFTRACE(Poller) ESP_LOGV(TAG, "Pollers: FrameRx(bus=%d)", GetBusNo(entry.entry_FrameRxTx.frame.origin));
         if (poller)
           poller->Incoming(entry.entry_FrameRxTx.frame, entry.entry_FrameRxTx.success);
         PollerFrameRx(entry.entry_FrameRxTx.frame);
@@ -1065,7 +1080,7 @@ void OvmsPollers::PollerTask()
       case OvmsPoller::OvmsPollEntryType::FrameTx:
         {
         auto poller = GetPoller(entry.entry_FrameRxTx.frame.origin);
-        ESP_LOGV(TAG, "Pollers: FrameTx(bus=%d)", GetBusNo(entry.entry_FrameRxTx.frame.origin));
+        IFTRACE(Poller) ESP_LOGV(TAG, "Pollers: FrameTx(bus=%d)", GetBusNo(entry.entry_FrameRxTx.frame.origin));
         if (poller)
           poller->Outgoing(entry.entry_FrameRxTx.frame, entry.entry_FrameRxTx.success);
         }
@@ -1074,7 +1089,7 @@ void OvmsPollers::PollerTask()
         if (!m_user_paused && !m_paused)
           {
           // Must not lock mutex while calling.
-          ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Send(%s)", entry.entry_Poll.busno, OvmsPoller::PollerSource(entry.entry_Poll.source));
+          IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Send(%s)", entry.entry_Poll.busno, OvmsPoller::PollerSource(entry.entry_Poll.source));
           if (entry.entry_Poll.busno != 0)
             {
             auto bus = GetBus(entry.entry_Poll.busno);
@@ -1256,7 +1271,7 @@ OvmsPoller *OvmsPollers::GetPoller(canbus *can, bool force)
     if (!busno)
       return nullptr;
 
-    ESP_LOGD(TAG, "GetPoller( busno=%" PRIu8 ")", busno);
+    IFTRACE(Poller) ESP_LOGD(TAG, "GetPoller( busno=%" PRIu8 ")", busno);
     auto newpoller =  new OvmsPoller(can, busno, this, m_poll_txcallback);
     newpoller->m_poll_state = m_poll_state;
     newpoller->m_poll_sequence_max = m_poll_sequence_max;
@@ -1287,7 +1302,7 @@ void OvmsPollers::QueuePollerSend(OvmsPoller::poller_source_t src, uint8_t busno
   entry.entry_Poll.source = src;
   entry.entry_Poll.poll_ticker = pollticker;
 
-  ESP_LOGV(TAG, "Pollers: Queue PollerSend(%s, %" PRIu8 ")", OvmsPoller::PollerSource(src), busno);
+  IFTRACE(TXRX) ESP_LOGV(TAG, "Pollers: Queue PollerSend(%s, %" PRIu8 ")", OvmsPoller::PollerSource(src), busno);
   if (xQueueSend(m_pollqueue, &entry, 0) != pdPASS)
     ESP_LOGI(TAG, "Pollers[Send]: Task Queue Overflow");
   }
@@ -1427,9 +1442,12 @@ void OvmsPollers::Queue_PollerFrame(const CAN_frame_t &frame, bool success, bool
   entry.entry_FrameRxTx.frame = frame;
   entry.entry_FrameRxTx.success = success;
 
-  ESP_LOGV(TAG, "Poller: Queue PollerFrame( %s, %s)", (success ? "OK" : "Fail"), ( istx ? "TX" : "RX") );
+  IFTRACE(TXRX) ESP_LOGV(TAG, "Poller: Queue PollerFrame(%s, %s)", (success ? "OK" : "Fail"), ( istx ? "TX" : "RX") );
   if (xQueueSend(m_pollqueue, &entry, 0) != pdPASS)
-    ESP_LOGI(TAG, "Poller[Frame]: Task Queue Overflow");
+    {
+    volatile uint32_t &count = m_overflow_count[istx ? 1 : 0];
+    Atomic_Increment(count);
+    }
   }
 
 void OvmsPollers::PollSetState(uint8_t state, canbus* bus)
@@ -1555,9 +1573,13 @@ void OvmsPollers::vehicle_pause_off(int verbosity, OvmsWriter* writer, OvmsComma
 void OvmsPollers::vehicle_poller_trace(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
   if (strcmp(cmd->GetName(), "on") == 0)
-    MyPollers.m_trace = true;
-  else
-    MyPollers.m_trace = false;
+    MyPollers.m_trace = trace_Poller;
+  else if (strcmp(cmd->GetName(), "txrx") == 0)
+    MyPollers.m_trace = trace_TXRX;
+  else if (strcmp(cmd->GetName(), "all") == 0)
+    MyPollers.m_trace = trace_All;
+  else if (strcmp(cmd->GetName(), "off") == 0)
+    MyPollers.m_trace = trace_Off;
 
   writer->printf("Vehicle OBD poller tracing is now %s\n", cmd->GetName());
   }
@@ -1655,11 +1677,11 @@ void OvmsPoller::PollSeriesList::Remove( poll_series_t *iter)
   if (iternext)
     iternext->prev = iterprev;
 
-  ESP_LOGV(TAG, "Poll List: Removing series %s", iter->name.c_str());
+  IFTRACE(Poller) ESP_LOGV(TAG, "Poll List: Removing series %s", iter->name.c_str());
   if (iter->series != nullptr)
      iter->series->Removing();
   iter->series = nullptr;
-  ESP_LOGV(TAG, "Poll List: Deleting series %s", iter->name.c_str());
+  IFTRACE(Poller) ESP_LOGV(TAG, "Poll List: Deleting series %s", iter->name.c_str());
   delete iter;
   }
 
@@ -1728,13 +1750,13 @@ void OvmsPoller::PollSeriesList::IncomingPacket(const OvmsPoller::poll_job_t& jo
   {
   if ((m_iter != nullptr) && (m_iter->series != nullptr))
     {
-    ESP_LOGD(TAG, "Poll List:[%s] IncomingPacket TYPE:%x PID: %03x LEN: %d REM: %d ", m_iter->name.c_str(), job.type, job.pid, length, job.mlremain);
+    IFTRACE(Poller) ESP_LOGD(TAG, "Poll List:[%s] IncomingPacket TYPE:%x PID: %03x LEN: %d REM: %d ", m_iter->name.c_str(), job.type, job.pid, length, job.mlremain);
 
     m_iter->series->IncomingPacket(job, data, length);
     }
   else
     {
-    ESP_LOGD(TAG, "Poll List:[Discard] IncomingPacket TYPE:%x PID: %03x LEN: %d REM: %d ", job.type, job.pid, length, job.mlremain);
+    IFTRACE(Poller) ESP_LOGD(TAG, "Poll List:[Discard] IncomingPacket TYPE:%x PID: %03x LEN: %d REM: %d ", job.type, job.pid, length, job.mlremain);
     }
   }
 
@@ -1743,12 +1765,12 @@ void OvmsPoller::PollSeriesList::IncomingError(const OvmsPoller::poll_job_t& job
   {
   if ((m_iter != nullptr) && (m_iter->series != nullptr))
     {
-    ESP_LOGD(TAG, "Poll List:[%s] IncomingError TYPE:%x PID: %03x Code: %02X", m_iter->name.c_str(), job.type, job.pid, code);
+    IFTRACE(Poller) ESP_LOGD(TAG, "Poll List:[%s] IncomingError TYPE:%x PID: %03x Code: %02X", m_iter->name.c_str(), job.type, job.pid, code);
     m_iter->series->IncomingError(job, code);
     }
   else
     {
-    ESP_LOGD(TAG, "Poll List:[Discard] IncomingError TYPE:%x PID: %03x Code: %02X", job.type, job.pid, code);
+    IFTRACE(Poller) ESP_LOGD(TAG, "Poll List:[Discard] IncomingError TYPE:%x PID: %03x Code: %02X", job.type, job.pid, code);
     }
   }
 
@@ -1757,12 +1779,12 @@ void OvmsPoller::PollSeriesList::IncomingTxReply(const OvmsPoller::poll_job_t& j
   {
   if ((m_iter != nullptr) && (m_iter->series != nullptr))
     {
-    ESP_LOGD(TAG, "Poll List:[%s] IncomingTXReply TYPE:%x PID: %03x Success: %s", m_iter->name.c_str(), job.type, job.pid, success ? "true" : "false");
+    IFTRACE(TXRX) ESP_LOGV(TAG, "Poll List:[%s] IncomingTXReply TYPE:%x PID: %03x Success: %s", m_iter->name.c_str(), job.type, job.pid, success ? "true" : "false");
     m_iter->series->IncomingTxReply(job, success);
     }
   else
     {
-    ESP_LOGD(TAG, "Poll List:[Discard] IncomingTXReply TYPE:%x PID: %03x Success %s", job.type, job.pid, success ? "true" : "false");
+    IFTRACE(TXRX) ESP_LOGV(TAG, "Poll List:[Discard] IncomingTXReply TYPE:%x PID: %03x Success %s", job.type, job.pid, success ? "true" : "false");
     }
 
   }
@@ -1771,12 +1793,12 @@ OvmsPoller::OvmsNextPollResult OvmsPoller::PollSeriesList::NextPollEntry(poll_pi
   {
   if (!m_first)
     {
-    ESP_LOGV(TAG, "PollSeriesList::NextPollEntry - No List Set");
+    IFTRACE(Poller) ESP_LOGV(TAG, "PollSeriesList::NextPollEntry - No List Set");
     return OvmsPoller::OvmsNextPollResult::StillAtEnd;
     }
   if (!m_iter)
     {
-    ESP_LOGV(TAG, "PollSeriesList::NextPollEntry - Not Started");
+    IFTRACE(Poller) ESP_LOGV(TAG, "PollSeriesList::NextPollEntry - Not Started");
     return OvmsPoller::OvmsNextPollResult::StillAtEnd;
     }
 
@@ -1790,25 +1812,25 @@ OvmsPoller::OvmsNextPollResult OvmsPoller::PollSeriesList::NextPollEntry(poll_pi
       ++skipped;
       }
     if (skipped)
-      ESP_LOGV(TAG, "PollSeriesList::NextPollEntry Skipped %d", skipped);
+      {
+      IFTRACE(Poller) ESP_LOGV(TAG, "PollSeriesList::NextPollEntry Skipped %d", skipped);
+      }
 
     if (m_iter == nullptr)
       return OvmsPoller::OvmsNextPollResult::ReachedEnd;
     res = m_iter->series->NextPollEntry(entry, mybus, pollticker, pollstate);
 
-    ESP_LOGD(TAG, "PollSeriesList::NextPollEntry[%s]: %s", m_iter->name.c_str(), PollResStr(res));
+    IFTRACE(Poller) ESP_LOGV(TAG, "PollSeriesList::NextPollEntry[%s]: %s", m_iter->name.c_str(), PollResStr(res));
 
     switch (res)
       {
       case OvmsPoller::OvmsNextPollResult::NotReady:
         {
-        ESP_LOGV(TAG, "Poll Not Ready: '%s'", m_iter->name.c_str());
         m_iter = m_iter->next;
         break;
         }
       case OvmsPoller::OvmsNextPollResult::StillAtEnd:
         {
-        ESP_LOGV(TAG, "Poll Still at end: '%s'", m_iter->name.c_str());
         if (m_iter->is_blocking)
           {
           m_iter = nullptr;
@@ -1911,7 +1933,7 @@ void OvmsPoller::StandardPollSeries::SetParentPoller(OvmsPoller *poller)
 // Set the PID List in use.
 void OvmsPoller::StandardPollSeries::PollSetPidList(uint8_t defaultbus, const poll_pid_t* plist)
   {
-  ESP_LOGV(TAG, "Standard Poll Series: PID List set");
+  IFTRACE(Poller) ESP_LOGV(TAG, "Standard Poll Series: PID List set");
   m_poll_plcur = nullptr;
   m_poll_plist = plist;
   m_defaultbus = defaultbus;
@@ -1921,7 +1943,7 @@ void OvmsPoller::StandardPollSeries::ResetList(OvmsPoller::ResetMode mode)
   {
   if (mode == OvmsPoller::ResetMode::PollReset)
     {
-    ESP_LOGV(TAG, "Standard Poll Series: List reset");
+    IFTRACE(Poller) ESP_LOGV(TAG, "Standard Poll Series: List reset");
     m_poll_plcur = NULL;
     }
   }
@@ -1960,7 +1982,7 @@ OvmsPoller::OvmsNextPollResult OvmsPoller::StandardPollSeries::NextPollEntry(pol
       if (( polltime > 0) && ((pollticker % polltime) == 0))
         {
         entry = *m_poll_plcur;
-        ESP_LOGD(TAG, "Found Poll Entry for Standard Poll");
+        IFTRACE(Poller) ESP_LOGD(TAG, "Found Poll Entry for Standard Poll");
         return OvmsNextPollResult::FoundEntry;
         }
       }
@@ -2169,7 +2191,7 @@ void OvmsPoller::OnceOffPollBase::ResetList(OvmsPoller::ResetMode mode)
   switch(m_sent)
     {
     case status_t::Init:
-      ESP_LOGD(TAG, "Once Off Poll: List reset to start");
+      ESP_LOGV(TAG, "Once Off Poll: List reset to start");
       break;
     case status_t::Retry:
       if (mode == OvmsPoller::ResetMode::PollReset)
@@ -2179,7 +2201,7 @@ void OvmsPoller::OnceOffPollBase::ResetList(OvmsPoller::ResetMode mode)
           m_sent = status_t::Stopping;
           return;
           }
-        ESP_LOGD(TAG, "Once Off Poll: Reset for retry");
+        IFTRACE(Poller) ESP_LOGD(TAG, "Once Off Poll: Reset for retry");
         --m_retry_fail;
         m_sent = status_t::RetryInit;
         }
@@ -2208,7 +2230,7 @@ OvmsPoller::OvmsNextPollResult OvmsPoller::OnceOffPollBase::NextPollEntry(poll_p
       else
         {
         m_sent = status_t::Retry;
-        ESP_LOGD(TAG, "Once Off Poll: Retries left %d", m_retry_fail);
+        IFTRACE(Poller) ESP_LOGD(TAG, "Once Off Poll: Retries left %d", m_retry_fail);
         }
       return OvmsPoller::OvmsNextPollResult::ReachedEnd;
       }

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -394,7 +394,7 @@ void OvmsPoller::PollerSend(poller_source_t source)
 
   if (m_poll.ticker == init_ticker)
     {
-    ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Wait for next primary poll", m_poll.bus_no );
+    IFTRACE(Poller) ESP_LOGV(TAG, "[%" PRIu8 "]PollerSend: Wait for next primary poll", m_poll.bus_no );
     return;
     }
 

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -679,7 +679,9 @@ class OvmsPollers : public InternalRamAllocated {
     bool              m_ready;
     bool              m_paused;
     bool              m_user_paused;
-    bool              m_trace;                // true = enable verbose logging
+    typedef enum {trace_Off = 0x00, trace_Poller = 0x1, trace_TXRX = 0x2, trace_All= 0x3} tracetype_t;
+    tracetype_t       m_trace;                // true = enable verbose logging
+    uint32_t          m_overflow_count[2];    // Keep track of overflows.
 
     void PollerTxCallback(const CAN_frame_t* frame, bool success);
     void PollerRxCallback(const CAN_frame_t* frame, bool success);

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -680,7 +680,7 @@ class OvmsPollers : public InternalRamAllocated {
     bool              m_paused;
     bool              m_user_paused;
     typedef enum {trace_Off = 0x00, trace_Poller = 0x1, trace_TXRX = 0x2, trace_All= 0x3} tracetype_t;
-    tracetype_t       m_trace;                // true = enable verbose logging
+    uint8_t           m_trace;                // Current Trace flags.
     uint32_t          m_overflow_count[2];    // Keep track of overflows.
 
     void PollerTxCallback(const CAN_frame_t* frame, bool success);

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -720,5 +720,23 @@ class ovms_callback_register_t
     xTaskResumeAll();
     return tmp;
     }
+  template<typename T>
+  T Atomic_Increment( volatile T &variable)
+    {
+    vTaskSuspendAll();
+    T tmp = ++variable;
+    xTaskResumeAll();
+    return tmp;
+    }
+
+  template<typename T>
+  T Atomic_Subtract( volatile T &variable, T amt)
+    {
+    vTaskSuspendAll();
+    variable -= amt;
+    T tmp = variable;
+    xTaskResumeAll();
+    return tmp;
+    }
 
 #endif // __OVMS_UTILS_H__

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -707,36 +707,40 @@ class ovms_callback_register_t
       }
   };
 
+
   /** Get the variable and null it in an atomic way.
    * Should probably be used sparingly.
    */
   template<typename T>
+  T Atomic_Swap( volatile T &variable, T newVal)
+    {
+    return __atomic_exchange_n(&variable, newVal, __ATOMIC_SEQ_CST);
+    }
+  /** Get the variable and null it in an atomic way.
+   * Should probably be used sparingly.
+   * @return true if successful.
+   */
+  template<typename T>
   T Atomic_GetAndNull( volatile T &variable)
     {
-    T tmp;
-    vTaskSuspendAll();
-    tmp = variable;
-    variable = nullptr;
-    xTaskResumeAll();
-    return tmp;
+    return Atomic_Swap<T>(variable, nullptr);
+    }
+
+  template<typename T>
+  T Atomic_Get( volatile const T &variable)
+    {
+    return variable;
     }
   template<typename T>
-  T Atomic_Increment( volatile T &variable)
+  T Atomic_Increment( volatile T &variable, T amt)
     {
-    vTaskSuspendAll();
-    T tmp = ++variable;
-    xTaskResumeAll();
-    return tmp;
+    return __atomic_fetch_add(&variable, amt, __ATOMIC_SEQ_CST);
     }
 
   template<typename T>
   T Atomic_Subtract( volatile T &variable, T amt)
     {
-    vTaskSuspendAll();
-    variable -= amt;
-    T tmp = variable;
-    xTaskResumeAll();
-    return tmp;
+    return __atomic_fetch_sub(&variable, amt, __ATOMIC_SEQ_CST);
     }
 
 #endif // __OVMS_UTILS_H__


### PR DESCRIPTION
Splits the logging for the Poller into logs that would happen in the RX/TX Tasks (which can cause all sorts of issues)
and those that would happen in the poller task (which can be still problematic if response needs to be really quick).