### PR TITLE
Ioniq5 shortname

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -64,6 +64,10 @@
 #include <sstream>
 
 const char *OvmsHyundaiIoniqEv::TAG = "v-ioniq5";
+const char *OvmsHyundaiIoniqEv::FULL_NAME = "Hyundai Ioniq 5 EV/KIA EV6";
+const char *OvmsHyundaiIoniqEv::SHORT_NAME = "Ioniq 5/EV 6";
+const char *OvmsHyundaiIoniqEv::VEHICLE_TYPE = "I5";
+
 
 #ifdef bind
 #undef bind
@@ -692,6 +696,15 @@ OvmsHyundaiIoniqEv::OvmsHyundaiIoniqEv()
 }
 
 static const char *ECU_POLL = "!v.xiq.ecu";
+
+const char* OvmsHyundaiIoniqEv::VehicleShortName()
+  {
+  return SHORT_NAME;
+  }
+const char* OvmsHyundaiIoniqEv::VehicleType()
+  {
+  return VEHICLE_TYPE;
+  }
 
 void OvmsHyundaiIoniqEv::ECUStatusChange(bool run)
 {
@@ -1888,7 +1901,7 @@ public:
 
 OvmsHyundaiIoniqEvInit::OvmsHyundaiIoniqEvInit()
 {
-  ESP_LOGI(OvmsHyundaiIoniqEv::TAG, "Registering Vehicle: Hyundai Ioniq 5 EV (9000)");
+  ESP_LOGI(OvmsHyundaiIoniqEv::TAG, "Registering Vehicle: %s (9000)", OvmsHyundaiIoniqEv::FULL_NAME);
 
-  MyVehicleFactory.RegisterVehicle<OvmsHyundaiIoniqEv>("I5", "Hyundai Ioniq 5 EV/KIA EV6");
+  MyVehicleFactory.RegisterVehicle<OvmsHyundaiIoniqEv>(OvmsHyundaiIoniqEv::VEHICLE_TYPE, OvmsHyundaiIoniqEv::FULL_NAME);
 }

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
@@ -168,6 +168,11 @@ public:
   OvmsHyundaiIoniqEv();
   ~OvmsHyundaiIoniqEv();
   static const char *TAG;
+  static const char *SHORT_NAME;
+  static const char *FULL_NAME;
+  static const char *VEHICLE_TYPE;
+  const char* VehicleShortName() override;
+  const char* VehicleType() override;
 public:
   void IncomingFrameCan1(CAN_frame_t *p_frame) override;
   void Ticker1(uint32_t ticker) override;


### PR DESCRIPTION
Adds Ioniq 5 shortname - the menu name was getting a little long after the adding of EV6