### PR TITLE
Poller timer improvements

### DIFF
--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -795,6 +795,8 @@ OvmsPollers::OvmsPollers()
   MyEvents.RegisterEvent(TAG,"system.shuttingdown",std::bind(&OvmsPollers::EventSystemShuttingDown, this, _1, _2));
   MyEvents.RegisterEvent(TAG, "config.changed", std::bind(&OvmsPollers::ConfigChanged, this, _1, _2));
   MyEvents.RegisterEvent(TAG, "config.mounted", std::bind(&OvmsPollers::ConfigChanged, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "vehicle.charge.start", std::bind(&OvmsPollers::VehicleChargeStart, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "vehicle.on", std::bind(&OvmsPollers::VehicleOn, this, _1, _2));
   MyEvents.RegisterEvent(TAG, "vehicle.charge.stop", std::bind(&OvmsPollers::VehicleChargeStop, this, _1, _2));
   MyEvents.RegisterEvent(TAG, "vehicle.off", std::bind(&OvmsPollers::VehicleOff, this, _1, _2));
 
@@ -959,6 +961,16 @@ void OvmsPollers::EventSystemShuttingDown(std::string event, void* data)
   ShuttingDown(true);
   }
 
+void OvmsPollers::VehicleOn(std::string event, void* data)
+  {
+  IFTRACE(Times)
+    MyPollers.PollerTimesReset();
+  }
+void OvmsPollers::VehicleChargeStart(std::string event, void* data)
+  {
+  IFTRACE(Times)
+    MyPollers.PollerTimesReset();
+  }
 void OvmsPollers::VehicleOff(std::string event, void* data)
   {
   NotifyPollerTrace();

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -800,6 +800,8 @@ class OvmsPollers : public InternalRamAllocated {
     void ConfigChanged(std::string event, void* data);
     void LoadPollerTimerConfig();
 
+    void VehicleOn(std::string event, void* data);
+    void VehicleChargeStart(std::string event, void* data);
     void VehicleOff(std::string event, void* data);
     void VehicleChargeStop(std::string event, void* data);
 

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -702,7 +702,7 @@ class OvmsPollers : public InternalRamAllocated {
     void PollerStatus(int verbosity, OvmsWriter* writer);
     void SetUserPauseStatus(bool paused, int verbosity, OvmsWriter* writer);
   public:
-    void PollerTimesTrace( OvmsWriter* writer);
+    bool PollerTimesTrace( OvmsWriter* writer, bool is_notify = false);
     bool IsTracingTimes() { return (m_trace & trace_Times) != 0; }
     typedef std::function<void(canbus*, void *)> PollCallback;
     typedef std::function<void(const CAN_frame_t &)> FrameCallback;


### PR DESCRIPTION
- Improve averaging algorithm to include better start-up (but still fast)
- Shorten message and split if necessary.
- Reset averages on vehicle.on and charging.start