### PR TITLE
Console - Improve completion support for paths

### DIFF
--- a/vehicle/OVMS.V3/components/microrl/microrl.h
+++ b/vehicle/OVMS.V3/components/microrl/microrl.h
@@ -7,9 +7,6 @@ extern "C" {
 
 #include "microrl_config.h"
 
-#define true  1
-#define false 0
-
  /* define the Key codes */
 #define KEY_NUL 0 /**< ^@ Null character */
 #define KEY_SOH 1 /**< ^A Start of heading, = console interrupt */
@@ -97,7 +94,7 @@ struct microrl {
 	quoted_token_t quotes[_QUOTED_TOKEN_NMB];// pointers to quoted tokens
 #endif
 	int (*execute) (microrl_t* pThis, int argc, const char * const * argv );            // ptr to 'execute' callback
-	char ** (*get_completion) (microrl_t* pThis, int argc, const char * const * argv ); // ptr to 'completion' callback
+	char ** (*get_completion) (microrl_t* pThis, int argc, const char * const * argv, int *complete_common, int *finished ); // ptr to 'completion' callback
 	void (*print) (microrl_t* pThis, const char *);                                     // ptr to 'print' callback
 	void (*error_print) (microrl_t* pThis, const char *);                               // ptr to 'print' callback for error msg
 #ifdef _USE_CTLR_C
@@ -113,13 +110,16 @@ void microrl_init (microrl_t * pThis, void (*print)(microrl_t* pThis, const char
 // echo mode will enabled after user press Enter.
 void microrl_set_echo (int);
 
-// set pointer to callback complition func, that called when user press 'Tab'
+// set pointer to callback completion func, that called when user press 'Tab'
 // callback func description:
-//   param: argc - argument count, argv - pointer array to token string
-//   must return NULL-terminated string, contain complite variant splitted by 'Whitespace'
-//   If complite token found, it's must contain only one token to be complitted
-//   Empty string if complite not found, and multiple string if there are some token
-void microrl_set_complete_callback (microrl_t * pThis, char ** (*get_completion)(microrl_t*, int, const char* const*));
+//   param: argc - argument count
+//   param: argv - pointer array to token strings
+//   param: complete_common - can be optionally populated to the length of the
+//          common portion of the strings.
+//   param: finished - should be set to 0 if the signal completion element is not
+//          considered finished completing.
+//   return: Null terminated Array of NULL-terminated strings contain the completion tokens.
+void microrl_set_complete_callback (microrl_t * pThis, char ** (*get_completion_ext) (microrl_t* pThis, int argc, const char * const * argv, int *complete_common, int *finished ));
 
 // pointer to callback func, that called when user press 'Enter'
 // execute func param: argc - argument count, argv - pointer array to token string

--- a/vehicle/OVMS.V3/main/ovms_command.cpp
+++ b/vehicle/OVMS.V3/main/ovms_command.cpp
@@ -365,7 +365,7 @@ bool OvmsCommand::UnregisterCommand(const char* name)
     }
   }
 
-char ** OvmsCommand::Complete(OvmsWriter* writer, int argc, const char * const * argv)
+char ** OvmsCommand::Complete(OvmsWriter* writer, int argc, const char * const * argv, int &common_len, bool &finished)
   {
   writer->SetCompletion(0, NULL);       // Start with no completion tokens
   if (m_validate)
@@ -374,7 +374,7 @@ char ** OvmsCommand::Complete(OvmsWriter* writer, int argc, const char * const *
     if (argc > 0)
       used = m_validate(writer, this, argc > m_max ? m_max : argc, argv, true);
     if (used < 0 || used == argc)
-      return writer->GetCompletions();
+      return writer->GetCompletions(common_len, finished);
     argc -= used;
     argv += used;
     }
@@ -387,7 +387,7 @@ char ** OvmsCommand::Complete(OvmsWriter* writer, int argc, const char * const *
     {
     return writer->SetCompletion(0, NULL);
     }
-  return cmd->Complete(writer, argc-1, ++argv);
+  return cmd->Complete(writer, argc-1, ++argv, common_len, finished);
   }
 
 void OvmsCommand::Execute(int verbosity, OvmsWriter* writer, int argc, const char * const * argv)
@@ -998,9 +998,9 @@ int OvmsCommandApp::HexDump(const char* tag, const char* prefix, const char* dat
   return length;
   }
 
-char ** OvmsCommandApp::Complete(OvmsWriter* writer, int argc, const char * const * argv)
+char ** OvmsCommandApp::Complete(OvmsWriter* writer, int argc, const char * const * argv, int &common_len, bool &finished)
   {
-  return m_root.Complete(writer, argc, argv);
+  return m_root.Complete(writer, argc, argv, common_len, finished);
   }
 
 void OvmsCommandApp::Execute(int verbosity, OvmsWriter* writer, int argc, const char * const * argv)
@@ -1611,4 +1611,67 @@ bool OvmsCommandTask::Terminator(OvmsWriter* writer, void* userdata, char ch)
   if (ch == 3) // Ctrl-C
     ((OvmsCommandTask*) userdata)->m_state = OCS_StopRequested;
   return true;
+  }
+
+bool option_completer_t::check_param(char param, bool has_more)
+  {
+
+  bool found = false;
+  for (int idx = 0; idx < (m_argc-1); ++idx)
+    {
+    const char *cur = m_argv[idx];
+    if (cur[0] == '-' && cur[1] == param)
+      {
+      found = true;
+      break;
+      }
+    }
+  const char *last_arg = m_argv[m_argc-1];
+  if (last_arg[0] == '-')
+    {
+    char ch = last_arg[1];
+    if (!m_complete)
+      {
+      if (ch == param)
+        {
+        m_valid = true;
+        m_found_param = true;
+        return true;
+        }
+      }
+    else if (!ch)
+      {
+      if (!found)
+        {
+        char complete[3];
+        complete[0] = '-';
+        complete[1] = param;
+        complete[2] = '\0';
+        m_writer->SetCompletion(m_complete_idx++, complete, !has_more);
+        m_found_param = true;
+        }
+      }
+    else if (ch == param)
+      {
+      m_writer->SetCompletion(m_complete_idx++, last_arg, false);
+      m_found_param = true;
+      found = true;
+      }
+    }
+
+  return found;
+  }
+
+int option_completer_t::param_index()
+  {
+  if (m_argv[m_argc-1][0] == '-')
+    return -1; // the current argc is a '-' option parameter
+
+  int final_posn = m_argc-1;
+  for (int idx = 0; idx < (m_argc-1); ++idx)
+    {
+    if (m_argv[idx][0] == '-')
+      --final_posn;
+    }
+  return final_posn;
   }

--- a/vehicle/OVMS.V3/main/ovms_console.h
+++ b/vehicle/OVMS.V3/main/ovms_console.h
@@ -81,8 +81,8 @@ class OvmsConsole : public OvmsShell
 
   public:
     void Initialize(const char* console);
-    char** SetCompletion(int index, const char* token);
-    char** GetCompletions() { return m_completions; }
+    char** SetCompletion(int index, const char* token, bool isfinal) override;
+    char** GetCompletions(int &common_len, bool &finished ) override;
     void Log(LogBuffers* message);
     void Poll(portTickType ticks, QueueHandle_t queue = NULL);
 
@@ -96,7 +96,9 @@ class OvmsConsole : public OvmsShell
   protected:
     bool m_ready;
     char *m_completions[COMPLETION_MAX_TOKENS+2];
+    int m_common;
     char m_space[COMPLETION_MAX_TOKENS+2][TOKEN_MAX_LENGTH];
+    bool m_final;
     QueueHandle_t m_queue;
     QueueHandle_t m_deferred;
     int m_discarded;

--- a/vehicle/OVMS.V3/main/ovms_vfs.cpp
+++ b/vehicle/OVMS.V3/main/ovms_vfs.cpp
@@ -790,7 +790,7 @@ bool vfs_expand(OvmsWriter* writer, const char *token, bool complete, bool dirok
 #ifdef LOG_VFS_EXPAND
         ESP_LOGD(TAGX, "complete add: [%d] %s", index, name.c_str());
 #endif
-        writer->SetCompletion(index++, name.c_str());
+        writer->SetCompletion(index++, name.c_str(), !it->is_dir);
         }
       }
     if (index > 0)
@@ -808,39 +808,16 @@ int vfs_file_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const char
 
 static int vfs_mkdir_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv, bool complete)
   {
-  if (argc == 1)
-    {
-    if (argv[0][0] == '-')
-      {
-      if (complete)
-        {
-        std::string name("-p");
-        if (strlen(argv[0]) == 1)
-          {
-          if (complete)
-            {
-            writer->SetCompletion(0, NULL);
-            writer->SetCompletion(0, name.c_str());
-            return argc;
-            }
-          }
-        else
-          {
-          if ((name == argv[0]))
-            {
-            if (complete)
-              {
-              writer->SetCompletion(0,NULL);
-              writer->SetCompletion(0, name.c_str());
-              }
-            return argc;
-            }
-          }
-        }
-      return -1;
-      }
-    }
-  if (argc > 0)
+  if (complete)
+    writer->SetCompletion(0,NULL);
+  option_completer_t comp(writer, complete, argc, argv);
+
+  comp.check_param('p');
+
+  if (comp.do_return())
+    return comp.return_val();
+
+  if (comp.param_index() == 0)
     return vfs_expand(writer, argv[argc-1], complete, true, false) ? argc : -1;
   return -1;
   }
@@ -852,10 +829,19 @@ static int vfs_ls_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const
   return -1;
   }
 
-static int vfs_dir_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv, bool complete)
+static int vfs_rmdir_validate(OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv, bool complete)
   {
-  if (argc == 1)
-    return vfs_expand(writer, argv[0], complete, true, false) ? 1 : -1;
+  if (complete)
+    writer->SetCompletion(0,NULL);
+  option_completer_t comp(writer, complete, argc, argv);
+
+  comp.check_param('r');
+
+  if (comp.do_return())
+    return comp.return_val();
+
+  if (comp.param_index() == 0)
+    return vfs_expand(writer, argv[argc-1], complete, true, false) ? argc : -1;
   return -1;
   }
 
@@ -903,7 +889,7 @@ VfsInit::VfsInit()
   cmd_vfs->RegisterCommand("mkdir","VFS Create a directory",vfs_mkdir, "[-p] <path>\n"
     "-p = create full path including missing parents", 1, 2, true, vfs_mkdir_validate);
   cmd_vfs->RegisterCommand("rmdir","VFS Delete a directory",vfs_rmdir, "[-r] <path>\n"
-    "-r = delete recursively including all files and subdirectories", 1, 2, true, vfs_dir_validate);
+    "-r = delete recursively including all files and subdirectories", 1, 2, true, vfs_rmdir_validate);
   cmd_vfs->RegisterCommand("rm","VFS Delete a file",vfs_rm, "<file>", 1, 1, true, vfs_file_validate);
   cmd_vfs->RegisterCommand("mv","VFS Rename a file",vfs_mv, "<source> <target>", 2, 2, true, vfs_cp_mv_validate);
   cmd_vfs->RegisterCommand("cp","VFS Copy a file",vfs_cp, "<source> <target>", 2, 2, true, vfs_cp_mv_validate);


### PR DESCRIPTION
- Gets the completion length via the callback to count for dropped entries
- Supports not adding space when a completion item (path) is not 'complete'