### PR TITLE
Vehicle - enable compilation with ESP-IDF v5+

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/vehicle/CMakeLists.txt
@@ -1,6 +1,6 @@
 # requirements can't depend on config
-idf_component_register(SRCS "./vehicle.cpp" "./vehicle_bms.cpp" "./vehicle_duktape.cpp" "./vehicle_poller.cpp" "./vehicle_poller_isotp.cpp" "./vehicle_poller_vwtp.cpp" "./vehicle_shell.cpp"
+idf_component_register(SRCS "./vehicle.cpp" "./vehicle_bms.cpp" "./vehicle_duktape.cpp" "./vehicle_shell.cpp"
                        INCLUDE_DIRS .
-                       REQUIRES "ovms_webserver"
+                       REQUIRES "ovms_webserver" "poller"
                        PRIV_REQUIRES "main"
                        WHOLE_ARCHIVE)

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -550,8 +550,9 @@ bool OvmsVehicle::IsShutdown()
   if (!m_is_shutdown)
     return false;
 #ifndef CONFIG_OVMS_COMP_POLLER
-  if (Atomic_Get(m_vqueue) != nullptr) then
+  if (Atomic_Get(m_vqueue) != nullptr) {
     return false;
+  }
 #endif
   return true;
   }


### PR DESCRIPTION
Following 43ca259 and the split of the `poller` component, a change is needed to properly compile with ESP-IDF v5+.
A compilation issue is also fixed.