### PR TITLE
Ovms_Webserver - int64_t format strings changes

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_framework.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_framework.cpp
@@ -838,7 +838,7 @@ void OvmsWebServer::HandleAsset(PageEntry_t& p, PageContext_t& c)
   char etag[50], current_time[50], last_modified[50];
   time_t t = (time_t) mg_time();
   struct tm timeinfo;
-  snprintf(etag, sizeof(etag), "\"%lx.%" INT64_FMT "\"", (unsigned long) mtime, (int64_t) size);
+  snprintf(etag, sizeof(etag), "\"%lx.%" PRId64 "\"", (unsigned long) mtime, (int64_t) size);
   strftime(current_time, sizeof(current_time), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&t, &timeinfo));
   strftime(last_modified, sizeof(last_modified), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&mtime, &timeinfo));
 


### PR DESCRIPTION
`INT64_FMT` replaced with `PRId64` because `INT64_FMT` is a Mongoose 6.x specific define, and this define does not exist any more in Mongoose 7.x releases.