### PR TITLE
Vehicle_Vweup - fix a compilation issue

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
@@ -1247,9 +1247,9 @@ void OvmsVehicleVWeUp::Profile0RetryCallBack()
       if (profile0_val == 1) {
         if (!fakestop)
           charge_timeout = true;
-          if (xChargeSemaphore != NULL)
-            xSemaphoreGive(xChargeSemaphore);
-          MyNotify.NotifyStringf("alert", "Charge control", "Failed to %s charge!", (profile0_activate)? "start" : "stop");
+        if (xChargeSemaphore != NULL)
+          xSemaphoreGive(xChargeSemaphore);
+        MyNotify.NotifyStringf("alert", "Charge control", "Failed to %s charge!", (profile0_activate)? "start" : "stop");
       }
       else
         MyNotify.NotifyStringf("alert", "Climatecontrol", "Failed to %s remote climate control!", (profile0_activate)? "start" : "stop");


### PR DESCRIPTION
The compiler in ESP-IDF v5+ is very sensitive to detecting potential issue. Here, an indentation could be interpreted by the human reader as if an `if` block was encompassing a whole indented block.

The fix here is either to remove the indentation, or to add curly braces to explicitely delimit the block managed by the `if` condition.

The indentation was removed.

**Note** : I erred on the safe side by remove the indentation, so that it compiles the same way it does on ESP-IDF v3. However, as I'm note familiar with the code and the intention of the `if` condition, I'd appreciate a full review of this block of code by a more knowledgeable person than me. Thanks :-)