### PR TITLE
ESP-IDFv4+ : fix missing header

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_peripherals.cpp
+++ b/vehicle/OVMS.V3/main/ovms_peripherals.cpp
@@ -40,8 +40,11 @@ static const char *TAG = "peripherals";
 #include "driver/gpio.h"
 #include "ovms_peripherals.h"
 #include "esp_idf_version.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
+#include "esp_netif.h"
 #if ESP_IDF_VERSION_MAJOR >= 5
 #include <esp_mac.h>
+#endif
 #endif
 
 Peripherals::Peripherals()


### PR DESCRIPTION
A missing `esp_netif.h` header for ESP-IDF v4+ in `ovms_peripherals.cpp`