### PR TITLE
Ensure Network Stability Before Server Connection

### DIFF
--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -1021,6 +1021,13 @@ void esp32wifi::EventWifiGotIp(std::string event, void* data)
     IP2STR(&m_ip_info_sta.ip), IP2STR(&m_ip_info_sta.netmask), IP2STR(&m_ip_info_sta.gw));
   }
 
+bool esp32wifi::WifiHasIp()
+{
+  char numstr[150];
+  sprintf(numstr, IPSTR, IP2STR(&m_ip_info_sta.ip));
+  return strcmp(numstr, "0.0.0.0") == 1;
+}
+
 void esp32wifi::EventWifiLostIp(std::string event, void* data)
   {
   memset(&m_ip_info_sta,0,sizeof(m_ip_info_sta));

--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -1022,11 +1022,11 @@ void esp32wifi::EventWifiGotIp(std::string event, void* data)
   }
 
 bool esp32wifi::WifiHasIp()
-{
+  {
   char numstr[150];
   sprintf(numstr, IPSTR, IP2STR(&m_ip_info_sta.ip));
   return strcmp(numstr, "0.0.0.0") == 1;
-}
+  }
 
 void esp32wifi::EventWifiLostIp(std::string event, void* data)
   {

--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
@@ -87,6 +87,7 @@ class esp32wifi : public pcp, public InternalRamAllocated
     void StartDhcpClient();
     void SetSTAWifiIP(std::string ip="", std::string sn="", std::string gw="");
     void SetAPWifiBW();
+    bool WifiHasIp();
 
   public:
     void EventWifiStaState(std::string event, void* data);

--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
@@ -101,6 +101,7 @@ class esp32wifi : public pcp, public InternalRamAllocated
     void EventWifiScanDone(std::string event, void* data);
     void EventSystemShuttingDown(std::string event, void* data);
     void OutputStatus(int verbosity, OvmsWriter* writer);
+    void ConfigChanged(std::string event, void *data);
 
   protected:
     bool m_poweredup;
@@ -133,6 +134,9 @@ class esp32wifi : public pcp, public InternalRamAllocated
     uint32_t m_sta_reconnect;
     wifi_ap_record_t m_sta_ap_info;
     int m_sta_rssi;                               // smoothed RSSI [dBm/10]
+    float m_good_dbm;
+    float m_bad_dbm;
+    bool m_good_signal;
   };
 
 #endif //#ifndef __ESP32WIFI_H__

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -358,6 +358,11 @@ void modem::SetPowerMode(PowerMode powermode)
     }
   }
 
+bool modem::ModemIsNetMode()
+  {
+    return m_state1 == NetMode;
+  }
+
 void modem::AutoInit()
   {
   if (MyConfig.GetParamValueBool("auto", "modem", false))

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -360,7 +360,7 @@ void modem::SetPowerMode(PowerMode powermode)
 
 bool modem::ModemIsNetMode()
   {
-    return m_state1 == NetMode;
+  return m_state1 == NetMode;
   }
 
 void modem::AutoInit()

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -41,6 +41,7 @@ static const char *TAG = "cellular";
 #include "ovms_events.h"
 #include "ovms_notify.h"
 #include "ovms_boot.h"
+#include "ovms_config.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Global convenience variables
@@ -292,6 +293,7 @@ modem::modem(const char* name, uart_port_t uartnum, int baud, int rxpin, int txp
   for (size_t k=0; k<CELLULAR_NETREG_COUNT; k++) { m_netreg_d[k] = Unknown; }
   m_provider = "";
   m_sq = 99; // Unknown
+  m_good_signal = false;
   m_powermode = Off;
   m_pincode_required = false;
   m_err_uart_fifo_ovf = 0;
@@ -311,8 +313,11 @@ modem::modem(const char* name, uart_port_t uartnum, int baud, int rxpin, int txp
 
   using std::placeholders::_1;
   using std::placeholders::_2;
-  MyEvents.RegisterEvent(TAG,"ticker.1", std::bind(&modem::Ticker, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "ticker.1", std::bind(&modem::Ticker, this, _1, _2));
   MyEvents.RegisterEvent(TAG, "system.shuttingdown", std::bind(&modem::EventListener, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "config.mounted", std::bind(&modem::ConfigChanged, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "config.changed", std::bind(&modem::ConfigChanged, this, _1, _2));
+  ConfigChanged("config.mounted", NULL);
   }
 
 modem::~modem()
@@ -1513,6 +1518,18 @@ void modem::EventListener(std::string event, void* data)
     }
   }
 
+void modem::ConfigChanged(std::string event, void* data)
+  {
+  ESP_LOGE(TAG, "Network config has been changed, reconfiguring modem");
+  OvmsConfigParam* param = (OvmsConfigParam*)data;
+  if (event == "config.mounted" || !param || param->GetName() == "network")
+    {
+    // Network config has been changed, apply:
+    m_good_dbm = MyConfig.GetParamValueFloat("network", "modem.sq.good", -95);
+    m_bad_dbm = MyConfig.GetParamValueFloat("network", "modem.sq.bad", -93);
+    }
+  }
+
 void modem::IncomingMuxData(GsmMuxChannel* channel)
   {
   // The MUX has indicated there is data on the specified channel
@@ -1621,10 +1638,16 @@ void modem::SetSignalQuality(int newsq)
     {
     m_sq = newsq;
     ESP_LOGD(TAG, "Signal Quality is: %d (%d dBm)", m_sq, UnitConvert(sq, dbm, m_sq));
+    float current_dbm = UnitConvert(sq, dbm, m_sq);
     StdMetrics.ms_m_net_mdm_sq->SetValue(m_sq, sq);
     if (StdMetrics.ms_m_net_type->AsString() == "modem")
       {
       StdMetrics.ms_m_net_sq->SetValue(m_sq, sq);
+      if (m_good_signal && current_dbm < m_bad_dbm)
+        m_good_signal = false;
+      if (!m_good_signal && current_dbm > m_good_dbm)
+        m_good_signal = true;
+      StdMetrics.ms_m_net_good_sq->SetValue(m_good_signal);
       }
     }
   }
@@ -1639,6 +1662,7 @@ void modem::ClearNetMetrics()
   StdMetrics.ms_m_net_mdm_network->Clear();
 
   m_sq = 99;
+  m_good_signal = false;
   StdMetrics.ms_m_net_mdm_sq->Clear();
 
   if (StdMetrics.ms_m_net_type->AsString() == "modem")

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -1520,7 +1520,6 @@ void modem::EventListener(std::string event, void* data)
 
 void modem::ConfigChanged(std::string event, void* data)
   {
-  ESP_LOGE(TAG, "Network config has been changed, reconfiguring modem");
   OvmsConfigParam* param = (OvmsConfigParam*)data;
   if (event == "config.mounted" || !param || param->GetName() == "network")
     {

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
@@ -65,6 +65,9 @@ class modem : public pcp, public InternalRamAllocated
     int m_txpin;
     int m_pwregpio;
     int m_dtregpio;
+    float m_good_dbm;
+    float m_bad_dbm;
+    bool m_good_signal;
 
   public:
     typedef enum
@@ -212,6 +215,7 @@ class modem : public pcp, public InternalRamAllocated
     void Task();
     void Ticker(std::string event, void* data);
     void EventListener(std::string event, void* data);
+    void ConfigChanged(std::string event, void *data);
     void IncomingMuxData(GsmMuxChannel* channel);
     void SendSetState1(modem_state1_t newstate);
     bool IsStarted();

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
@@ -199,6 +199,7 @@ class modem : public pcp, public InternalRamAllocated
 
   public:
     // High level API functions
+    bool ModemIsNetMode();
     void StartTask();
     void StopTask();
     bool StartNMEA(bool force=false);

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -136,10 +136,9 @@ static void OvmsServerV3MongooseCallback(struct mg_connection *nc, int ev, void 
       ESP_LOGI(TAG, "Incoming message %.*s: %.*s", (int) msg->topic.len,
              msg->topic.p, (int) msg->payload.len, msg->payload.p);
       if (MyOvmsServerV3)
-        {                            
-        MyOvmsServerV3->IncomingMsg(
-          std::string(msg->topic.p,msg->topic.len),
-          std::string(msg->payload.p,msg->payload.len));
+        {
+        MyOvmsServerV3->IncomingMsg(std::string(msg->topic.p, msg->topic.len),
+                                    std::string(msg->payload.p, msg->payload.len));
         }
       if (msg->qos == 1)
         {

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -137,8 +137,8 @@ static void OvmsServerV3MongooseCallback(struct mg_connection *nc, int ev, void 
              msg->topic.p, (int) msg->payload.len, msg->payload.p);
       if (MyOvmsServerV3)
         {
-        MyOvmsServerV3->IncomingMsg(std::string(msg->topic.p, msg->topic.len),
-                                    std::string(msg->payload.p, msg->payload.len));
+        MyOvmsServerV3->IncomingMsg(std::string(msg->topic.p,msg->topic.len),
+                                    std::string(msg->payload.p,msg->payload.len));
         }
       if (msg->qos == 1)
         {
@@ -885,7 +885,8 @@ void OvmsServerV3::NetmanStop(std::string event, void* data)
 void OvmsServerV3::Ticker1(std::string event, void* data)
   {
   m_connection_available = StdMetrics.ms_m_net_connected->AsBool() &&
-                              StdMetrics.ms_m_net_ip->AsBool();
+                              StdMetrics.ms_m_net_ip->AsBool() &&
+                              !StdMetrics.ms_m_net_good_sq->AsBool();
 
   if (!m_connection_available && m_mgconn)
     {

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -95,6 +95,7 @@ class OvmsServerV3 : public OvmsServer
     struct mg_connection *m_mgconn;
     OvmsMutex m_mgconn_mutex;
     int m_connretry;
+    int m_connection_counter;
     bool m_sendall;
     int m_msgid;
     int m_lasttx;

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -96,7 +96,6 @@ class OvmsServerV3 : public OvmsServer
     OvmsMutex m_mgconn_mutex;
     int m_connretry;
     bool m_sendall;
-    int accept_command;
     int m_msgid;
     int m_lasttx;
     int m_lasttx_sendall;
@@ -109,7 +108,7 @@ class OvmsServerV3 : public OvmsServer
     int m_updatetime_charging;
     int m_updatetime_sendall;
 
-    bool connection_available;
+    bool m_connection_available;
     bool m_notify_info_pending;
     bool m_notify_error_pending;
     bool m_notify_alert_pending;

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -96,6 +96,7 @@ class OvmsServerV3 : public OvmsServer
     OvmsMutex m_mgconn_mutex;
     int m_connretry;
     bool m_sendall;
+    int accept_command;
     int m_msgid;
     int m_lasttx;
     int m_lasttx_sendall;
@@ -108,6 +109,7 @@ class OvmsServerV3 : public OvmsServer
     int m_updatetime_charging;
     int m_updatetime_sendall;
 
+    bool connection_available;
     bool m_notify_info_pending;
     bool m_notify_error_pending;
     bool m_notify_alert_pending;

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -48,6 +48,9 @@ MetricsStandard::MetricsStandard()
   ms_m_net_type = new OvmsMetricString(MS_N_TYPE, SM_STALE_MAX);
   ms_m_net_sq = new OvmsMetricInt(MS_N_SQ, SM_STALE_MAX, dbm);
   ms_m_net_provider = new OvmsMetricString(MS_N_PROVIDER, SM_STALE_MAX);
+  ms_m_net_connected = new OvmsMetricBool(MS_N_CONNECTED);
+  ms_m_net_ip = new OvmsMetricBool(MS_N_IP);
+  ms_m_net_good_sq = new OvmsMetricBool(MS_N_GOOD_SQ);
   ms_m_net_wifi_sq = new OvmsMetricFloat(MS_N_WIFI_SQ, SM_STALE_MAX, dbm);
   ms_m_net_wifi_network = new OvmsMetricString(MS_N_WIFI_NETWORK, SM_STALE_MAX);
   ms_m_net_mdm_sq = new OvmsMetricFloat(MS_N_MDM_SQ, SM_STALE_MAX, dbm);
@@ -56,8 +59,6 @@ MetricsStandard::MetricsStandard()
   ms_m_net_mdm_iccid = new OvmsMetricString(MS_N_MDM_ICCID, SM_STALE_MAX);
   ms_m_net_mdm_model = new OvmsMetricString(MS_N_MDM_MODEL, SM_STALE_MAX);
   ms_m_net_mdm_mode = new OvmsMetricString(MS_N_MDM_MODE, SM_STALE_MAX);
-  ms_m_net_connected = new OvmsMetricBool(MS_N_CONNECTED);
-  ms_m_net_ip = new OvmsMetricBool(MS_N_IP);
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
   ms_m_egpio_input = new OvmsMetricBitset<10,0>(MS_M_EGPIO_INPUT, SM_STALE_MAX);

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -56,6 +56,8 @@ MetricsStandard::MetricsStandard()
   ms_m_net_mdm_iccid = new OvmsMetricString(MS_N_MDM_ICCID, SM_STALE_MAX);
   ms_m_net_mdm_model = new OvmsMetricString(MS_N_MDM_MODEL, SM_STALE_MAX);
   ms_m_net_mdm_mode = new OvmsMetricString(MS_N_MDM_MODE, SM_STALE_MAX);
+  ms_m_net_connected = new OvmsMetricBool(MS_N_CONNECTED);
+  ms_m_net_ip = new OvmsMetricBool(MS_N_IP);
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
   ms_m_egpio_input = new OvmsMetricBitset<10,0>(MS_M_EGPIO_INPUT, SM_STALE_MAX);

--- a/vehicle/OVMS.V3/main/metrics_standard.h
+++ b/vehicle/OVMS.V3/main/metrics_standard.h
@@ -50,6 +50,9 @@
 
 #define MS_N_TYPE                   "m.net.type"
 #define MS_N_SQ                     "m.net.sq"
+#define MS_N_CONNECTED              "m.net.connected"
+#define MS_N_IP                     "m.net.ip"
+#define MS_N_GOOD_SQ                "m.net.good.sq"
 #define MS_N_PROVIDER               "m.net.provider"
 #define MS_N_MDM_ICCID              "m.net.mdm.iccid"
 #define MS_N_MDM_MODEL              "m.net.mdm.model"
@@ -59,8 +62,6 @@
 #define MS_N_MDM_MODE               "m.net.mdm.mode"
 #define MS_N_WIFI_NETWORK           "m.net.wifi.network"
 #define MS_N_WIFI_SQ                "m.net.wifi.sq"
-#define MS_N_CONNECTED              "m.net.connected"
-#define MS_N_IP                     "m.net.ip"
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
 #define MS_M_EGPIO_INPUT            "m.egpio.input"
@@ -301,6 +302,7 @@ class MetricsStandard
     OvmsMetricString* ms_m_net_mdm_mode;                  // Cellular connection mode and status
     OvmsMetricBool*  ms_m_net_connected;                  // True = connected_any is true
     OvmsMetricBool*  ms_m_net_ip;                         // True = device has ip available
+    OvmsMetricBool*  ms_m_net_good_sq;                    // True = sq is above the configured threshold for sq usability
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
     OvmsMetricBitset<10,0>* ms_m_egpio_input;             // EGPIO (MAX7317) input port state (ports 0…9)

--- a/vehicle/OVMS.V3/main/metrics_standard.h
+++ b/vehicle/OVMS.V3/main/metrics_standard.h
@@ -59,6 +59,8 @@
 #define MS_N_MDM_MODE               "m.net.mdm.mode"
 #define MS_N_WIFI_NETWORK           "m.net.wifi.network"
 #define MS_N_WIFI_SQ                "m.net.wifi.sq"
+#define MS_N_CONNECTED              "m.net.connected"
+#define MS_N_IP                     "m.net.ip"
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
 #define MS_M_EGPIO_INPUT            "m.egpio.input"
@@ -297,6 +299,8 @@ class MetricsStandard
     OvmsMetricString* ms_m_net_mdm_iccid;                 // ICCID of SIM card in modem
     OvmsMetricString* ms_m_net_mdm_model;                 // Model of modem discovered
     OvmsMetricString* ms_m_net_mdm_mode;                  // Cellular connection mode and status
+    OvmsMetricBool*  ms_m_net_connected;                  // True = connected_any is true
+    OvmsMetricBool*  ms_m_net_ip;                         // True = device has ip available
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
     OvmsMetricBitset<10,0>* ms_m_egpio_input;             // EGPIO (MAX7317) input port state (ports 0…9)

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -49,6 +49,7 @@ static const char *TAG = "netmanager";
 #include "ovms_command.h"
 #include "ovms_config.h"
 #include "ovms_module.h"
+#include "ovms_boot.h"
 #ifdef CONFIG_OVMS_DEV_NETMANAGER_PING
 #include "ping/ping_sock.h"
 #endif // CONFIG_OVMS_DEV_NETMANAGER_PING

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -415,6 +415,7 @@ OvmsNetManager::OvmsNetManager()
   //   dns                Space-separated list of DNS servers
   //   wifi.sq.good       Threshold for usable wifi signal [dBm], default -87
   //   wifi.sq.bad        Threshold for unusable wifi signal [dBm], default -89
+  StdMetrics.ms_m_net_ip->SetValue(false);
 
 #ifdef CONFIG_OVMS_COMP_WIFI
   MyMetrics.RegisterListener(TAG, MS_N_WIFI_SQ, std::bind(&OvmsNetManager::WifiStaCheckSQ, this, _1));
@@ -661,7 +662,6 @@ void OvmsNetManager::Ticker1(std::string event, void *data)
   {
   if (!m_connected_any)
     {
-    StdMetrics.ms_m_net_ip->SetValue(false);
     StdMetrics.ms_m_net_connected->SetValue(false);
     }
   else
@@ -685,7 +685,6 @@ void OvmsNetManager::Ticker1(std::string event, void *data)
         connected = MyPeripherals->m_esp32wifi->WifiHasIp();
         }
       }
-    StdMetrics.ms_m_net_ip->SetValue(connected);
     if (m_connected_any && !connected)
       {
       m_not_connected_counter++;

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -661,6 +661,7 @@ void OvmsNetManager::Ticker1(std::string event, void *data)
     {
     if (m_connected_any && !m_has_ip && StdMetrics.ms_m_net_good_sq->AsBool())
       {
+      ESP_LOGI(TAG, "Connection available with good signal, but no IP address; rebooting in %i seconds", 300-m_not_connected_counter);
       m_not_connected_counter++;
       if (m_not_connected_counter > 300)
         {
@@ -745,7 +746,7 @@ void OvmsNetManager::ConfigChanged(std::string event, void* data)
   if (!param || param->GetName() == "network")
     {
     // Network config has been changed, apply:
-    m_cfg_reboot_no_connection = MyConfig.GetParamValueBool("network", "reboot.no.connection", false);
+    m_cfg_reboot_no_connection = MyConfig.GetParamValueBool("network", "reboot.no.ip", false);
     m_cfg_wifi_sq_good = MyConfig.GetParamValueFloat("network", "wifi.sq.good", -87);
     m_cfg_wifi_sq_bad = MyConfig.GetParamValueFloat("network", "wifi.sq.bad",  -89);
     if (m_cfg_wifi_sq_good < m_cfg_wifi_sq_bad)

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -659,11 +659,13 @@ void OvmsNetManager::WifiApStaDisconnect(std::string event, void* data)
 
 void OvmsNetManager::Ticker1(std::string event, void *data)
   {
-  StdMetrics.ms_m_net_connected->SetValue(m_connected_any);
-  if (!m_connected_any)
+  if (!m_connected_any){
     StdMetrics.ms_m_net_ip->SetValue(false);
+    StdMetrics.ms_m_net_connected->SetValue(false);
+  }
   else
-    {
+  {
+    StdMetrics.ms_m_net_connected->SetValue(true);
     bool connected = false;
     // respect the priority of wifi over modem
     if (m_connected_modem){
@@ -689,7 +691,7 @@ void OvmsNetManager::Ticker1(std::string event, void *data)
     } else {
       not_connected_counter = 0;
     }
-    }
+  }
   }
 
 void OvmsNetManager::ModemUp(std::string event, void* data)

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -344,7 +344,7 @@ void network_connections(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, in
 OvmsNetManager::OvmsNetManager()
   {
   ESP_LOGI(TAG, "Initialising NETMANAGER (8999)");
-  not_connected_counter = 0;
+  m_not_connected_counter = 0;
   m_connected_wifi = false;
   m_connected_modem = false;
   m_connected_any = false;
@@ -659,39 +659,46 @@ void OvmsNetManager::WifiApStaDisconnect(std::string event, void* data)
 
 void OvmsNetManager::Ticker1(std::string event, void *data)
   {
-  if (!m_connected_any){
+  if (!m_connected_any)
+    {
     StdMetrics.ms_m_net_ip->SetValue(false);
     StdMetrics.ms_m_net_connected->SetValue(false);
-  }
+    }
   else
-  {
+    {
     StdMetrics.ms_m_net_connected->SetValue(true);
     bool connected = false;
     // respect the priority of wifi over modem
-    if (m_connected_modem){
-      if (MyPeripherals && MyPeripherals->m_cellular_modem)
+    if (m_connected_modem)
       {
+      if (MyPeripherals && MyPeripherals->m_cellular_modem)
+        {
         connected = MyPeripherals->m_cellular_modem->ModemIsNetMode() &&
                     MyPeripherals->m_cellular_modem->m_mux->IsMuxUp() &&
                     MyPeripherals->m_cellular_modem->m_ppp->m_connected;
+        }
       }
-    }
-    if (m_connected_wifi){
-      if (MyPeripherals && MyPeripherals->m_esp32wifi)
+    if (m_connected_wifi)
       {
+      if (MyPeripherals && MyPeripherals->m_esp32wifi)
+        {
         connected = MyPeripherals->m_esp32wifi->WifiHasIp();
+        }
       }
-    }
     StdMetrics.ms_m_net_ip->SetValue(connected);
-    if (m_connected_any && !connected){
-      not_connected_counter++;
-      if (not_connected_counter > 300){
+    if (m_connected_any && !connected)
+      {
+      m_not_connected_counter++;
+      if (m_not_connected_counter > 300)
+        {
         MyBoot.Restart();
+        }
       }
-    } else {
-      not_connected_counter = 0;
+    else
+      {
+      m_not_connected_counter = 0;
+      }
     }
-  }
   }
 
 void OvmsNetManager::ModemUp(std::string event, void* data)

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -871,7 +871,6 @@ void OvmsNetManager::PrioritiseAndIndicate()
 
 void OvmsNetManager::DoSafePrioritiseAndIndicate()
   {
-  ESP_LOGE(TAG, "DoSafePrioritiseAndIndicate");
   const char *search = NULL;
   ip_addr_t* dns = NULL;
 
@@ -900,9 +899,9 @@ void OvmsNetManager::DoSafePrioritiseAndIndicate()
               MyPeripherals->m_cellular_modem->m_mux->IsMuxUp() &&
               MyPeripherals->m_cellular_modem->m_ppp->m_connected;
     }
-    StdMetrics.ms_m_net_ip->SetValue(m_has_ip);
+  StdMetrics.ms_m_net_ip->SetValue(m_has_ip);
 
-    if (search == NULL)
+  if (search == NULL)
     {
     SetNetType("none");
     return;

--- a/vehicle/OVMS.V3/main/ovms_netmanager.h
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.h
@@ -116,6 +116,7 @@ class OvmsNetManager
     void WifiApStaDisconnect(std::string event, void* data);
 #endif // CONFIG_OVMS_COMP_WIFI
 
+    void Ticker1(std::string event, void *data);
     void ModemUp(std::string event, void* data);
     void ModemDown(std::string event, void* data);
     void InterfaceUp(std::string event, void* data);

--- a/vehicle/OVMS.V3/main/ovms_netmanager.h
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.h
@@ -138,7 +138,7 @@ class OvmsNetManager
     void SetDNSServer(ip_addr_t* dnsstore);
 
   public:
-    int not_connected_counter;
+    int m_not_connected_counter;
     bool m_connected_wifi;
     bool m_connected_modem;
     bool m_connected_any;

--- a/vehicle/OVMS.V3/main/ovms_netmanager.h
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.h
@@ -142,6 +142,7 @@ class OvmsNetManager
     bool m_connected_wifi;
     bool m_connected_modem;
     bool m_connected_any;
+    bool m_has_ip;
     bool m_wifi_sta;
     bool m_wifi_good;
     bool m_wifi_ap;
@@ -152,6 +153,7 @@ class OvmsNetManager
     char m_previous_name[2];
 
   protected:
+    bool m_cfg_reboot_no_connection;
     float m_cfg_wifi_sq_good;               // config network wifi.sq.good   [dBm] default -87
     float m_cfg_wifi_sq_bad;                // config network wifi.sq.bad    [dBm] default -89
 

--- a/vehicle/OVMS.V3/main/ovms_netmanager.h
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.h
@@ -137,6 +137,7 @@ class OvmsNetManager
     void SetDNSServer(ip_addr_t* dnsstore);
 
   public:
+    int not_connected_counter;
     bool m_connected_wifi;
     bool m_connected_modem;
     bool m_connected_any;


### PR DESCRIPTION
This PR introduces a safeguard to prevent the device from connecting to server v3 if there is a cellular or Wi-Fi connection that is not yet fully established.

For each connection type, the device checks whether the OVMS has been assigned an IP address or if the cellular connection (netMode + mux + ppp) is complete. It also takes into consideration thresholds for good and bad connection and does not attempt a connection whenever there is no good signal. 

If the connection is established but remains unready for a specified duration, the device will assume a failure has occurred and will automatically restart. This can also be disable via the config ("network", "reboot.no.connection") and is false by default.

Server v3 does not connect if less than 10 seconds of a "good " connection have passed.

The configs for cellular good and bad signal and automatic reboot if no connection were added to the web server.