### PR TITLE
Handle Flash Memory Corruption with Full Factory Reset

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_config.cpp
+++ b/vehicle/OVMS.V3/main/ovms_config.cpp
@@ -46,6 +46,8 @@ static const char *TAG = "config";
 #include "ovms_boot.h"
 #include "ovms_semaphore.h"
 #include "ovms_vfs.h"
+#include "ovms_module.h"
+
 
 #ifdef CONFIG_OVMS_SC_ZIP
 #include "zip_archive.h"
@@ -1189,7 +1191,16 @@ void OvmsConfigParam::RewriteConfig()
   path.append(m_name);
   FILE* f = fopen(path.c_str(), "w");
   if (!f)
+    {
     ESP_LOGE(TAG, "RewriteConfig: can't open '%s': %s", path.c_str(), strerror(errno));
+    // in case /store/ovms_config/ is not accesible factory reset.
+    // This is a workaround in case config is corrupted
+    if (startsWith(path, "/store/ovms_config/"))
+    {
+      ESP_LOGE(TAG, "RewriteConfig: factory reset");
+      ExecuteDriverFactoryReset();
+    }
+    }
   else
     {
 #ifdef OVMS_PERSIST_METADATA

--- a/vehicle/OVMS.V3/main/ovms_module.cpp
+++ b/vehicle/OVMS.V3/main/ovms_module.cpp
@@ -1134,6 +1134,11 @@ bool module_factory_reset_yesno(OvmsWriter* writer, void* ctx, char ch)
   return false;
   }
 
+void ExecuteDriverFactoryReset()
+  {
+    module_perform_factoryreset(NULL);
+  }
+
 static void module_factory_reset(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
   if (argc > 0)

--- a/vehicle/OVMS.V3/main/ovms_module.h
+++ b/vehicle/OVMS.V3/main/ovms_module.h
@@ -31,6 +31,7 @@
 #ifndef __OVMS_MODULE_H__
 
 extern void AddTaskToMap(TaskHandle_t task);
+extern void ExecuteDriverFactoryReset();
 
 #define __OVMS_MODULE_H__
 


### PR DESCRIPTION
This PR addresses the issue of internal flash memory corruption. When such corruption is detected, the OVMS will automatically perform a full factory reset. This process allows the device to rewrite the configuration file and resume normal operation.