### PR TITLE
Handle Event Queue Overflow

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_events.cpp
+++ b/vehicle/OVMS.V3/main/ovms_events.cpp
@@ -225,7 +225,7 @@ OvmsEvents::OvmsEvents()
   cmd_eventtrace->RegisterCommand("off","Turn event tracing OFF",event_trace);
 
   m_taskqueue = xQueueCreate(CONFIG_OVMS_HW_EVENT_QUEUE_SIZE,sizeof(event_queue_t));
-  xTaskCreatePinnedToCore(EventLaunchTask, "OVMS Events", 8192, (void*)this, 8, &m_taskid, CORE(1));
+  xTaskCreatePinnedToCore(EventLaunchTask, "OVMS Events", 12288, (void*)this, 8, &m_taskid, CORE(1));
   AddTaskToMap(m_taskid);
 
   #ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE
@@ -246,6 +246,7 @@ OvmsEvents::~OvmsEvents()
 void OvmsEvents::EventTask()
   {
   event_queue_t msg;
+  detect_event_loop_blockage = 0;
 
   esp_task_wdt_add(NULL); // WATCHDOG is active for this task
   while(1)
@@ -259,7 +260,25 @@ void OvmsEvents::EventTask()
           break;
         case EVENT_signal:
           m_current_event = msg.body.signal.event;
-          HandleQueueSignalEvent(&msg);
+          if (startsWith(m_current_event, "ticker.") && uxQueueSpacesAvailable(m_taskqueue) < CONFIG_OVMS_HW_EVENT_QUEUE_SIZE/5)
+          {
+            ESP_LOGE(TAG, "Droped %s, counter %i", m_current_event.c_str(), detect_event_loop_blockage);
+            FreeQueueSignalEvent(&msg);
+            detect_event_loop_blockage++;
+            if (detect_event_loop_blockage > 30)
+            {
+              ESP_LOGE(TAG, "Timer service / ticker timer has died => aborting");
+              MyBoot.Restart();
+            }
+          }
+          else
+          {
+            HandleQueueSignalEvent(&msg);
+            if (startsWith(m_current_event, "ticker.") && detect_event_loop_blockage > 0)
+            {
+              detect_event_loop_blockage--;
+            }
+          }
           esp_task_wdt_reset(); // Reset WATCHDOG timer for this task
           m_current_event.clear();
           break;

--- a/vehicle/OVMS.V3/main/ovms_events.h
+++ b/vehicle/OVMS.V3/main/ovms_events.h
@@ -129,6 +129,7 @@ class OvmsEvents
     TimerList m_timers;
     TimerStatusMap m_timer_active;
     OvmsMutex m_timers_mutex;
+    int detect_event_loop_blockage;
 #if ESP_IDF_VERSION_MAJOR >= 4
     esp_event_handler_instance_t event_handler_instance;
 #endif


### PR DESCRIPTION
This PR aims to prevent overflow in the event queue. When the number of available task slots drops to less than a fifth of the original capacity, ticker events are discarded. If more than 30 ticker events are discarded, the OVMS will be restarted, as this indicates that too much time has passed since the last ticker event was processed.