### PR TITLE
Maxus Euniq 6 - Initializing module.  

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(srcs)
+set(include_dirs)
+
+if (CONFIG_OVMS_VEHICLE_MAXE6)
+  list(APPEND srcs "vehicle_me6.cpp")
+  list(APPEND include_dirs "src")
+endif ()
+
+# requirements can't depend on config
+idf_component_register(SRCS ${srcs}
+                       INCLUDE_DIRS ${include_dirs}
+                       PRIV_REQUIRES "main"
+                       WHOLE_ARCHIVE)

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/component.mk
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/component.mk
@@ -1,0 +1,14 @@
+#
+# Main component makefile.
+#
+# This Makefile can be left empty. By default, it will take the sources in the
+# src/ directory, compile them and link them into lib(subdirectory_name).a
+# in the build directory. This behaviour is entirely configurable,
+# please read the ESP-IDF documents if you need to do this.
+#
+
+ifdef CONFIG_OVMS_VEHICLE_MAXE6
+COMPONENT_ADD_INCLUDEDIRS:=src
+COMPONENT_SRCDIRS:=src
+COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive
+endif

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
@@ -34,7 +34,6 @@ static const char *TAG = "v-maxe6";
 #include <stdexcept>
 
 #include "vehicle_me6.h"
-#include "me56_pids.h"
 #include "ovms_notify.h"
 #include <algorithm>
 #include "metrics_standard.h"
@@ -51,7 +50,7 @@ static const char *TAG = "v-maxe6";
 #define CAN_BIT(b,pos) !!(data[b] & (1<<(pos)))
 
 OvmsVehicleMaxe6::OvmsVehicleMaxe6()
-  {
+{
   ESP_LOGI(TAG, "Start Maxus Euniq 6 vehicle module");
 
   // Init CAN:
@@ -77,124 +76,120 @@ OvmsVehicleMaxe6::OvmsVehicleMaxe6()
   // Require GPS:
   MyEvents.SignalEvent("vehicle.require.gps", NULL);
   MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
-  }
+}
 
 OvmsVehicleMaxe6::~OvmsVehicleMaxe6()
-  {
+{
   ESP_LOGI(TAG, "Stop Euniq 6 vehicle module");
-  }
+}
 
 void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t *p_frame)
 {
 
-	uint8_t *d = p_frame->data.u8;
+  uint8_t *d = p_frame->data.u8;
 
-	// Check if response is from synchronous can message
-	if (send_can_buffer.status == 0xff && p_frame->MsgID == (send_can_buffer.id + 0x08))
+  // Check if response is from synchronous can message
+  if (send_can_buffer.status == 0xff && p_frame->MsgID == (send_can_buffer.id + 0x08))
+  {
+    // Store message bytes so that the async method can continue
+    send_can_buffer.status = 3;
+
+    send_can_buffer.byte[0] = d[0];
+    send_can_buffer.byte[1] = d[1];
+    send_can_buffer.byte[2] = d[2];
+    send_can_buffer.byte[3] = d[3];
+    send_can_buffer.byte[4] = d[4];
+    send_can_buffer.byte[5] = d[5];
+    send_can_buffer.byte[6] = d[6];
+    send_can_buffer.byte[7] = d[7];
+  }
+
+  /*
+  BASIC METRICS
+  StdMetrics.ms_v_pos_speed           ok
+  StdMetrics.ms_v_bat_soc           ok
+  StdMetrics.ms_v_pos_odometer         ok
+
+  StdMetrics.ms_v_door_fl           ok; yes when open, no when closed
+  StdMetrics.ms_v_door_fr           ok
+  StdMetrics.ms_v_door_rl           ok
+  StdMetrics.ms_v_door_rr           ok
+  StdMetrics.ms_v_trunk             ok
+  StdMetrics.ms_v_env_locked           ok
+
+  StdMetrics.ms_v_env_onepedal         -
+  StdMetrics.ms_v_env_efficiencymode       -
+  StdMetrics.ms_v_env_regenlevel Percentage   -
+
+  StdMetrics.ms_v_bat_current         -
+  StdMetrics.ms_v_bat_voltage         -
+  StdMetrics.ms_v_bat_power           wip esta en porcentaje
+
+  StdMetrics.ms_v_charge_inprogress       ok
+
+  StdMetrics.ms_v_env_on             ok
+  StdMetrics.ms_v_env_awake           ok
+
+  StdMetrics.ms_v_env_aux12v          ok
+  */
+
+  uint8_t *data = p_frame->data.u8;
+
+  switch (p_frame->MsgID)
 	{
-		// Store message bytes so that the async method can continue
-		send_can_buffer.status = 3;
-
-		send_can_buffer.byte[0] = d[0];
-		send_can_buffer.byte[1] = d[1];
-		send_can_buffer.byte[2] = d[2];
-		send_can_buffer.byte[3] = d[3];
-		send_can_buffer.byte[4] = d[4];
-		send_can_buffer.byte[5] = d[5];
-		send_can_buffer.byte[6] = d[6];
-		send_can_buffer.byte[7] = d[7];
-	}
-
-	/*
-	BASIC METRICS
-	StdMetrics.ms_v_pos_speed 					ok
-	StdMetrics.ms_v_bat_soc 					ok
-	StdMetrics.ms_v_pos_odometer 				ok
-
-	StdMetrics.ms_v_door_fl 					ok; yes when open, no when closed
-	StdMetrics.ms_v_door_fr 					ok
-	StdMetrics.ms_v_door_rl 					ok
-	StdMetrics.ms_v_door_rr 					ok
-	StdMetrics.ms_v_trunk	 					ok
-	StdMetrics.ms_v_env_locked 					ok
-
-	StdMetrics.ms_v_env_onepedal 				-
-	StdMetrics.ms_v_env_efficiencymode 			-
-	StdMetrics.ms_v_env_regenlevel Percentage 	-
-
-	StdMetrics.ms_v_bat_current 				-
-	StdMetrics.ms_v_bat_voltage 				-
-	StdMetrics.ms_v_bat_power 					wip esta en porcentaje
-
-	StdMetrics.ms_v_charge_inprogress 			ok
-
-	StdMetrics.ms_v_env_on 						ok
-	StdMetrics.ms_v_env_awake 					ok
-
-	StdMetrics.ms_v_env_aux12v					ok
-
-	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FL, value, PSI);
-	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FR, value, PSI);
-	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RL, value, PSI);
-	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RR, value, PSI);
-	*/
-
-	uint8_t *data = p_frame->data.u8;
-
-	switch (p_frame->MsgID)
-	{
-	case 0x0c9:
-	{
-		StdMetrics.ms_v_charge_inprogress->SetValue(
-			CAN_BIT(2,0) && CAN_BIT(2,1) && CAN_BIT(2,2)
-			);
-		break;
-	}
-	case 0x281:
-	{
-		StdMetrics.ms_v_env_locked->SetValue(
-			CAN_BIT(1,0) &&	CAN_BIT(1,2) &&	CAN_BIT(1,4) &&	CAN_BIT(1,6) &&
-			!StdMetrics.ms_v_door_fl->AsBool() &&
-			!StdMetrics.ms_v_door_fr->AsBool() &&
-			!StdMetrics.ms_v_door_rl->AsBool() &&
-			!StdMetrics.ms_v_door_rr->AsBool() &&
-			!StdMetrics.ms_v_door_trunk->AsBool());
-		break;
-	}
-	case 0x46a:
-	{
-		StdMetrics.ms_v_door_fl->SetValue(CAN_BIT(0, 0));
-		StdMetrics.ms_v_door_fr->SetValue(CAN_BIT(0, 3));
-		StdMetrics.ms_v_door_rr->SetValue(CAN_BIT(0, 5));
-		StdMetrics.ms_v_door_rl->SetValue(CAN_BIT(0, 7));
-		StdMetrics.ms_v_door_trunk->SetValue(CAN_BIT(1, 1));
-		break;
-	}
-	case 0x540:
-	{
-		StdMetrics.ms_v_pos_odometer->SetValue(CAN_UINT24(0));
-		break;
-	}
-	case 0x6f0:
-	{
-		StdMetrics.ms_v_pos_speed->SetValue(CAN_BYTE(4));
-		break;
-	}
-	case 0x6f1:
-	{
-		StdMetrics.ms_v_env_awake->SetValue(CAN_BIT(4,7));
-		StdMetrics.ms_v_env_on->SetValue(CAN_BIT(1,4) && CAN_BIT(4,7));
-		break;
-	}
-	case 0x6f2:
-	{
-		StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(1));
-		StdMetrics.ms_v_bat_power->SetValue((CAN_BYTE(2) - 100) * 120, kW); // es porcentaje
-		break;
-	}
-	default:
-		break;
-	}
+		case 0x0c9:
+		{
+			StdMetrics.ms_v_charge_inprogress->SetValue(
+				CAN_BIT(2,0) && CAN_BIT(2,1) && CAN_BIT(2,2)
+				);
+			break;
+		}
+		case 0x281:
+		{
+			StdMetrics.ms_v_env_locked->SetValue(
+				CAN_BIT(1,0) &&  CAN_BIT(1,2) &&  CAN_BIT(1,4) &&  CAN_BIT(1,6) &&
+				!StdMetrics.ms_v_door_fl->AsBool() &&
+				!StdMetrics.ms_v_door_fr->AsBool() &&
+				!StdMetrics.ms_v_door_rl->AsBool() &&
+				!StdMetrics.ms_v_door_rr->AsBool() &&
+				!StdMetrics.ms_v_door_trunk->AsBool());
+			break;
+		}
+		case 0x46a:
+		{
+			StdMetrics.ms_v_door_fl->SetValue(CAN_BIT(0, 0));
+			StdMetrics.ms_v_door_fr->SetValue(CAN_BIT(0, 3));
+			StdMetrics.ms_v_door_rr->SetValue(CAN_BIT(0, 5));
+			StdMetrics.ms_v_door_rl->SetValue(CAN_BIT(0, 7));
+			StdMetrics.ms_v_door_trunk->SetValue(CAN_BIT(1, 1));
+			break;
+		}
+		case 0x540:
+		{
+			StdMetrics.ms_v_pos_odometer->SetValue(CAN_UINT24(0));
+			break;
+		}
+		case 0x6f0:
+		{
+			StdMetrics.ms_v_pos_speed->SetValue(CAN_BYTE(4));
+			break;
+		}
+		case 0x6f1:
+		{
+			StdMetrics.ms_v_env_awake->SetValue(CAN_BIT(4,7));
+			StdMetrics.ms_v_env_on->SetValue(CAN_BIT(1,4) && CAN_BIT(4,7));
+			break;
+		}
+		case 0x6f2:
+		{
+			StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(1));
+			// Units percentage.
+			StdMetrics.ms_v_bat_power->SetValue((CAN_BYTE(2) - 100) * 120, kW);
+			break;
+		}
+		default:
+			break;
+  }
 }
 
 void OvmsVehicleMaxe6::Ticker1(uint32_t ticker)
@@ -202,13 +197,13 @@ void OvmsVehicleMaxe6::Ticker1(uint32_t ticker)
 }
 
 class OvmsVehicleMaxe6Init
-  {
-  public: OvmsVehicleMaxe6Init();
-  } OvmsVehicleMaxe6Init  __attribute__ ((init_priority (9000)));
+{
+public: OvmsVehicleMaxe6Init();
+} OvmsVehicleMaxe6Init  __attribute__ ((init_priority (9000)));
 
 OvmsVehicleMaxe6Init::OvmsVehicleMaxe6Init()
-  {
+{
   ESP_LOGI(TAG, "Registering Vehicle: Maxus Euniq 6 (9000)");
 
   MyVehicleFactory.RegisterVehicle<OvmsVehicleMaxe6>("ME56","Maxus Euniq 6");
-  }
+}

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
@@ -106,31 +106,27 @@ void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t *p_frame)
 
   /*
   BASIC METRICS
-  StdMetrics.ms_v_pos_speed           ok
+  StdMetrics.ms_v_pos_speed         ok
   StdMetrics.ms_v_bat_soc           ok
-  StdMetrics.ms_v_pos_odometer         ok
+  StdMetrics.ms_v_pos_odometer      ok
 
-  StdMetrics.ms_v_door_fl           ok; yes when open, no when closed
+  StdMetrics.ms_v_door_fl           ok
   StdMetrics.ms_v_door_fr           ok
   StdMetrics.ms_v_door_rl           ok
   StdMetrics.ms_v_door_rr           ok
   StdMetrics.ms_v_trunk             ok
-  StdMetrics.ms_v_env_locked           ok
+  StdMetrics.ms_v_env_locked        ok
 
-  StdMetrics.ms_v_env_onepedal         -
-  StdMetrics.ms_v_env_efficiencymode       -
-  StdMetrics.ms_v_env_regenlevel Percentage   -
+  StdMetrics.ms_v_bat_current       -
+  StdMetrics.ms_v_bat_voltage       -
+  StdMetrics.ms_v_bat_power         wip (percentage units)
 
-  StdMetrics.ms_v_bat_current         -
-  StdMetrics.ms_v_bat_voltage         -
-  StdMetrics.ms_v_bat_power           wip esta en porcentaje
+  StdMetrics.ms_v_charge_inprogress ok
 
-  StdMetrics.ms_v_charge_inprogress       ok
+  StdMetrics.ms_v_env_on            ok
+  StdMetrics.ms_v_env_awake         ok
 
-  StdMetrics.ms_v_env_on             ok
-  StdMetrics.ms_v_env_awake           ok
-
-  StdMetrics.ms_v_env_aux12v          ok
+  StdMetrics.ms_v_env_aux12v        ok
   */
 
   uint8_t *data = p_frame->data.u8;

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
@@ -136,59 +136,59 @@ void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t *p_frame)
   uint8_t *data = p_frame->data.u8;
 
   switch (p_frame->MsgID)
-	{
-		case 0x0c9:
-		{
-			StdMetrics.ms_v_charge_inprogress->SetValue(
-				CAN_BIT(2,0) && CAN_BIT(2,1) && CAN_BIT(2,2)
-				);
-			break;
-		}
-		case 0x281:
-		{
-			StdMetrics.ms_v_env_locked->SetValue(
-				CAN_BIT(1,0) &&  CAN_BIT(1,2) &&  CAN_BIT(1,4) &&  CAN_BIT(1,6) &&
-				!StdMetrics.ms_v_door_fl->AsBool() &&
-				!StdMetrics.ms_v_door_fr->AsBool() &&
-				!StdMetrics.ms_v_door_rl->AsBool() &&
-				!StdMetrics.ms_v_door_rr->AsBool() &&
-				!StdMetrics.ms_v_door_trunk->AsBool());
-			break;
-		}
-		case 0x46a:
-		{
-			StdMetrics.ms_v_door_fl->SetValue(CAN_BIT(0, 0));
-			StdMetrics.ms_v_door_fr->SetValue(CAN_BIT(0, 3));
-			StdMetrics.ms_v_door_rr->SetValue(CAN_BIT(0, 5));
-			StdMetrics.ms_v_door_rl->SetValue(CAN_BIT(0, 7));
-			StdMetrics.ms_v_door_trunk->SetValue(CAN_BIT(1, 1));
-			break;
-		}
-		case 0x540:
-		{
-			StdMetrics.ms_v_pos_odometer->SetValue(CAN_UINT24(0));
-			break;
-		}
-		case 0x6f0:
-		{
-			StdMetrics.ms_v_pos_speed->SetValue(CAN_BYTE(4));
-			break;
-		}
-		case 0x6f1:
-		{
-			StdMetrics.ms_v_env_awake->SetValue(CAN_BIT(4,7));
-			StdMetrics.ms_v_env_on->SetValue(CAN_BIT(1,4) && CAN_BIT(4,7));
-			break;
-		}
-		case 0x6f2:
-		{
-			StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(1));
-			// Units percentage.
-			StdMetrics.ms_v_bat_power->SetValue((CAN_BYTE(2) - 100) * 120, kW);
-			break;
-		}
-		default:
-			break;
+  {
+    case 0x0c9:
+    {
+      StdMetrics.ms_v_charge_inprogress->SetValue(
+        CAN_BIT(2,0) && CAN_BIT(2,1) && CAN_BIT(2,2)
+        );
+      break;
+    }
+    case 0x281:
+    {
+      StdMetrics.ms_v_env_locked->SetValue(
+        CAN_BIT(1,0) &&  CAN_BIT(1,2) &&  CAN_BIT(1,4) &&  CAN_BIT(1,6) &&
+        !StdMetrics.ms_v_door_fl->AsBool() &&
+        !StdMetrics.ms_v_door_fr->AsBool() &&
+        !StdMetrics.ms_v_door_rl->AsBool() &&
+        !StdMetrics.ms_v_door_rr->AsBool() &&
+        !StdMetrics.ms_v_door_trunk->AsBool());
+      break;
+    }
+    case 0x46a:
+    {
+      StdMetrics.ms_v_door_fl->SetValue(CAN_BIT(0, 0));
+      StdMetrics.ms_v_door_fr->SetValue(CAN_BIT(0, 3));
+      StdMetrics.ms_v_door_rr->SetValue(CAN_BIT(0, 5));
+      StdMetrics.ms_v_door_rl->SetValue(CAN_BIT(0, 7));
+      StdMetrics.ms_v_door_trunk->SetValue(CAN_BIT(1, 1));
+      break;
+    }
+    case 0x540:
+    {
+      StdMetrics.ms_v_pos_odometer->SetValue(CAN_UINT24(0));
+      break;
+    }
+    case 0x6f0:
+    {
+      StdMetrics.ms_v_pos_speed->SetValue(CAN_BYTE(4));
+      break;
+    }
+    case 0x6f1:
+    {
+      StdMetrics.ms_v_env_awake->SetValue(CAN_BIT(4,7));
+      StdMetrics.ms_v_env_on->SetValue(CAN_BIT(1,4) && CAN_BIT(4,7));
+      break;
+    }
+    case 0x6f2:
+    {
+      StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(1));
+      // Units percentage.
+      StdMetrics.ms_v_bat_power->SetValue((CAN_BYTE(2) - 100) * 120, kW);
+      break;
+    }
+    default:
+      break;
   }
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
@@ -55,23 +55,9 @@ OvmsVehicleMaxe6::OvmsVehicleMaxe6()
 
   // Init CAN:
   RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
-
-  // Init CAN buffer:
-  send_can_buffer.id = 0;
-  send_can_buffer.status = 0;
-  memset(send_can_buffer.byte, 0, sizeof(send_can_buffer.byte));
-
-  // Init BMS:
-  BmsSetCellArrangementVoltage(96, 16);
-  BmsSetCellArrangementTemperature(16, 1);
-  BmsSetCellLimitsVoltage(2.0, 5.0);
-  BmsSetCellLimitsTemperature(-39, 200);
-  BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
-  BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
   
   // Init Energy:
   StdMetrics.ms_v_charge_mode->SetValue("standard");
-  StdMetrics.ms_v_env_ctrl_login->SetValue(true);
 
   // Require GPS:
   MyEvents.SignalEvent("vehicle.require.gps", NULL);
@@ -85,25 +71,6 @@ OvmsVehicleMaxe6::~OvmsVehicleMaxe6()
 
 void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t *p_frame)
 {
-
-  uint8_t *d = p_frame->data.u8;
-
-  // Check if response is from synchronous can message
-  if (send_can_buffer.status == 0xff && p_frame->MsgID == (send_can_buffer.id + 0x08))
-  {
-    // Store message bytes so that the async method can continue
-    send_can_buffer.status = 3;
-
-    send_can_buffer.byte[0] = d[0];
-    send_can_buffer.byte[1] = d[1];
-    send_can_buffer.byte[2] = d[2];
-    send_can_buffer.byte[3] = d[3];
-    send_can_buffer.byte[4] = d[4];
-    send_can_buffer.byte[5] = d[5];
-    send_can_buffer.byte[6] = d[6];
-    send_can_buffer.byte[7] = d[7];
-  }
-
   /*
   BASIC METRICS
   StdMetrics.ms_v_pos_speed         ok
@@ -121,12 +88,12 @@ void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t *p_frame)
   StdMetrics.ms_v_bat_voltage       -
   StdMetrics.ms_v_bat_power         wip (percentage units)
 
-  StdMetrics.ms_v_charge_inprogress ok
+  StdMetrics.ms_v_charge_inprogress rev
 
   StdMetrics.ms_v_env_on            ok
   StdMetrics.ms_v_env_awake         ok
 
-  StdMetrics.ms_v_env_aux12v        ok
+  StdMetrics.ms_v_env_aux12v        rev
   */
 
   uint8_t *data = p_frame->data.u8;
@@ -178,8 +145,8 @@ void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t *p_frame)
     }
     case 0x6f2:
     {
-      StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(1));
       // Units percentage.
+      StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(1));
       StdMetrics.ms_v_bat_power->SetValue((CAN_BYTE(2) - 100) * 120, kW);
       break;
     }

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
@@ -31,605 +31,174 @@
 static const char *TAG = "v-maxe6";
 
 #include <stdio.h>
+#include <stdexcept>
+
 #include "vehicle_me6.h"
 #include "me56_pids.h"
 #include "ovms_notify.h"
 #include <algorithm>
 #include "metrics_standard.h"
 
-// Vehicle states:
-#define STATE_OFF             0     // Pollstate 0 - POLLSTATE_OFF      - car is off
-#define STATE_ON              1     // Pollstate 1 - POLLSTATE_ON       - car is on
-#define STATE_RUNNING         2     // Pollstate 2 - POLLSTATE_RUNNING  - car is driving
-#define STATE_CHARGING        3     // Pollstate 3 - POLLSTATE_CHARGING - car is charging
+// CAN buffer access macros: b=byte# 0..7 / n=nibble# 0..15
+#define CAN_BYTE(b)     data[b]
+#define CAN_INT(b)      ((int16_t)CAN_UINT(b))
+#define CAN_UINT(b)     (((UINT)CAN_BYTE(b) << 8) | CAN_BYTE(b+1))
+#define CAN_UINT24(b)   (((uint32_t)CAN_BYTE(b) << 16) | ((UINT)CAN_BYTE(b+1) << 8) | CAN_BYTE(b+2))
+#define CAN_UINT32(b)   (((uint32_t)CAN_BYTE(b) << 24) | ((uint32_t)CAN_BYTE(b+1) << 16)  | ((UINT)CAN_BYTE(b+2) << 8) | CAN_BYTE(b+3))
+#define CAN_NIBL(b)     (can_databuffer[b] & 0x0f)
+#define CAN_NIBH(b)     (can_databuffer[b] >> 4)
+#define CAN_NIB(n)      (((n)&1) ? CAN_NIBL((n)>>1) : CAN_NIBH((n)>>1))
+#define CAN_BIT(b,pos) !!(data[b] & (1<<(pos)))
 
-// RX buffer access macros: b=byte#
-#define RXB_BYTE(b)           m_rxbuf[b]
-#define RXB_UINT16(b)         (((uint16_t)RXB_BYTE(b) << 8) | RXB_BYTE(b+1))
-#define RXB_UINT24(b)         (((uint32_t)RXB_BYTE(b) << 16) | ((uint32_t)RXB_BYTE(b+1) << 8) \
-                               | RXB_BYTE(b+2))
-#define RXB_UINT32(b)         (((uint32_t)RXB_BYTE(b) << 24) | ((uint32_t)RXB_BYTE(b+1) << 16) \
-                               | ((uint32_t)RXB_BYTE(b+2) << 8) | RXB_BYTE(b+3))
-#define RXB_INT8(b)           ((int8_t)RXB_BYTE(b))
-#define RXB_INT16(b)          ((int16_t)RXB_UINT16(b))
-#define RXB_INT32(b)          ((int32_t)RXB_UINT32(b))
-
-namespace
-{
-
-// The parameter namespace for this vehicle
-const char PARAM_NAME[] = "xme";
-
-static const OvmsPoller::poll_pid_t obdii_polls[] =
-    {
-        // VCU Polls
-//        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcusoc, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //SOC Scaled below
-        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcutemp1, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //temp
-        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcutemp2, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //temp
-        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcuspeed, {  0, 0, 1, 30  }, 0, ISOTP_STD }, //speed in KM (maybe cruise setpoint)
-        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcupackvolts, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //Pack Voltage
-        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcu12vamps, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //12v amps?
-        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcuchargervolts, {  0, 0, 15, 15  }, 0, ISOTP_STD }, //charger volts at a guess?
-//        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcuchargeramps, {  0, 0, 5, 5  }, 0, ISOTP_STD }, //charger amps?
-        // BMS Polls
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsStatusPid, {  0, 5, 5, 5  }, 0, ISOTP_STD }, //bms charger state???
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, cellvolts, {  0, 0, 15, 15  }, 0, ISOTP_STD }, //cell volts
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, celltemps, {  0, 0, 15, 15  }, 0, ISOTP_STD }, //cell temps
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmssoc, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms SOC
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmssoh, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms SOH??
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmssocraw, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms raw SOC
-//        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, packamps, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms hv amps to pack
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsccsamps, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
-        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsacamps, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
-//        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsccschargeon, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
-//        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsacchargeon, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
-        { 0, 0, 0x00, 0x00, { 0, 0, 0, 0 }, 0, 0 }
-    };
-charging_profile granny_steps[]  = {
-    {0,98,6375}, // Max charge rate (7200) less charge loss
-    {98,100,2700}, // Observed charge rate
-    {0,0,0},
-    };
-
-charging_profile ccs_steps[] = {
-    {0,20,75000},
-    {20,30,67000},
-    {30,40,59000},
-    {40,50,50000},
-    {50,60,44000},
-    {60,80,37000},
-    {80,83,26600},
-    {83,95,16200},
-    {95,100,5700},
-    {0,0,0},
-};
-
-// Responses to the BMS Status PID
-enum BmsStatus : unsigned char {
-    Off = 0x0,  // Seen when connected but not locked
-    Idle = 0x1,  // When the car does not have the ignition on
-    CcsCharging = 0x2,  // When charging on a rapid CCS charger
-    Charging = 0x3,  // When charging normally
-    Running = 0x4,  // When the ignition is on aux or running
-//    AboutToSleep = 0x8,  // Seen just before going to sleep
-//    Connected = 0xa,  // Connected but not charging
-//    StartingCharge = 0xc  // Seen when the charge was about to start
-};
-
-}  // anon namespace
-
-// OvmsVehicleMaxe6 constructor
- 
 OvmsVehicleMaxe6::OvmsVehicleMaxe6()
-    {
-        ESP_LOGI(TAG, "Start Maxus Euniq 6 vehicle module");
+  {
+  ESP_LOGI(TAG, "Start Maxus Euniq 6 vehicle module");
 
-        // Init CAN:
-        RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
+  // Init CAN:
+  RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
 
-        // Init BMS:
-        BmsSetCellArrangementVoltage(96, 16);
-        BmsSetCellArrangementTemperature(16, 1);
-        BmsSetCellLimitsVoltage(2.0, 5.0);
-        BmsSetCellLimitsTemperature(-39, 200);
-        BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
-        BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
+  // Init CAN buffer:
+  send_can_buffer.id = 0;
+  send_can_buffer.status = 0;
+  memset(send_can_buffer.byte, 0, sizeof(send_can_buffer.byte));
 
-        // Init polling:
-        PollSetThrottling(0);
-        PollSetResponseSeparationTime(1);
-        PollSetState(STATE_OFF);
-        PollSetPidList(m_can1, obdii_polls);
-        
-        // Init VIN:
-        memset(m_vin, 0, sizeof(m_vin));
-        
-        // Init Raw Soc:
-        m_poll_state_metric = MyMetrics.InitInt("xme.state.poll", SM_STALE_MAX, m_poll_state);
-        m_soc_raw = MyMetrics.InitFloat("xme.v.soc.raw", 0, SM_STALE_HIGH, Percentage);
-        m_consump_raw = MyMetrics.InitFloat("xme.v.consump.raw", 0, SM_STALE_HIGH); // temp to monitor bms range
-        m_consumprange_raw = MyMetrics.InitFloat("xme.v.consumprange.raw", 0, SM_STALE_HIGH); // temp to monitor bms range
-        m_watt_hour_raw = MyMetrics.InitFloat("xme.v.watt.hour.raw", 0, SM_STALE_HIGH); // temp to monitor bms range
-        m_poll_bmsstate = MyMetrics.InitFloat("xme.bmsstate.poll", SM_STALE_HIGH); //temp to monitor bms state
-    
-        // Register config params
-        MyConfig.RegisterParam("xme", "Maxus EV configuration", true, true);
+  // Init BMS:
+  BmsSetCellArrangementVoltage(96, 16);
+  BmsSetCellArrangementTemperature(16, 1);
+  BmsSetCellLimitsVoltage(2.0, 5.0);
+  BmsSetCellLimitsTemperature(-39, 200);
+  BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
+  BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
+  
+  // Init Energy:
+  StdMetrics.ms_v_charge_mode->SetValue("standard");
+  StdMetrics.ms_v_env_ctrl_login->SetValue(true);
 
-        
-        // Init Energy:
-        StdMetrics.ms_v_charge_mode->SetValue("standard");
-        StdMetrics.ms_v_env_ctrl_login->SetValue(true);
-        me56_cum_energy_charge_wh = 0;
-    }
-
-//OvmsVehicleMaxe6 destructor
+  // Require GPS:
+  MyEvents.SignalEvent("vehicle.require.gps", NULL);
+  MyEvents.SignalEvent("vehicle.require.gpstime", NULL);
+  }
 
 OvmsVehicleMaxe6::~OvmsVehicleMaxe6()
-    {
-        ESP_LOGI(TAG, "Stop Euniq 6 vehicle module");
-        PollSetPidList(m_can1, NULL);
-    }
-
-// IncomingPollReply:
-
-void OvmsVehicleMaxe6::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length)
-{
-  // init / fill rx buffer:
-  if (job.mlframe == 0) {
-    m_rxbuf.clear();
-    m_rxbuf.reserve(length + job.mlremain);
-  }
-  m_rxbuf.append((char*)data, length);
-  if (job.mlremain)
-    return;
-
-  // response complete:
-    ESP_LOGV(TAG, "IncomingPollReply: PID %02X: len=%d %s", job.pid, m_rxbuf.size(), hexencode(m_rxbuf).c_str());
-    
-    int value1 = (int)data[0];
-    int value2 = ((int)data[0] << 8) + (int)data[1];
-    
-  switch (job.pid)
   {
-      case vcuvin:  // VIN
-          StdMetrics.ms_v_vin->SetValue(m_rxbuf);
-          break;
-      case bmsStatusPid:
-          SetBmsStatus(data[0]);
-          m_poll_bmsstate->SetValue(value1);
-          break;
-          
-            // set status to on  StdMetrics.ms_v_env_on->SetValue(bool( d[7] & 0x10 ));
-      case bmssoh: //soh
-          StdMetrics.ms_v_bat_soh->SetValue(value1);
-          break;
-      case bmssoc: //soc from bms
-          StdMetrics.ms_v_bat_soc->SetValue(value2 / 100.0f);
-          if(StdMetrics.ms_v_bat_soc->AsFloat() >=99.35)StdMetrics.ms_v_bat_soc->SetValue(100.0f);
-          break;
-          
-      case bmssocraw: //soc from bms
-          m_soc_raw->SetValue(value2 / 100.0f);
-          break;
-      case vcutemp1:  // temperature??
-          StdMetrics.ms_v_mot_temp->SetValue(value1 / 10.0f);
-          break;
-      case vcutemp2:  // temperature??
-          StdMetrics.ms_v_env_temp->SetValue(value1 / 10.0f);
-          break;
-      case vcuspeed:  // Speed in Km
-      {
-          vanIsOn = StdMetrics.ms_v_env_on->AsBool();
-          if (vanIsOn)
-          StdMetrics.ms_v_pos_speed->SetValue(value1); // in km
-          else
-              StdMetrics.ms_v_pos_speed->SetValue(0);
-      }
-          break;
-      case vcupackvolts:  // Pack Voltage
-          StdMetrics.ms_v_bat_voltage->SetValue(value2 / 10.0f);
-          break;
-
-
-      case bmsccsamps:
-          if (StdMetrics.ms_v_charge_type->AsString() == "ccs")
-        {
-            StdMetrics.ms_v_bat_current->SetValue((value2 / 10.0f) - ((value2 / 10.0f) * 2)); // converted to negative
-            StdMetrics.ms_v_bat_power->SetValue((((value2 / 10.0f) - ((value2 / 10.0f) * 2)) * StdMetrics.ms_v_bat_voltage->AsFloat()) / 1000.0f);// converted to negtive
-        }
-          break;
-
-      case bmsacamps:
-          if (StdMetrics.ms_v_charge_type->AsString() == "type2")
-        {
-          StdMetrics.ms_v_bat_current->SetValue((StdMetrics.ms_v_bat_power->AsFloat() * 1000) / StdMetrics.ms_v_bat_voltage->AsFloat() ); //
-          
-          //
-          StdMetrics.ms_v_charge_current->SetValue((value2 *2) / 10.0f);
-        }
-          
-          break;
-
-      case vcu12vamps:
-          StdMetrics.ms_v_bat_12v_current->SetValue(value1 / 10.0f);
-          break;
-      case vcuchargervolts:
-          if (StdMetrics.ms_v_charge_type->AsString() == "type2")
-          {
-          StdMetrics.ms_v_charge_voltage->SetValue(value2 - 16140); // possible but always 224 untill found only
-          }
-          break;
-
-      case cellvolts:
-        {
-            // Read battery cell voltages 1-96:
-            BmsRestartCellVoltages();
-            for (int i = 0; i < 96; i++)
-                {
-                    BmsSetCellVoltage(i, RXB_UINT16(i*2) * 0.001f);
-                }
-            break;
-        }
-        case celltemps:
-        {
-            // Read battery cell temperatures 1-20:
-                BmsRestartCellTemperatures();
-            for (int i = 0; i < 20; i++)
-                {
-                    BmsSetCellTemperature(i, RXB_UINT16(i*2) * 0.001f);
-                }
-            break;
-        }
-
-    default:
-    {
-      ESP_LOGW(TAG, "IncomingPollReply: unhandled PID %02X: len=%d %s", job.pid, m_rxbuf.size(), hexencode(m_rxbuf).c_str());
-    }
+  ESP_LOGI(TAG, "Stop Euniq 6 vehicle module");
   }
-}
 
-void OvmsVehicleMaxe6::SetBmsStatus(uint8_t status)
+void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t *p_frame)
 {
-    switch (status) {
-//        case StartingCharge:
-        case Charging:
-            StdMetrics.ms_v_charge_type->SetValue("type2");
-            StdMetrics.ms_v_door_chargeport->SetValue(true);
-            StdMetrics.ms_v_charge_pilot->SetValue(true);
-            StdMetrics.ms_v_charge_inprogress->SetValue(true);
-            //StdMetrics.ms_v_charge_substate->SetValue("onrequest");
-            StdMetrics.ms_v_charge_state->SetValue("charging");
-            StdMetrics.ms_v_charge_climit->SetValue(StdMetrics.ms_v_charge_current->AsFloat());
-            StdMetrics.ms_v_charge_power->SetValue((StdMetrics.ms_v_charge_current->AsFloat() * StdMetrics.ms_v_charge_voltage->AsFloat()) / 1000);
-            PollSetState(STATE_CHARGING);
-            
-            break;
-        case CcsCharging:
-            StdMetrics.ms_v_charge_type->SetValue("ccs");
-            StdMetrics.ms_v_door_chargeport->SetValue(true);
-            StdMetrics.ms_v_charge_pilot->SetValue(true);
-            StdMetrics.ms_v_charge_inprogress->SetValue(true);
-            StdMetrics.ms_v_charge_state->SetValue("charging");
-            //These are added while CCS charging, EVCC won't show up so we set these here
-            StdMetrics.ms_v_charge_current->SetValue(-StdMetrics.ms_v_bat_current->AsFloat());
-            StdMetrics.ms_v_charge_power->SetValue(-StdMetrics.ms_v_bat_power->AsFloat());
-            StdMetrics.ms_v_charge_climit->SetValue(-StdMetrics.ms_v_bat_current->AsFloat());
-            StdMetrics.ms_v_charge_voltage->SetValue(StdMetrics.ms_v_bat_voltage->AsFloat());
-            PollSetState(STATE_CHARGING);
-            break;
-        case Running:
-            StdMetrics.ms_v_env_on->SetValue(true);
-            StdMetrics.ms_v_charge_pilot->SetValue(false);
-            StdMetrics.ms_v_charge_inprogress->SetValue(false);
-            StdMetrics.ms_v_door_chargeport->SetValue(false);
-            StdMetrics.ms_v_charge_type->SetValue("");
-            PollSetState(STATE_RUNNING);
-            break;
-        default:
-            StdMetrics.ms_v_charge_pilot->SetValue(false);
-            StdMetrics.ms_v_charge_inprogress->SetValue(false);
-            StdMetrics.ms_v_door_chargeport->SetValue(false);
-            StdMetrics.ms_v_charge_type->SetValue("");
-            StdMetrics.ms_v_charge_state->SetValue("");
-  /*          if (!StdMetrics.ms_v_charge_inprogress->AsBool())
-            {
-                StdMetrics.ms_v_bat_current->SetValue(0);
-                StdMetrics.ms_v_bat_power->SetValue(0);
-                
-            } */
-            break;
-    }
-}
 
+	uint8_t *d = p_frame->data.u8;
 
+	// Check if response is from synchronous can message
+	if (send_can_buffer.status == 0xff && p_frame->MsgID == (send_can_buffer.id + 0x08))
+	{
+		// Store message bytes so that the async method can continue
+		send_can_buffer.status = 3;
 
-// Can Frames
+		send_can_buffer.byte[0] = d[0];
+		send_can_buffer.byte[1] = d[1];
+		send_can_buffer.byte[2] = d[2];
+		send_can_buffer.byte[3] = d[3];
+		send_can_buffer.byte[4] = d[4];
+		send_can_buffer.byte[5] = d[5];
+		send_can_buffer.byte[6] = d[6];
+		send_can_buffer.byte[7] = d[7];
+	}
 
-void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t* p_frame)
-  {
-      
-//set batt temp
-      StdMetrics.ms_v_bat_temp->SetValue(StdMetrics.ms_v_bat_pack_tavg->AsFloat());
-      
-      uint8_t *d = p_frame->data.u8;
+	/*
+	BASIC METRICS
+	StdMetrics.ms_v_pos_speed 					ok
+	StdMetrics.ms_v_bat_soc 					ok
+	StdMetrics.ms_v_pos_odometer 				ok
 
-      switch (p_frame->MsgID)
-        {
-        case 0x6f2: // broadcast
-            {
-        //Set ideal, est  when CANdata received
-              float soc = StdMetrics.ms_v_bat_soc->AsFloat();
-              // Setup Calculates for Efficient Range
-                    float batTemp = StdMetrics.ms_v_bat_temp->AsFloat();
-                    float effSoh = StdMetrics.ms_v_bat_soh->AsFloat();
-                    float kwhPerKm = 1000/(consumpRange * 59 + consumpRange) / 60;
-                    float kmPerKwh = (1000/kwhPerKm) * 1.609;
-                    //float kmPerKwhAvg = (kmPerKwh * 59 + kmPerKwh) / 60;
-                    m_watt_hour_raw->SetValue(kmPerKwh);
-                    m_consumprange_raw->SetValue(kwhPerKm);
-                    m_consump_raw->SetValue(consumpRange);
-                        
-                    if(kmPerKwh<4.5)kmPerKwh=4.5;
-                    if(kmPerKwh>6.4)kmPerKwh=6.6;
-                    if(batTemp>20)batTemp=20;
-              
-              StdMetrics.ms_v_bat_range_full->SetValue(360);
-              StdMetrics.ms_v_bat_range_ideal->SetValue(360 * soc / 100);
-                //StdMetrics.ms_v_bat_range_est->SetValue(360 * soc / 108);
-              StdMetrics.ms_v_bat_range_est->SetValue(72.7*((kmPerKwh * (1-((20-batTemp)*1.3)/100)*(soc/100))*(effSoh/100)));
-        
-              break;
-        }
-        default:
-          break;
-                
-            case 0x540:  // odometer in KM
-                {
-                    StdMetrics.ms_v_pos_odometer->SetValue(d[0] << 16 | d[1] << 8 | d[2]);// odometer
-                    break;
-                }
-      
-            case 0x389:  // charger or battery temp
-                {
-                float invtemp = d[1];
-                    StdMetrics.ms_v_inv_temp->SetValue(invtemp / 10);
-                break;
-                }
-                
-            case 0x604:  // actual power to HV Battery ( does not work on ccs and maybe ac?\)
-                {
-              //  hvpower = d[5];
-              //      float hvbatpower = (hvpower * 42 / 1000);
-              //  StdMetrics.ms_v_bat_power->SetValue(-hvbatpower);
-                break;
-                }
-    }
+	StdMetrics.ms_v_door_fl 					ok; yes when open, no when closed
+	StdMetrics.ms_v_door_fr 					ok
+	StdMetrics.ms_v_door_rl 					ok
+	StdMetrics.ms_v_door_rr 					ok
+	StdMetrics.ms_v_trunk	 					ok
+	StdMetrics.ms_v_env_locked 					ok
+
+	StdMetrics.ms_v_env_onepedal 				-
+	StdMetrics.ms_v_env_efficiencymode 			-
+	StdMetrics.ms_v_env_regenlevel Percentage 	-
+
+	StdMetrics.ms_v_bat_current 				-
+	StdMetrics.ms_v_bat_voltage 				-
+	StdMetrics.ms_v_bat_power 					wip esta en porcentaje
+
+	StdMetrics.ms_v_charge_inprogress 			ok
+
+	StdMetrics.ms_v_env_on 						ok
+	StdMetrics.ms_v_env_awake 					ok
+
+	StdMetrics.ms_v_env_aux12v					ok
+
+	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FL, value, PSI);
+	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FR, value, PSI);
+	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RL, value, PSI);
+	StdMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RR, value, PSI);
+	*/
+
+	uint8_t *data = p_frame->data.u8;
+
+	switch (p_frame->MsgID)
+	{
+	case 0x0c9:
+	{
+		StdMetrics.ms_v_charge_inprogress->SetValue(
+			CAN_BIT(2,0) && CAN_BIT(2,1) && CAN_BIT(2,2)
+			);
+		break;
+	}
+	case 0x281:
+	{
+		StdMetrics.ms_v_env_locked->SetValue(
+			CAN_BIT(1,0) &&	CAN_BIT(1,2) &&	CAN_BIT(1,4) &&	CAN_BIT(1,6) &&
+			!StdMetrics.ms_v_door_fl->AsBool() &&
+			!StdMetrics.ms_v_door_fr->AsBool() &&
+			!StdMetrics.ms_v_door_rl->AsBool() &&
+			!StdMetrics.ms_v_door_rr->AsBool() &&
+			!StdMetrics.ms_v_door_trunk->AsBool());
+		break;
+	}
+	case 0x46a:
+	{
+		StdMetrics.ms_v_door_fl->SetValue(CAN_BIT(0, 0));
+		StdMetrics.ms_v_door_fr->SetValue(CAN_BIT(0, 3));
+		StdMetrics.ms_v_door_rr->SetValue(CAN_BIT(0, 5));
+		StdMetrics.ms_v_door_rl->SetValue(CAN_BIT(0, 7));
+		StdMetrics.ms_v_door_trunk->SetValue(CAN_BIT(1, 1));
+		break;
+	}
+	case 0x540:
+	{
+		StdMetrics.ms_v_pos_odometer->SetValue(CAN_UINT24(0));
+		break;
+	}
+	case 0x6f0:
+	{
+		StdMetrics.ms_v_pos_speed->SetValue(CAN_BYTE(4));
+		break;
+	}
+	case 0x6f1:
+	{
+		StdMetrics.ms_v_env_awake->SetValue(CAN_BIT(4,7));
+		StdMetrics.ms_v_env_on->SetValue(CAN_BIT(1,4) && CAN_BIT(4,7));
+		break;
+	}
+	case 0x6f2:
+	{
+		StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(1));
+		StdMetrics.ms_v_bat_power->SetValue((CAN_BYTE(2) - 100) * 120, kW); // es porcentaje
+		break;
+	}
+	default:
+		break;
+	}
 }
 
 void OvmsVehicleMaxe6::Ticker1(uint32_t ticker)
 {
-    processEnergy();
-}
-
-// PollerStateTicker: framework callback: check for state changes
-// This is called by VehicleTicker1() just before the next PollerSend().
-
-void OvmsVehicleMaxe6::PollerStateTicker(canbus *bus)
-{
-    bool charging12v = StdMetrics.ms_v_env_charging12v->AsBool();
-    StdMetrics.ms_v_env_charging12v->SetValue(StdMetrics.ms_v_bat_12v_voltage->AsFloat() >= 12.9);
-    //StdMetrics.ms_v_charge_inprogress->SetValue(-StdMetrics.ms_v_bat_power->AsFloat() >=  1.000f);
-    m_poll_state_metric->SetValue(m_poll_state);
-    
-  // Determine new polling state:
- // int poll_state;
-        if (charging12v)
-        {
-          //  poll_state = STATE_ON;
-            PollSetState(STATE_ON);
-            StdMetrics.ms_v_env_awake->SetValue(true);
-        }
-        else
-        {
-         //   poll_state = STATE_OFF;
-            PollSetState(STATE_OFF);
-            StdMetrics.ms_v_env_awake->SetValue(false);
-        }
-}
-
-// Vehicle framework registration
-
-void OvmsVehicleMaxe6::processEnergy()
-{
-    // When called each to battery power for a second is calculated.
-    // This is added to ms_v_bat_energy_recd if regenerating or
-    // ms_v_bat_energy_used if power is being drawn from the battery
-    
-    // Only calculate if the car is turned on and not charging.
-    if (StdMetrics.ms_v_env_awake->AsBool() &&
-        !StdMetrics.ms_v_charge_inprogress->AsBool()) {
-        // Are we in READY state? Ready to drive off.
-        if (StdMetrics.ms_v_env_on->AsBool()) {
-            auto bat_power = StdMetrics.ms_v_bat_power->AsFloat();
-            // Calculate battery power (kW) for one second
-            auto energy = bat_power / 3600.0;
-            // Calculate current (A) used for one second.
-            auto coulombs = (StdMetrics.ms_v_bat_current->AsFloat() / 3600.0);
-            // Car is still parked so trip has not started.
-            // Set all values to zero
-            if (StdMetrics.ms_v_env_drivetime->AsInt() == 0) {
-                ESP_LOGI(TAG, "Trip has started");
-                StdMetrics.ms_v_bat_coulomb_used->SetValue(0);
-                StdMetrics.ms_v_bat_coulomb_recd->SetValue(0);
-                StdMetrics.ms_v_bat_energy_used->SetValue(0);
-                StdMetrics.ms_v_bat_energy_recd->SetValue(0);
-            // Otherwise we are already moving so do calculations
-            }
-            else
-            {
-                // Calculate regeneration power
-                if (bat_power < 0) {
-                    StdMetrics.ms_v_bat_energy_recd->SetValue
-                    (StdMetrics.ms_v_bat_energy_recd->AsFloat() + -(energy));
-                    
-                    StdMetrics.ms_v_bat_coulomb_recd->SetValue
-                    (StdMetrics.ms_v_bat_coulomb_recd->AsFloat() + -(coulombs));
-                    
-                // Calculate power usage. Add power used each second
-                }
-                else
-                {
-                    StdMetrics.ms_v_bat_energy_used->SetValue
-                    (StdMetrics.ms_v_bat_energy_used->AsFloat() + energy);
-                    
-                    StdMetrics.ms_v_bat_coulomb_used->SetValue
-                    (StdMetrics.ms_v_bat_coulomb_used->AsFloat() + coulombs);
-                }
-            }
-        }
-        // Not in READY so must have been turned off
-        else
-        {
-            // We have only just stopped so add trip values to the totals
-            if (StdMetrics.ms_v_env_parktime->AsInt() == 0) {
-                ESP_LOGI(TAG, "Trip has ended");
-                StdMetrics.ms_v_bat_energy_used_total->SetValue
-                (StdMetrics.ms_v_bat_energy_used_total->AsFloat()
-                    + StdMetrics.ms_v_bat_energy_used->AsFloat());
-                
-                StdMetrics.ms_v_bat_energy_recd_total->SetValue
-                (StdMetrics.ms_v_bat_energy_recd_total->AsFloat()
-                 + StdMetrics.ms_v_bat_energy_recd->AsFloat());
-                
-                StdMetrics.ms_v_bat_coulomb_used_total->SetValue
-                (StdMetrics.ms_v_bat_coulomb_used_total->AsFloat()
-                 + StdMetrics.ms_v_bat_coulomb_used->AsFloat());
-                
-                StdMetrics.ms_v_bat_coulomb_recd_total->SetValue
-                (StdMetrics.ms_v_bat_coulomb_recd_total->AsFloat()
-                 + StdMetrics.ms_v_bat_coulomb_recd->AsFloat());
-            }
-        }
-    }
-    
-    // Add cumulative charge energy each second to ms_v_charge_power
-    if(StdMetrics.ms_v_charge_inprogress->AsBool())
-    {
-        me56_cum_energy_charge_wh += StdMetrics.ms_v_charge_power->AsFloat()*1000/3600;
-        StdMetrics.ms_v_charge_kwh->SetValue(me56_cum_energy_charge_wh/1000);
-//        me56_cum_energy_charge_wh += StdMetrics.ms_v_charge_power->AsFloat()/3600;
-//        StdMetrics.ms_v_charge_kwh->SetValue((me56_cum_energy_charge_wh/1000) * 1.609f);
-        
-        int limit_soc      = StdMetrics.ms_v_charge_limit_soc->AsInt(0);
-        float limit_range    = StdMetrics.ms_v_charge_limit_range->AsFloat(0, Kilometers);
-        float max_range      = StdMetrics.ms_v_bat_range_full->AsFloat(0, Kilometers);
-        
-        // Calculate time to reach 100% charge
-        int minsremaining_full = StdMetrics.ms_v_charge_type->AsString() == "ccs" ? calcMinutesRemaining(100, ccs_steps) : calcMinutesRemaining(100, granny_steps);
-        StdMetrics.ms_v_charge_duration_full->SetValue(minsremaining_full);
-        ESP_LOGV(TAG, "Time remaining: %d mins to full", minsremaining_full);
-        
-        // Calculate time to charge to SoC Limit
-        if (limit_soc > 0)
-        {
-            // if limit_soc is set, then calculate remaining time to limit_soc
-            int minsremaining_soc = StdMetrics.ms_v_charge_type->AsString() == "ccs" ? calcMinutesRemaining(limit_soc, ccs_steps) : calcMinutesRemaining(limit_soc, granny_steps);
-            StdMetrics.ms_v_charge_duration_soc->SetValue(minsremaining_soc, Minutes);
-            if ( minsremaining_soc == 0 && !soc_limit_reached && limit_soc >= StdMetrics.ms_v_bat_soc->AsFloat(100))
-            {
-                  MyNotify.NotifyStringf("info", "charge.limit.soc", "Charge limit of %d%% reached", limit_soc);
-                  soc_limit_reached = true;
-            }
-            ESP_LOGV(TAG, "Time remaining: %d mins to %d%% soc", minsremaining_soc, limit_soc);
-        }
-        
-        // Calculate time to charge to Range Limit
-        if (limit_range > 0.0 && max_range > 0.0)
-        {
-            // if range limit is set, then compute required soc and then calculate remaining time to that soc
-            int range_soc = limit_range / max_range * 100.0;
-            int minsremaining_range = StdMetrics.ms_v_charge_type->AsString() == "ccs" ? calcMinutesRemaining(range_soc, ccs_steps) : calcMinutesRemaining(range_soc, granny_steps);
-            StdMetrics.ms_v_charge_duration_range->SetValue(minsremaining_range, Minutes);
-            if ( minsremaining_range == 0 && !range_limit_reached && range_soc >= StdMetrics.ms_v_bat_soc->AsFloat(100))
-            {
-                MyNotify.NotifyStringf("info", "charge.limit.range", "Charge limit of %dkm reached", (int) limit_range);
-                range_limit_reached = true;
-            }
-            ESP_LOGV(TAG, "Time remaining: %d mins for %0.0f km (%d%% soc)", minsremaining_range, limit_range, range_soc);
-        }
-        // When we are not charging set back to zero ready for next charge.
-    }
-    else
-    {
-        me56_cum_energy_charge_wh=0;
-        StdMetrics.ms_v_charge_duration_full->SetValue(0);
-        StdMetrics.ms_v_charge_duration_soc->SetValue(0);
-        StdMetrics.ms_v_charge_duration_range->SetValue(0);
-        soc_limit_reached = false;
-        range_limit_reached = false;
-    }
-}
-
-// Calculate the time to reach the Target and return in minutes
-int OvmsVehicleMaxe6::calcMinutesRemaining(int toSoc, charging_profile charge_steps[])
-{
-    
-    int minutes = 0;
-    int percents_In_Step;
-    int fromSoc = StdMetrics.ms_v_bat_soc->AsInt(100);
-    int batterySize = 72700;
-    float chargespeed = -StdMetrics.ms_v_bat_power->AsFloat() * 1000;
-
-    for (int i = 0; charge_steps[i].toPercent != 0; i++) {
-          if (charge_steps[i].toPercent > fromSoc && charge_steps[i].fromPercent<toSoc) {
-                 percents_In_Step = (charge_steps[i].toPercent>toSoc ? toSoc : charge_steps[i].toPercent) - (charge_steps[i].fromPercent<fromSoc ? fromSoc : charge_steps[i].fromPercent);
-                 minutes += batterySize * percents_In_Step * 0.6 / (chargespeed<charge_steps[i].maxChargeSpeed ? chargespeed : charge_steps[i].maxChargeSpeed);
-          }
-    }
-    return minutes;
-}
-
-
-// Calculate wh/km
-void OvmsVehicleMaxe6::calculateEfficiency()
-    {
-    float consumption = 0;
-        if (StdMetrics.ms_v_pos_speed->AsFloat() >= 5) //temp removed till speed found
-        //if (StdMetrics.ms_v_env_on->AsBool()) //Temp till speed found
-            consumption = ABS(StdMetrics.ms_v_bat_power->AsFloat(0, Watts)) / StdMetrics.ms_v_pos_speed->AsFloat();
-    StdMetrics.ms_v_bat_consumption->SetValue((StdMetrics.ms_v_bat_consumption->AsFloat() * 29 + consumption) / 30);
-        consumpRange = ABS(StdMetrics.ms_v_bat_consumption->AsFloat());
-        
-    
-    }
-
-//Called by OVMS when a config param is changed
-void OvmsVehicleMaxe6::ConfigChanged(OvmsConfigParam* param)
-{
-    if (param && param->GetName() != PARAM_NAME)
-    {
-        return;
-    }
-
-    ESP_LOGI(TAG, "%s config changed", PARAM_NAME);
-
-    // Instances:
-    // xme
-    //  suffsoc              Sufficient SOC [%] (Default: 0=disabled)
-    //  suffrange            Sufficient range [km] (Default: 0=disabled)
-    StdMetrics.ms_v_charge_limit_soc->SetValue(
-            (float) MyConfig.GetParamValueInt("xme", "suffsoc"),   Percentage );
-    
-    if (MyConfig.GetParamValue("vehicle", "units.distance") == "K")
-    {
-        StdMetrics.ms_v_charge_limit_range->SetValue(
-                (float) MyConfig.GetParamValueInt("xme", "suffrange"), Kilometers );
-    }
-    else
-    {
-        StdMetrics.ms_v_charge_limit_range->SetValue(
-            (float) MyConfig.GetParamValueInt("xme", "suffrange"), Miles );
-    }
 }
 
 class OvmsVehicleMaxe6Init

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
@@ -1,0 +1,645 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th August 2024
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2021       Jaime Middleton / Tucar
+;    (C) 2021       Axel Troncoso   / Tucar
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#include "ovms_log.h"
+static const char *TAG = "v-maxe6";
+
+#include <stdio.h>
+#include "vehicle_me6.h"
+#include "me56_pids.h"
+#include "ovms_notify.h"
+#include <algorithm>
+#include "metrics_standard.h"
+
+// Vehicle states:
+#define STATE_OFF             0     // Pollstate 0 - POLLSTATE_OFF      - car is off
+#define STATE_ON              1     // Pollstate 1 - POLLSTATE_ON       - car is on
+#define STATE_RUNNING         2     // Pollstate 2 - POLLSTATE_RUNNING  - car is driving
+#define STATE_CHARGING        3     // Pollstate 3 - POLLSTATE_CHARGING - car is charging
+
+// RX buffer access macros: b=byte#
+#define RXB_BYTE(b)           m_rxbuf[b]
+#define RXB_UINT16(b)         (((uint16_t)RXB_BYTE(b) << 8) | RXB_BYTE(b+1))
+#define RXB_UINT24(b)         (((uint32_t)RXB_BYTE(b) << 16) | ((uint32_t)RXB_BYTE(b+1) << 8) \
+                               | RXB_BYTE(b+2))
+#define RXB_UINT32(b)         (((uint32_t)RXB_BYTE(b) << 24) | ((uint32_t)RXB_BYTE(b+1) << 16) \
+                               | ((uint32_t)RXB_BYTE(b+2) << 8) | RXB_BYTE(b+3))
+#define RXB_INT8(b)           ((int8_t)RXB_BYTE(b))
+#define RXB_INT16(b)          ((int16_t)RXB_UINT16(b))
+#define RXB_INT32(b)          ((int32_t)RXB_UINT32(b))
+
+namespace
+{
+
+// The parameter namespace for this vehicle
+const char PARAM_NAME[] = "xme";
+
+static const OvmsPoller::poll_pid_t obdii_polls[] =
+    {
+        // VCU Polls
+//        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcusoc, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //SOC Scaled below
+        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcutemp1, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //temp
+        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcutemp2, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //temp
+        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcuspeed, {  0, 0, 1, 30  }, 0, ISOTP_STD }, //speed in KM (maybe cruise setpoint)
+        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcupackvolts, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //Pack Voltage
+        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcu12vamps, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //12v amps?
+        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcuchargervolts, {  0, 0, 15, 15  }, 0, ISOTP_STD }, //charger volts at a guess?
+//        { vcutx, vcurx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, vcuchargeramps, {  0, 0, 5, 5  }, 0, ISOTP_STD }, //charger amps?
+        // BMS Polls
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsStatusPid, {  0, 5, 5, 5  }, 0, ISOTP_STD }, //bms charger state???
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, cellvolts, {  0, 0, 15, 15  }, 0, ISOTP_STD }, //cell volts
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, celltemps, {  0, 0, 15, 15  }, 0, ISOTP_STD }, //cell temps
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmssoc, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms SOC
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmssoh, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms SOH??
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmssocraw, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms raw SOC
+//        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, packamps, {  0, 0, 30, 30  }, 0, ISOTP_STD }, //bms hv amps to pack
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsccsamps, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
+        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsacamps, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
+//        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsccschargeon, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
+//        { bmstx, bmsrx, VEHICLE_POLL_TYPE_OBDIIEXTENDED, bmsacchargeon, {  0, 0, 15, 15  }, 0, ISOTP_STD }, // looks CCS state
+        { 0, 0, 0x00, 0x00, { 0, 0, 0, 0 }, 0, 0 }
+    };
+charging_profile granny_steps[]  = {
+    {0,98,6375}, // Max charge rate (7200) less charge loss
+    {98,100,2700}, // Observed charge rate
+    {0,0,0},
+    };
+
+charging_profile ccs_steps[] = {
+    {0,20,75000},
+    {20,30,67000},
+    {30,40,59000},
+    {40,50,50000},
+    {50,60,44000},
+    {60,80,37000},
+    {80,83,26600},
+    {83,95,16200},
+    {95,100,5700},
+    {0,0,0},
+};
+
+// Responses to the BMS Status PID
+enum BmsStatus : unsigned char {
+    Off = 0x0,  // Seen when connected but not locked
+    Idle = 0x1,  // When the car does not have the ignition on
+    CcsCharging = 0x2,  // When charging on a rapid CCS charger
+    Charging = 0x3,  // When charging normally
+    Running = 0x4,  // When the ignition is on aux or running
+//    AboutToSleep = 0x8,  // Seen just before going to sleep
+//    Connected = 0xa,  // Connected but not charging
+//    StartingCharge = 0xc  // Seen when the charge was about to start
+};
+
+}  // anon namespace
+
+// OvmsVehicleMaxe6 constructor
+ 
+OvmsVehicleMaxe6::OvmsVehicleMaxe6()
+    {
+        ESP_LOGI(TAG, "Start Maxus Euniq 6 vehicle module");
+
+        // Init CAN:
+        RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
+
+        // Init BMS:
+        BmsSetCellArrangementVoltage(96, 16);
+        BmsSetCellArrangementTemperature(16, 1);
+        BmsSetCellLimitsVoltage(2.0, 5.0);
+        BmsSetCellLimitsTemperature(-39, 200);
+        BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
+        BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
+
+        // Init polling:
+        PollSetThrottling(0);
+        PollSetResponseSeparationTime(1);
+        PollSetState(STATE_OFF);
+        PollSetPidList(m_can1, obdii_polls);
+        
+        // Init VIN:
+        memset(m_vin, 0, sizeof(m_vin));
+        
+        // Init Raw Soc:
+        m_poll_state_metric = MyMetrics.InitInt("xme.state.poll", SM_STALE_MAX, m_poll_state);
+        m_soc_raw = MyMetrics.InitFloat("xme.v.soc.raw", 0, SM_STALE_HIGH, Percentage);
+        m_consump_raw = MyMetrics.InitFloat("xme.v.consump.raw", 0, SM_STALE_HIGH); // temp to monitor bms range
+        m_consumprange_raw = MyMetrics.InitFloat("xme.v.consumprange.raw", 0, SM_STALE_HIGH); // temp to monitor bms range
+        m_watt_hour_raw = MyMetrics.InitFloat("xme.v.watt.hour.raw", 0, SM_STALE_HIGH); // temp to monitor bms range
+        m_poll_bmsstate = MyMetrics.InitFloat("xme.bmsstate.poll", SM_STALE_HIGH); //temp to monitor bms state
+    
+        // Register config params
+        MyConfig.RegisterParam("xme", "Maxus EV configuration", true, true);
+
+        
+        // Init Energy:
+        StdMetrics.ms_v_charge_mode->SetValue("standard");
+        StdMetrics.ms_v_env_ctrl_login->SetValue(true);
+        me56_cum_energy_charge_wh = 0;
+    }
+
+//OvmsVehicleMaxe6 destructor
+
+OvmsVehicleMaxe6::~OvmsVehicleMaxe6()
+    {
+        ESP_LOGI(TAG, "Stop Euniq 6 vehicle module");
+        PollSetPidList(m_can1, NULL);
+    }
+
+// IncomingPollReply:
+
+void OvmsVehicleMaxe6::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length)
+{
+  // init / fill rx buffer:
+  if (job.mlframe == 0) {
+    m_rxbuf.clear();
+    m_rxbuf.reserve(length + job.mlremain);
+  }
+  m_rxbuf.append((char*)data, length);
+  if (job.mlremain)
+    return;
+
+  // response complete:
+    ESP_LOGV(TAG, "IncomingPollReply: PID %02X: len=%d %s", job.pid, m_rxbuf.size(), hexencode(m_rxbuf).c_str());
+    
+    int value1 = (int)data[0];
+    int value2 = ((int)data[0] << 8) + (int)data[1];
+    
+  switch (job.pid)
+  {
+      case vcuvin:  // VIN
+          StdMetrics.ms_v_vin->SetValue(m_rxbuf);
+          break;
+      case bmsStatusPid:
+          SetBmsStatus(data[0]);
+          m_poll_bmsstate->SetValue(value1);
+          break;
+          
+            // set status to on  StdMetrics.ms_v_env_on->SetValue(bool( d[7] & 0x10 ));
+      case bmssoh: //soh
+          StdMetrics.ms_v_bat_soh->SetValue(value1);
+          break;
+      case bmssoc: //soc from bms
+          StdMetrics.ms_v_bat_soc->SetValue(value2 / 100.0f);
+          if(StdMetrics.ms_v_bat_soc->AsFloat() >=99.35)StdMetrics.ms_v_bat_soc->SetValue(100.0f);
+          break;
+          
+      case bmssocraw: //soc from bms
+          m_soc_raw->SetValue(value2 / 100.0f);
+          break;
+      case vcutemp1:  // temperature??
+          StdMetrics.ms_v_mot_temp->SetValue(value1 / 10.0f);
+          break;
+      case vcutemp2:  // temperature??
+          StdMetrics.ms_v_env_temp->SetValue(value1 / 10.0f);
+          break;
+      case vcuspeed:  // Speed in Km
+      {
+          vanIsOn = StdMetrics.ms_v_env_on->AsBool();
+          if (vanIsOn)
+          StdMetrics.ms_v_pos_speed->SetValue(value1); // in km
+          else
+              StdMetrics.ms_v_pos_speed->SetValue(0);
+      }
+          break;
+      case vcupackvolts:  // Pack Voltage
+          StdMetrics.ms_v_bat_voltage->SetValue(value2 / 10.0f);
+          break;
+
+
+      case bmsccsamps:
+          if (StdMetrics.ms_v_charge_type->AsString() == "ccs")
+        {
+            StdMetrics.ms_v_bat_current->SetValue((value2 / 10.0f) - ((value2 / 10.0f) * 2)); // converted to negative
+            StdMetrics.ms_v_bat_power->SetValue((((value2 / 10.0f) - ((value2 / 10.0f) * 2)) * StdMetrics.ms_v_bat_voltage->AsFloat()) / 1000.0f);// converted to negtive
+        }
+          break;
+
+      case bmsacamps:
+          if (StdMetrics.ms_v_charge_type->AsString() == "type2")
+        {
+          StdMetrics.ms_v_bat_current->SetValue((StdMetrics.ms_v_bat_power->AsFloat() * 1000) / StdMetrics.ms_v_bat_voltage->AsFloat() ); //
+          
+          //
+          StdMetrics.ms_v_charge_current->SetValue((value2 *2) / 10.0f);
+        }
+          
+          break;
+
+      case vcu12vamps:
+          StdMetrics.ms_v_bat_12v_current->SetValue(value1 / 10.0f);
+          break;
+      case vcuchargervolts:
+          if (StdMetrics.ms_v_charge_type->AsString() == "type2")
+          {
+          StdMetrics.ms_v_charge_voltage->SetValue(value2 - 16140); // possible but always 224 untill found only
+          }
+          break;
+
+      case cellvolts:
+        {
+            // Read battery cell voltages 1-96:
+            BmsRestartCellVoltages();
+            for (int i = 0; i < 96; i++)
+                {
+                    BmsSetCellVoltage(i, RXB_UINT16(i*2) * 0.001f);
+                }
+            break;
+        }
+        case celltemps:
+        {
+            // Read battery cell temperatures 1-20:
+                BmsRestartCellTemperatures();
+            for (int i = 0; i < 20; i++)
+                {
+                    BmsSetCellTemperature(i, RXB_UINT16(i*2) * 0.001f);
+                }
+            break;
+        }
+
+    default:
+    {
+      ESP_LOGW(TAG, "IncomingPollReply: unhandled PID %02X: len=%d %s", job.pid, m_rxbuf.size(), hexencode(m_rxbuf).c_str());
+    }
+  }
+}
+
+void OvmsVehicleMaxe6::SetBmsStatus(uint8_t status)
+{
+    switch (status) {
+//        case StartingCharge:
+        case Charging:
+            StdMetrics.ms_v_charge_type->SetValue("type2");
+            StdMetrics.ms_v_door_chargeport->SetValue(true);
+            StdMetrics.ms_v_charge_pilot->SetValue(true);
+            StdMetrics.ms_v_charge_inprogress->SetValue(true);
+            //StdMetrics.ms_v_charge_substate->SetValue("onrequest");
+            StdMetrics.ms_v_charge_state->SetValue("charging");
+            StdMetrics.ms_v_charge_climit->SetValue(StdMetrics.ms_v_charge_current->AsFloat());
+            StdMetrics.ms_v_charge_power->SetValue((StdMetrics.ms_v_charge_current->AsFloat() * StdMetrics.ms_v_charge_voltage->AsFloat()) / 1000);
+            PollSetState(STATE_CHARGING);
+            
+            break;
+        case CcsCharging:
+            StdMetrics.ms_v_charge_type->SetValue("ccs");
+            StdMetrics.ms_v_door_chargeport->SetValue(true);
+            StdMetrics.ms_v_charge_pilot->SetValue(true);
+            StdMetrics.ms_v_charge_inprogress->SetValue(true);
+            StdMetrics.ms_v_charge_state->SetValue("charging");
+            //These are added while CCS charging, EVCC won't show up so we set these here
+            StdMetrics.ms_v_charge_current->SetValue(-StdMetrics.ms_v_bat_current->AsFloat());
+            StdMetrics.ms_v_charge_power->SetValue(-StdMetrics.ms_v_bat_power->AsFloat());
+            StdMetrics.ms_v_charge_climit->SetValue(-StdMetrics.ms_v_bat_current->AsFloat());
+            StdMetrics.ms_v_charge_voltage->SetValue(StdMetrics.ms_v_bat_voltage->AsFloat());
+            PollSetState(STATE_CHARGING);
+            break;
+        case Running:
+            StdMetrics.ms_v_env_on->SetValue(true);
+            StdMetrics.ms_v_charge_pilot->SetValue(false);
+            StdMetrics.ms_v_charge_inprogress->SetValue(false);
+            StdMetrics.ms_v_door_chargeport->SetValue(false);
+            StdMetrics.ms_v_charge_type->SetValue("");
+            PollSetState(STATE_RUNNING);
+            break;
+        default:
+            StdMetrics.ms_v_charge_pilot->SetValue(false);
+            StdMetrics.ms_v_charge_inprogress->SetValue(false);
+            StdMetrics.ms_v_door_chargeport->SetValue(false);
+            StdMetrics.ms_v_charge_type->SetValue("");
+            StdMetrics.ms_v_charge_state->SetValue("");
+  /*          if (!StdMetrics.ms_v_charge_inprogress->AsBool())
+            {
+                StdMetrics.ms_v_bat_current->SetValue(0);
+                StdMetrics.ms_v_bat_power->SetValue(0);
+                
+            } */
+            break;
+    }
+}
+
+
+
+// Can Frames
+
+void OvmsVehicleMaxe6::IncomingFrameCan1(CAN_frame_t* p_frame)
+  {
+      
+//set batt temp
+      StdMetrics.ms_v_bat_temp->SetValue(StdMetrics.ms_v_bat_pack_tavg->AsFloat());
+      
+      uint8_t *d = p_frame->data.u8;
+
+      switch (p_frame->MsgID)
+        {
+        case 0x6f2: // broadcast
+            {
+        //Set ideal, est  when CANdata received
+              float soc = StdMetrics.ms_v_bat_soc->AsFloat();
+              // Setup Calculates for Efficient Range
+                    float batTemp = StdMetrics.ms_v_bat_temp->AsFloat();
+                    float effSoh = StdMetrics.ms_v_bat_soh->AsFloat();
+                    float kwhPerKm = 1000/(consumpRange * 59 + consumpRange) / 60;
+                    float kmPerKwh = (1000/kwhPerKm) * 1.609;
+                    //float kmPerKwhAvg = (kmPerKwh * 59 + kmPerKwh) / 60;
+                    m_watt_hour_raw->SetValue(kmPerKwh);
+                    m_consumprange_raw->SetValue(kwhPerKm);
+                    m_consump_raw->SetValue(consumpRange);
+                        
+                    if(kmPerKwh<4.5)kmPerKwh=4.5;
+                    if(kmPerKwh>6.4)kmPerKwh=6.6;
+                    if(batTemp>20)batTemp=20;
+              
+              StdMetrics.ms_v_bat_range_full->SetValue(360);
+              StdMetrics.ms_v_bat_range_ideal->SetValue(360 * soc / 100);
+                //StdMetrics.ms_v_bat_range_est->SetValue(360 * soc / 108);
+              StdMetrics.ms_v_bat_range_est->SetValue(72.7*((kmPerKwh * (1-((20-batTemp)*1.3)/100)*(soc/100))*(effSoh/100)));
+        
+              break;
+        }
+        default:
+          break;
+                
+            case 0x540:  // odometer in KM
+                {
+                    StdMetrics.ms_v_pos_odometer->SetValue(d[0] << 16 | d[1] << 8 | d[2]);// odometer
+                    break;
+                }
+      
+            case 0x389:  // charger or battery temp
+                {
+                float invtemp = d[1];
+                    StdMetrics.ms_v_inv_temp->SetValue(invtemp / 10);
+                break;
+                }
+                
+            case 0x604:  // actual power to HV Battery ( does not work on ccs and maybe ac?\)
+                {
+              //  hvpower = d[5];
+              //      float hvbatpower = (hvpower * 42 / 1000);
+              //  StdMetrics.ms_v_bat_power->SetValue(-hvbatpower);
+                break;
+                }
+    }
+}
+
+void OvmsVehicleMaxe6::Ticker1(uint32_t ticker)
+{
+    processEnergy();
+}
+
+// PollerStateTicker: framework callback: check for state changes
+// This is called by VehicleTicker1() just before the next PollerSend().
+
+void OvmsVehicleMaxe6::PollerStateTicker(canbus *bus)
+{
+    bool charging12v = StdMetrics.ms_v_env_charging12v->AsBool();
+    StdMetrics.ms_v_env_charging12v->SetValue(StdMetrics.ms_v_bat_12v_voltage->AsFloat() >= 12.9);
+    //StdMetrics.ms_v_charge_inprogress->SetValue(-StdMetrics.ms_v_bat_power->AsFloat() >=  1.000f);
+    m_poll_state_metric->SetValue(m_poll_state);
+    
+  // Determine new polling state:
+ // int poll_state;
+        if (charging12v)
+        {
+          //  poll_state = STATE_ON;
+            PollSetState(STATE_ON);
+            StdMetrics.ms_v_env_awake->SetValue(true);
+        }
+        else
+        {
+         //   poll_state = STATE_OFF;
+            PollSetState(STATE_OFF);
+            StdMetrics.ms_v_env_awake->SetValue(false);
+        }
+}
+
+// Vehicle framework registration
+
+void OvmsVehicleMaxe6::processEnergy()
+{
+    // When called each to battery power for a second is calculated.
+    // This is added to ms_v_bat_energy_recd if regenerating or
+    // ms_v_bat_energy_used if power is being drawn from the battery
+    
+    // Only calculate if the car is turned on and not charging.
+    if (StdMetrics.ms_v_env_awake->AsBool() &&
+        !StdMetrics.ms_v_charge_inprogress->AsBool()) {
+        // Are we in READY state? Ready to drive off.
+        if (StdMetrics.ms_v_env_on->AsBool()) {
+            auto bat_power = StdMetrics.ms_v_bat_power->AsFloat();
+            // Calculate battery power (kW) for one second
+            auto energy = bat_power / 3600.0;
+            // Calculate current (A) used for one second.
+            auto coulombs = (StdMetrics.ms_v_bat_current->AsFloat() / 3600.0);
+            // Car is still parked so trip has not started.
+            // Set all values to zero
+            if (StdMetrics.ms_v_env_drivetime->AsInt() == 0) {
+                ESP_LOGI(TAG, "Trip has started");
+                StdMetrics.ms_v_bat_coulomb_used->SetValue(0);
+                StdMetrics.ms_v_bat_coulomb_recd->SetValue(0);
+                StdMetrics.ms_v_bat_energy_used->SetValue(0);
+                StdMetrics.ms_v_bat_energy_recd->SetValue(0);
+            // Otherwise we are already moving so do calculations
+            }
+            else
+            {
+                // Calculate regeneration power
+                if (bat_power < 0) {
+                    StdMetrics.ms_v_bat_energy_recd->SetValue
+                    (StdMetrics.ms_v_bat_energy_recd->AsFloat() + -(energy));
+                    
+                    StdMetrics.ms_v_bat_coulomb_recd->SetValue
+                    (StdMetrics.ms_v_bat_coulomb_recd->AsFloat() + -(coulombs));
+                    
+                // Calculate power usage. Add power used each second
+                }
+                else
+                {
+                    StdMetrics.ms_v_bat_energy_used->SetValue
+                    (StdMetrics.ms_v_bat_energy_used->AsFloat() + energy);
+                    
+                    StdMetrics.ms_v_bat_coulomb_used->SetValue
+                    (StdMetrics.ms_v_bat_coulomb_used->AsFloat() + coulombs);
+                }
+            }
+        }
+        // Not in READY so must have been turned off
+        else
+        {
+            // We have only just stopped so add trip values to the totals
+            if (StdMetrics.ms_v_env_parktime->AsInt() == 0) {
+                ESP_LOGI(TAG, "Trip has ended");
+                StdMetrics.ms_v_bat_energy_used_total->SetValue
+                (StdMetrics.ms_v_bat_energy_used_total->AsFloat()
+                    + StdMetrics.ms_v_bat_energy_used->AsFloat());
+                
+                StdMetrics.ms_v_bat_energy_recd_total->SetValue
+                (StdMetrics.ms_v_bat_energy_recd_total->AsFloat()
+                 + StdMetrics.ms_v_bat_energy_recd->AsFloat());
+                
+                StdMetrics.ms_v_bat_coulomb_used_total->SetValue
+                (StdMetrics.ms_v_bat_coulomb_used_total->AsFloat()
+                 + StdMetrics.ms_v_bat_coulomb_used->AsFloat());
+                
+                StdMetrics.ms_v_bat_coulomb_recd_total->SetValue
+                (StdMetrics.ms_v_bat_coulomb_recd_total->AsFloat()
+                 + StdMetrics.ms_v_bat_coulomb_recd->AsFloat());
+            }
+        }
+    }
+    
+    // Add cumulative charge energy each second to ms_v_charge_power
+    if(StdMetrics.ms_v_charge_inprogress->AsBool())
+    {
+        me56_cum_energy_charge_wh += StdMetrics.ms_v_charge_power->AsFloat()*1000/3600;
+        StdMetrics.ms_v_charge_kwh->SetValue(me56_cum_energy_charge_wh/1000);
+//        me56_cum_energy_charge_wh += StdMetrics.ms_v_charge_power->AsFloat()/3600;
+//        StdMetrics.ms_v_charge_kwh->SetValue((me56_cum_energy_charge_wh/1000) * 1.609f);
+        
+        int limit_soc      = StdMetrics.ms_v_charge_limit_soc->AsInt(0);
+        float limit_range    = StdMetrics.ms_v_charge_limit_range->AsFloat(0, Kilometers);
+        float max_range      = StdMetrics.ms_v_bat_range_full->AsFloat(0, Kilometers);
+        
+        // Calculate time to reach 100% charge
+        int minsremaining_full = StdMetrics.ms_v_charge_type->AsString() == "ccs" ? calcMinutesRemaining(100, ccs_steps) : calcMinutesRemaining(100, granny_steps);
+        StdMetrics.ms_v_charge_duration_full->SetValue(minsremaining_full);
+        ESP_LOGV(TAG, "Time remaining: %d mins to full", minsremaining_full);
+        
+        // Calculate time to charge to SoC Limit
+        if (limit_soc > 0)
+        {
+            // if limit_soc is set, then calculate remaining time to limit_soc
+            int minsremaining_soc = StdMetrics.ms_v_charge_type->AsString() == "ccs" ? calcMinutesRemaining(limit_soc, ccs_steps) : calcMinutesRemaining(limit_soc, granny_steps);
+            StdMetrics.ms_v_charge_duration_soc->SetValue(minsremaining_soc, Minutes);
+            if ( minsremaining_soc == 0 && !soc_limit_reached && limit_soc >= StdMetrics.ms_v_bat_soc->AsFloat(100))
+            {
+                  MyNotify.NotifyStringf("info", "charge.limit.soc", "Charge limit of %d%% reached", limit_soc);
+                  soc_limit_reached = true;
+            }
+            ESP_LOGV(TAG, "Time remaining: %d mins to %d%% soc", minsremaining_soc, limit_soc);
+        }
+        
+        // Calculate time to charge to Range Limit
+        if (limit_range > 0.0 && max_range > 0.0)
+        {
+            // if range limit is set, then compute required soc and then calculate remaining time to that soc
+            int range_soc = limit_range / max_range * 100.0;
+            int minsremaining_range = StdMetrics.ms_v_charge_type->AsString() == "ccs" ? calcMinutesRemaining(range_soc, ccs_steps) : calcMinutesRemaining(range_soc, granny_steps);
+            StdMetrics.ms_v_charge_duration_range->SetValue(minsremaining_range, Minutes);
+            if ( minsremaining_range == 0 && !range_limit_reached && range_soc >= StdMetrics.ms_v_bat_soc->AsFloat(100))
+            {
+                MyNotify.NotifyStringf("info", "charge.limit.range", "Charge limit of %dkm reached", (int) limit_range);
+                range_limit_reached = true;
+            }
+            ESP_LOGV(TAG, "Time remaining: %d mins for %0.0f km (%d%% soc)", minsremaining_range, limit_range, range_soc);
+        }
+        // When we are not charging set back to zero ready for next charge.
+    }
+    else
+    {
+        me56_cum_energy_charge_wh=0;
+        StdMetrics.ms_v_charge_duration_full->SetValue(0);
+        StdMetrics.ms_v_charge_duration_soc->SetValue(0);
+        StdMetrics.ms_v_charge_duration_range->SetValue(0);
+        soc_limit_reached = false;
+        range_limit_reached = false;
+    }
+}
+
+// Calculate the time to reach the Target and return in minutes
+int OvmsVehicleMaxe6::calcMinutesRemaining(int toSoc, charging_profile charge_steps[])
+{
+    
+    int minutes = 0;
+    int percents_In_Step;
+    int fromSoc = StdMetrics.ms_v_bat_soc->AsInt(100);
+    int batterySize = 72700;
+    float chargespeed = -StdMetrics.ms_v_bat_power->AsFloat() * 1000;
+
+    for (int i = 0; charge_steps[i].toPercent != 0; i++) {
+          if (charge_steps[i].toPercent > fromSoc && charge_steps[i].fromPercent<toSoc) {
+                 percents_In_Step = (charge_steps[i].toPercent>toSoc ? toSoc : charge_steps[i].toPercent) - (charge_steps[i].fromPercent<fromSoc ? fromSoc : charge_steps[i].fromPercent);
+                 minutes += batterySize * percents_In_Step * 0.6 / (chargespeed<charge_steps[i].maxChargeSpeed ? chargespeed : charge_steps[i].maxChargeSpeed);
+          }
+    }
+    return minutes;
+}
+
+
+// Calculate wh/km
+void OvmsVehicleMaxe6::calculateEfficiency()
+    {
+    float consumption = 0;
+        if (StdMetrics.ms_v_pos_speed->AsFloat() >= 5) //temp removed till speed found
+        //if (StdMetrics.ms_v_env_on->AsBool()) //Temp till speed found
+            consumption = ABS(StdMetrics.ms_v_bat_power->AsFloat(0, Watts)) / StdMetrics.ms_v_pos_speed->AsFloat();
+    StdMetrics.ms_v_bat_consumption->SetValue((StdMetrics.ms_v_bat_consumption->AsFloat() * 29 + consumption) / 30);
+        consumpRange = ABS(StdMetrics.ms_v_bat_consumption->AsFloat());
+        
+    
+    }
+
+//Called by OVMS when a config param is changed
+void OvmsVehicleMaxe6::ConfigChanged(OvmsConfigParam* param)
+{
+    if (param && param->GetName() != PARAM_NAME)
+    {
+        return;
+    }
+
+    ESP_LOGI(TAG, "%s config changed", PARAM_NAME);
+
+    // Instances:
+    // xme
+    //  suffsoc              Sufficient SOC [%] (Default: 0=disabled)
+    //  suffrange            Sufficient range [km] (Default: 0=disabled)
+    StdMetrics.ms_v_charge_limit_soc->SetValue(
+            (float) MyConfig.GetParamValueInt("xme", "suffsoc"),   Percentage );
+    
+    if (MyConfig.GetParamValue("vehicle", "units.distance") == "K")
+    {
+        StdMetrics.ms_v_charge_limit_range->SetValue(
+                (float) MyConfig.GetParamValueInt("xme", "suffrange"), Kilometers );
+    }
+    else
+    {
+        StdMetrics.ms_v_charge_limit_range->SetValue(
+            (float) MyConfig.GetParamValueInt("xme", "suffrange"), Miles );
+    }
+}
+
+class OvmsVehicleMaxe6Init
+  {
+  public: OvmsVehicleMaxe6Init();
+  } OvmsVehicleMaxe6Init  __attribute__ ((init_priority (9000)));
+
+OvmsVehicleMaxe6Init::OvmsVehicleMaxe6Init()
+  {
+  ESP_LOGI(TAG, "Registering Vehicle: Maxus Euniq 6 (9000)");
+
+  MyVehicleFactory.RegisterVehicle<OvmsVehicleMaxe6>("ME56","Maxus Euniq 6");
+  }

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.cpp
@@ -168,5 +168,5 @@ OvmsVehicleMaxe6Init::OvmsVehicleMaxe6Init()
 {
   ESP_LOGI(TAG, "Registering Vehicle: Maxus Euniq 6 (9000)");
 
-  MyVehicleFactory.RegisterVehicle<OvmsVehicleMaxe6>("ME56","Maxus Euniq 6");
+  MyVehicleFactory.RegisterVehicle<OvmsVehicleMaxe6>("ME6","Maxus Euniq 6");
 }

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
@@ -49,9 +49,27 @@ public:
 
 protected:
   void Ticker1(uint32_t ticker) override;
+  void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     
 private:
   void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+
+  enum class PollState
+  {
+    OFF,
+    RUNNING,
+    CHARGING
+  };
+
+  void HandleCharging();
+  void HandleChargeStop();
+  void HandleCarOn();
+  void HandleCarOff();
+
+  void SetChargeType();
+  void ResetChargeType();
+
+  PollState GetPollState();
 };
 
 #endif //#ifndef __VEHICLE_ME6_H__

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
@@ -52,12 +52,6 @@ protected:
     
 private:
   void IncomingFrameCan1(CAN_frame_t* p_frame) override;
-
-  struct {
-    uint8_t byte[8];
-    uint8_t status;
-    uint16_t id;
-  } send_can_buffer;
 };
 
 #endif //#ifndef __VEHICLE_ME6_H__

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
@@ -41,24 +41,24 @@
 using namespace std;
 
 class OvmsVehicleMaxe6 : public OvmsVehicle
-  {
-  public:
+{
+public:
 
-    OvmsVehicleMaxe6();
-    ~OvmsVehicleMaxe6();
+  OvmsVehicleMaxe6();
+  ~OvmsVehicleMaxe6();
 
-  protected:
-    void Ticker1(uint32_t ticker) override;
-      
-  private:
-    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
-  
-    struct {
-      uint8_t byte[8];
-      uint8_t status;
-      uint16_t id;
-    } send_can_buffer;
-  };
+protected:
+  void Ticker1(uint32_t ticker) override;
+    
+private:
+  void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+
+  struct {
+    uint8_t byte[8];
+    uint8_t status;
+    uint16_t id;
+  } send_can_buffer;
+};
 
 #endif //#ifndef __VEHICLE_ME6_H__
 

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
@@ -40,57 +40,24 @@
 
 using namespace std;
 
-typedef struct{
-       int fromPercent;
-       int toPercent;
-       float maxChargeSpeed;
-}charging_profile;
-
-class OvmsCommand;
-
 class OvmsVehicleMaxe6 : public OvmsVehicle
   {
   public:
+
     OvmsVehicleMaxe6();
     ~OvmsVehicleMaxe6();
-      
-    OvmsMetricInt *m_poll_state_metric; // Kept equal to m_poll_state for debugging purposes
-    OvmsMetricFloat* m_soc_raw;
-    OvmsMetricFloat* m_watt_hour_raw;
-    OvmsMetricFloat* m_consump_raw;
-    OvmsMetricFloat* m_consumprange_raw;
-    OvmsMetricFloat* m_poll_bmsstate;
 
   protected:
-      std::string         m_rxbuf;
-
-      
-  protected:
-      void ConfigChanged(OvmsConfigParam* param) override;
-      void PollerStateTicker(canbus *bus);
-      void Ticker1(uint32_t ticker) override;
-      void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
-      void processEnergy();
-      float consumpRange;
-      float hvpower;
-      char m_vin[17];
+    void Ticker1(uint32_t ticker) override;
       
   private:
-      void IncomingFrameCan1(CAN_frame_t* p_frame) override;
-      void IncomingPollFrame(CAN_frame_t* frame);
-      void SetBmsStatus(uint8_t status);
-      /// A temporary store for the VIN
-     
-      int calcMinutesRemaining(int toSoc, charging_profile charge_steps[]);
-      float me56_cum_energy_charge_wh;
-      bool soc_limit_reached;
-      bool range_limit_reached;
-      bool vanIsOn;
-      bool ccschargeon;
-      bool acchargeon;
-      
-      virtual void calculateEfficiency();
-      
+    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+  
+    struct {
+      uint8_t byte[8];
+      uint8_t status;
+      uint16_t id;
+    } send_can_buffer;
   };
 
 #endif //#ifndef __VEHICLE_ME6_H__

--- a/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
+++ b/vehicle/OVMS.V3/components/vehicle_maxus_euniq6/src/vehicle_me6.h
@@ -1,0 +1,97 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th August 2024
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2021       Jaime Middleton / Tucar
+;    (C) 2021       Axel Troncoso   / Tucar
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#ifndef __VEHICLE_ME6_H__
+#define __VEHICLE_ME6_H__
+
+#include "vehicle.h"
+#include "metrics_standard.h"
+
+#include "freertos/timers.h"
+
+#include <vector>
+
+
+using namespace std;
+
+typedef struct{
+       int fromPercent;
+       int toPercent;
+       float maxChargeSpeed;
+}charging_profile;
+
+class OvmsCommand;
+
+class OvmsVehicleMaxe6 : public OvmsVehicle
+  {
+  public:
+    OvmsVehicleMaxe6();
+    ~OvmsVehicleMaxe6();
+      
+    OvmsMetricInt *m_poll_state_metric; // Kept equal to m_poll_state for debugging purposes
+    OvmsMetricFloat* m_soc_raw;
+    OvmsMetricFloat* m_watt_hour_raw;
+    OvmsMetricFloat* m_consump_raw;
+    OvmsMetricFloat* m_consumprange_raw;
+    OvmsMetricFloat* m_poll_bmsstate;
+
+  protected:
+      std::string         m_rxbuf;
+
+      
+  protected:
+      void ConfigChanged(OvmsConfigParam* param) override;
+      void PollerStateTicker(canbus *bus);
+      void Ticker1(uint32_t ticker) override;
+      void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
+      void processEnergy();
+      float consumpRange;
+      float hvpower;
+      char m_vin[17];
+      
+  private:
+      void IncomingFrameCan1(CAN_frame_t* p_frame) override;
+      void IncomingPollFrame(CAN_frame_t* frame);
+      void SetBmsStatus(uint8_t status);
+      /// A temporary store for the VIN
+     
+      int calcMinutesRemaining(int toSoc, charging_profile charge_steps[]);
+      float me56_cum_energy_charge_wh;
+      bool soc_limit_reached;
+      bool range_limit_reached;
+      bool vanIsOn;
+      bool ccschargeon;
+      bool acchargeon;
+      
+      virtual void calculateEfficiency();
+      
+  };
+
+#endif //#ifndef __VEHICLE_ME6_H__
+

--- a/vehicle/OVMS.V3/main/Kconfig
+++ b/vehicle/OVMS.V3/main/Kconfig
@@ -429,6 +429,14 @@ config OVMS_VEHICLE_MAXE56
     depends on OVMS_COMP_POLLER
     help
         Enable to include support for Maxus Euniq 5 6-seats vehicle.
+        
+config OVMS_VEHICLE_MAXE6
+    bool "Include support for Maxus Euniq 6 vehicle"
+    default y
+    depends on OVMS
+    depends on OVMS_COMP_POLLER
+    help
+        Enable to include support for Maxus Euniq 6 vehicle.
 
 config OVMS_VEHICLE_KIASOULEV
     bool "Include support for Kia Soul EV vehicles"


### PR DESCRIPTION
Purpose: 
Initialize support for Maxus Euniq6 model. 

Features included: 
- Speed
- SOC
- Odometer
- ON/AWAKE status
- Vehicle lock/unlock status. 

Notes: 
Noticed there already is a Maxus Euniq5 with 6 seats model but the can bus communication is quite different. So thought it would be best to propose adding a new model instead of modifying the existing one. 