### PR TITLE
Add Aux 12v battery monitor to vehicle class  (with scripting and duktape intf)

### DIFF
--- a/docs/source/userguide/events.rst
+++ b/docs/source/userguide/events.rst
@@ -167,6 +167,13 @@ vehicle.asleep                                Vehicle systems are asleep
 vehicle.awake                                 Vehicle systems are awake
 vehicle.aux.12v.on                            Vehicle 12V auxiliary system is on (base system awake)
 vehicle.aux.12v.off                           Vehicle 12V auxiliary system is off
+vehicle.aux.12v.normal                        Vehicle 12V auxiliary system changed to normal voltage range
+vehicle.aux.12v.charging                      Vehicle 12V auxiliary system changed to charging voltage range
+vehicle.aux.12v.blip                          Vehicle 12V auxiliary system has spiked from normal voltage range
+vehicle.aux.12v.dip                           Vehicle 12V auxiliary system has dipped from normal voltage range
+vehicle.aux.12v.charging.blip                 Vehicle 12V auxiliary system has spiked from charging voltage range
+vehicle.aux.12v.charging.dip                  Vehicle 12V auxiliary system has dipped from charging voltage range
+vehicle.aux.12v.low                           Vehicle 12V auxiliary system is in low-voltage range
 vehicle.charge.12v.start                      Vehicle 12V battery is charging
 vehicle.charge.12v.stop                       Vehicle 12V battery has stopped charging
 vehicle.charge.finished                       Vehicle charge has completed normally

--- a/docs/source/userguide/scripting.rst
+++ b/docs/source/userguide/scripting.rst
@@ -1022,7 +1022,24 @@ The OvmsVehicle object is the most comprehensive, and exposes several methods to
         print(res.errortext);
       else
         print(res.response_hex);
-
+- ``success = OvmsVehicle.AuxMon.Enable( [ LowThreshholdV [, ChargeThreshholdV] ] )``
+    Enable the 12v Auxilary battery monitor. This will enable the 'vehicle.aux.12v.*' events to fire.
+    Useful for preventing battery drain by only polling ECUs when necesary (on certain cars).
+- ``OvmsVehicle.AuxMon.Disable()``
+    Disable the 12v Auxilary battery monitor.
+- ``Obj = vmsVehicle.AuxMon.Status()``
+    Returns the status of the Auilary battery monitor.
+    A 'dip' is a temporary lowering of the voltage.
+    A 'blip' is a temporary raising of the voltage.
+   .. code-block:: javascript
+   {
+     "enabled": <boolean>,
+     "low_threshold": <float>, // The voltage below which is considered low-voltage  (status="low")
+     "charge_threshold": <float>, // The voltage above which is considered charging (status="charging*")
+     "short_avg": <float>,     // The current 'short period' (2s) average.
+     "long_avg": <float>,      // The current 'long period' (8s) average.
+     "state": <string>         // On of: normal, charging, charging.dip, charging.blip, blip, dip, low
+   }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 OvmsVehicle Command Plugins

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,25 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Vehicle: Implement events and scripting for Auxillary batttery monitor
+  New events:
+    vehicle.aux.12v.normal
+    vehicle.aux.12v.charging
+    vehicle.aux.12v.blip
+    vehicle.aux.12v.dip
+    vehicle.aux.12v.charging.blip
+    vehicle.aux.12v.charging.dip
+    vehicle.aux.12v.low
+  New commands:
+    vehicle aux [status]
+    vehicle aux monitor [status]
+    vehicle aux monitor enable
+    vehicle aux monitor disable
+  Duktape Support:
+    OvmsVehicle.AuxMon.Enable
+    OvmsVehicle.AuxMon.Disable
+    OvmsVehicle.AuxMon.Status
+
 - Cellular: GPS run state signals added.
   New events:
     system.modem.gpsstart       -- GPS has started

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -102,6 +102,14 @@ struct DashboardConfig;
 // closes the channel (ECU ID 0 is an invalid destination):
 //   { 0x200,    0,     0,      0,  {…times…},    0 , VWTP_20 }
 
+// Define for Debug of battery monitor internal states.
+// Debug tool: Probably don't need it for production
+// #define OVMS_DEBUG_BATTERYMON
+
+#ifdef OVMS_DEBUG_BATTERYMON
+// Extra verbose debuuging of battery monitor.
+// #define OVMS_DEBUG_BATTERYMON_VERBOSE
+#endif
 
 // Standard MSG protocol commands:
 
@@ -150,6 +158,73 @@ enum class OvmsStatus : short {
 inline bool operator<(OvmsStatus lhs, OvmsStatus rhs) {
   return static_cast<short>(lhs) < static_cast<short>(rhs);
 }
+
+enum class OvmsBatteryState { Unknown, Normal, Charging, ChargingDip, ChargingBlip, Blip, Dip, Low };
+
+// 12V/Aux Battery monitor: The aim is to detect 'dips' (voltage dipping down) and 'blips' (voltage 'blipping' up),
+// as well as 'charging' states and 'low voltage'.
+// This is used to wake up the 'Ping' cycle and do some polling to detect what's going on.  This prevents us from
+// keeping the power-hungry modules from being kept awake and draining the 12V battery (in 3h)
+struct OvmsBatteryMon {
+private:
+  static const uint8_t long_count = 8;
+  static const uint8_t short_count = 2;
+
+  static const int32_t entry_mult       =  1000;
+  static const int32_t def_charge_threshold = 14000; // over 14.0v is 'Charging'
+  static const int32_t def_low_threshold    = 11500; // Under 11.5v is 'Low'
+  static const int32_t blip_threshold   =   300; // cur is > 0.3v over average is 'Blip'
+  static const int32_t dip_threshold    =  -250; // cur is < 0.25v under average is 'Dip'
+  static const int32_t chdip_threshold  =   -90; // cur is < 0.09v under average while charging is 'ChargeDip'
+  static const int32_t chblip_threshold =   100; // cur is > 0.1v over average while charing is  is 'ChargeBlip'
+
+  average_util_t<int32_t,long_count>  m_long_avg;
+  average_util_t<int32_t,short_count>  m_short_avg;
+
+  mutable bool m_dirty;
+  mutable bool m_to_notify;
+
+  // Last calculated state
+  mutable OvmsBatteryState m_lastState;
+  mutable int32_t m_diff_last;
+
+  // Parameters
+  int32_t m_low_threshold;
+  int32_t m_charge_threshold;
+
+public:
+  OvmsBatteryMon();
+
+  OvmsBatteryState calc_state(int32_t &diff_last) const;
+  OvmsBatteryState calc_state() const
+    {
+    int32_t diff_ign;
+    return calc_state(diff_ign);
+    }
+
+  void set_thresholds(float low_thresh, float charge_thresh)
+    {
+    m_low_threshold = lroundf(entry_mult * low_thresh);
+    m_charge_threshold = lroundf(entry_mult * charge_thresh);
+    m_dirty = true;
+    }
+
+  // Add a voltage to the smoothed averages
+  void add(float voltage);
+
+  // Calculate state and return true if changed
+  bool checkStateChange();
+
+  // Current State (update and return)
+  OvmsBatteryState state() const;
+
+  std::string to_string() const;
+
+  float average_lastf() const;
+  float diff_lastf() const;
+
+  static const char *state_code(OvmsBatteryState state);
+};
 
 class OvmsVehicle : public InternalRamAllocated
   {
@@ -251,6 +326,13 @@ class OvmsVehicle : public InternalRamAllocated
   protected:
     virtual void CalculateRangeSpeed();     // Derive momentary range gain/loss speed in kph
 
+    OvmsBatteryMon m_aux_battery_mon;
+    bool m_aux_enabled;
+
+    void EnableAuxMonitor();
+    void EnableAuxMonitor(float low_thresh, float charge_thresh);
+    void Check12vState();
+
   protected:
     int m_last_drivetime;                   // duration of current/most recent drive [s]
     int m_last_parktime;                    // duration of current/most recent parking period [s]
@@ -310,6 +392,8 @@ class OvmsVehicle : public InternalRamAllocated
     virtual void NotifyVehicleOn();
     virtual void NotifyVehicleOff();
 
+    void NotifyVehicleAux12vState(OvmsBatteryState new_state, const OvmsBatteryMon &monitor);
+
   protected:
     virtual void NotifyGenState();
 
@@ -339,6 +423,8 @@ class OvmsVehicle : public InternalRamAllocated
     virtual void NotifiedVehicleAux12vOff() {}
     virtual void NotifiedVehicleCharge12vStart() {}
     virtual void NotifiedVehicleCharge12vStop() {}
+    virtual void NotifiedVehicleAux12vStateChanged(OvmsBatteryState new_state, const OvmsBatteryMon &monitor) {}
+
     virtual void NotifiedVehicleLocked() {}
     virtual void NotifiedVehicleUnlocked() {}
     virtual void NotifiedVehicleValetOn() {}
@@ -556,6 +642,10 @@ class OvmsVehicle : public InternalRamAllocated
     void StartingUp();
     void ShuttingDown();
     virtual bool IsShutdown();
+    std::string BatteryMonStat()
+    {
+      return m_aux_battery_mon.to_string();
+    }
   };
 
 template<typename Type> OvmsVehicle* CreateVehicle()

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_duktape.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_duktape.cpp
@@ -521,4 +521,61 @@ duk_ret_t OvmsVehicleFactory::DukOvmsVehicleObdRequest(duk_context *ctx)
   return 1;
   }
 
+duk_ret_t OvmsVehicleFactory::DukOvmsVehicleAuxMonEnable(duk_context *ctx)
+  {
+  if (MyVehicleFactory.m_currentvehicle==nullptr)
+    {
+    duk_push_boolean(ctx, 0);
+    }
+  else
+    {
+    duk_idx_t numArgs = duk_get_top(ctx);
+    if (numArgs == 0)
+      MyVehicleFactory.m_currentvehicle->EnableAuxMonitor();
+    else
+      {
+      duk_double_t low_thresh, charge_thresh = 0;
+      low_thresh = duk_to_number(ctx, 0);
+      if (numArgs > 1)
+        charge_thresh = duk_to_number(ctx, 1);
+      MyVehicleFactory.m_currentvehicle->EnableAuxMonitor(low_thresh, charge_thresh);
+      }
+    duk_push_boolean(ctx, 1);
+    }
+  return 1;
+  }
+duk_ret_t OvmsVehicleFactory::DukOvmsVehicleAuxMonDisable(duk_context *ctx)
+  {
+  if (MyVehicleFactory.m_currentvehicle!=nullptr)
+    {
+    MyVehicleFactory.m_currentvehicle->DisableAuxMonitor();
+    }
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsVehicleAuxMonStatus(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    {
+    duk_push_null(ctx);
+    return 1;
+    }
+  DukContext dc(ctx);
+  // Push result object:
+  duk_idx_t obj_idx = dc.PushObject();
+  dc.Push(mycar->m_aux_enabled);
+  dc.PutProp(obj_idx, "enabled");
+  dc.Push(mycar->m_aux_battery_mon.low_threshold());
+  dc.PutProp(obj_idx, "low_threshold");
+  dc.Push(mycar->m_aux_battery_mon.charge_threshold());
+  dc.PutProp(obj_idx, "charge_threshold");
+  dc.Push(mycar->m_aux_battery_mon.average_lastf());
+  dc.PutProp(obj_idx, "short_avg");
+  dc.Push(mycar->m_aux_battery_mon.average_long());
+  dc.PutProp(obj_idx, "long_avg");
+  dc.Push(OvmsBatteryMon::state_code(mycar->m_aux_battery_mon.state()));
+  dc.PutProp(obj_idx, "state");
+  return 1;
+  }
 #endif // #ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_shell.cpp
@@ -463,6 +463,97 @@ void OvmsVehicleFactory::bms_reset(int verbosity, OvmsWriter* writer, OvmsComman
     }
   }
 
+void OvmsVehicleFactory::vehicle_aux(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  writer->printf("AUX BATTERY\n");
+  if (StdMetrics.ms_v_bat_12v_voltage->IsDefined())
+    {
+    const std::string &auxBatt = StdMetrics.ms_v_bat_12v_voltage->AsUnitString("-", Volts, 2);
+    writer->printf("  Voltage: %s\n", auxBatt.c_str());
+    }
+  if (StdMetrics.ms_v_bat_12v_current->IsDefined())
+    {
+    const std::string &auxBattI = StdMetrics.ms_v_bat_12v_current->AsUnitString("-", Amps, 2);
+    writer->printf("  Current: %s\n", auxBattI.c_str());
+    }
+
+  if (StdMetrics.ms_v_bat_12v_voltage_ref->IsDefined())
+    {
+    const std::string &auxBattVref = StdMetrics.ms_v_bat_12v_voltage_ref->AsUnitString("-", Volts, 2);
+    writer->printf("  Voltage Ref: %s\n", auxBattVref.c_str());
+    }
+
+  if (StdMetrics.ms_v_bat_12v_voltage_alert->IsDefined())
+    {
+    const std::string &auxBattI = StdMetrics.ms_v_bat_12v_voltage_alert->AsUnitString("-", Volts, 2);
+    writer->printf("  Voltage Alert: %s\n", auxBattI.c_str());
+    }
+  }
+
+void OvmsVehicleFactory::vehicle_aux_monitor(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == NULL)
+    {
+    writer->puts("Error: No vehicle module selected");
+    return;
+    }
+  if (!mycar->m_aux_enabled)
+    {
+    writer->puts("Aux Monitor Disabled");
+    return;
+    }
+
+  std::string stat = mycar->BatteryMonStat();
+  writer->puts(stat.c_str());
+  }
+
+void OvmsVehicleFactory::vehicle_aux_monitor_enable(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == NULL)
+    {
+    writer->puts("Error: No vehicle module selected");
+    return;
+    }
+  if (argc == 0)
+    {
+    mycar->EnableAuxMonitor();
+    }
+  else
+    {
+    float low_thresh, charge_thresh = 0;
+    if (0==sscanf(argv[0], "%f", &low_thresh))
+      {
+      writer->puts("Error: Expected float for low threshold");
+      return;
+      }
+    if (argc > 1 )
+      {
+      if (0 == sscanf(argv[1], "%f", &charge_thresh))
+        {
+        writer->puts("Error: Expected float for charge threshold");
+        return;
+        }
+      }
+    mycar->EnableAuxMonitor(low_thresh, charge_thresh);
+
+    }
+  writer->printf("Enabled (low=%f charge=%f)\n", mycar->m_aux_battery_mon.low_threshold(), mycar->m_aux_battery_mon.charge_threshold());
+  }
+
+void OvmsVehicleFactory::vehicle_aux_monitor_disable(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == NULL)
+    {
+    writer->puts("Error: No vehicle module selected");
+    return;
+    }
+  mycar->DisableAuxMonitor();
+  writer->puts("Disabled");
+  }
+
 void OvmsVehicleFactory::bms_alerts(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
   {
   if (MyVehicleFactory.m_currentvehicle != NULL)

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
@@ -142,23 +142,23 @@ void xiq_set_auto_door_lock(int verbosity, OvmsWriter *writer, OvmsCommand *cmd,
  */
 void xiq_aux(int verbosity, OvmsWriter *writer, OvmsCommand *cmd, int argc, const char *const *argv)
 {
-  if (MyVehicleFactory.m_currentvehicle == NULL) {
-    writer->puts("Error: No vehicle module selected");
-    return;
-  }
-
-
   writer->printf("AUX BATTERY\n");
-  if (StdMetrics.ms_v_bat_12v_voltage->IsDefined()) {
+  if (StdMetrics.ms_v_bat_12v_voltage->IsDefined())
+    {
     const std::string &auxBatt = StdMetrics.ms_v_bat_12v_voltage->AsUnitString("-", Volts, 2);
-    writer->printf("Aux battery voltage %s\n", auxBatt.c_str());
+    writer->printf("Voltage: %s\n", auxBatt.c_str());
+    }
+
+  if (MyVehicleFactory.m_currentvehicle == NULL) {
+    writer->puts("No vehicle module selected");
+    return;
   }
 
   OvmsHyundaiIoniqEv *niro = (OvmsHyundaiIoniqEv *) MyVehicleFactory.ActiveVehicle();
 
   if (niro->m_b_aux_soc->IsDefined()) {
     const std::string &auxSOC = niro->m_b_aux_soc->AsUnitString("-", Percentage, 1);
-    writer->printf("Aux battery SOC %s\n", auxSOC.c_str());
+    writer->printf("SOC: %s\n", auxSOC.c_str());
   }
 }
 
@@ -640,21 +640,21 @@ void OvmsHyundaiIoniqEv::RangeCalcReset()
 
 void xiq_range_reset(int verbosity, OvmsWriter *writer, OvmsCommand *cmd, int argc, const char *const *argv)
 {
-  if (MyVehicleFactory.m_currentvehicle == NULL) {
+  OvmsHyundaiIoniqEv *mycar = (OvmsHyundaiIoniqEv *)(MyVehicleFactory.ActiveVehicle());
+  if (mycar) {
     writer->puts("Error: No vehicle module selected");
     return;
   }
-  OvmsHyundaiIoniqEv *mycar = (OvmsHyundaiIoniqEv *)(MyVehicleFactory.ActiveVehicle());
   mycar->RangeCalcReset();
 }
 
 void xiq_aux_monitor(int verbosity, OvmsWriter *writer, OvmsCommand *cmd, int argc, const char *const *argv)
 {
-  if (MyVehicleFactory.m_currentvehicle == NULL) {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == NULL) {
     writer->puts("Error: No vehicle module selected");
     return;
   }
-  OvmsHyundaiIoniqEv *mycar = (OvmsHyundaiIoniqEv *)(MyVehicleFactory.ActiveVehicle());
   std::string stat = mycar->BatteryMonStat();
   writer->puts(stat.c_str());
 }

--- a/vehicle/OVMS.V3/main/ovms_housekeeping.cpp
+++ b/vehicle/OVMS.V3/main/ovms_housekeeping.cpp
@@ -71,6 +71,7 @@ static const char *TAG = "housekeeping";
 static int tick = 0;
 #ifdef CONFIG_OVMS_COMP_ADC
 static average_util_t<int32_t,4>  aux_avg_v;
+static float aux_factor = 195.7;
 #endif
 
 void HousekeepingUpdate12V()
@@ -86,12 +87,9 @@ void HousekeepingUpdate12V()
   aux_avg_v.add(MyPeripherals->m_esp32adc->read());
 
   // Allow the user to adjust the ADC conversion factor
-  float f = MyConfig.GetParamValueFloat("system.adc","factor12v");
-  if (f == 0) f = 195.7;
-
-  float v = (float)aux_avg_v.get() / f;
+  float v = (float)aux_avg_v.get() / aux_factor;
   // Round to 2 decimal places
-  v = trunc((v*100)+0.5) / 100;
+  v = truncf((v*100)+0.5) / 100;
   if (v < 1.0) v=0;
   m1->SetValue(v);
   if (StandardMetrics.ms_v_bat_12v_voltage_ref->AsFloat() == 0)
@@ -170,6 +168,12 @@ Housekeeping::Housekeeping()
   MyEvents.RegisterEvent(TAG,"housekeeping.init", std::bind(&Housekeeping::Init, this, _1, _2));
   MyEvents.RegisterEvent(TAG,"ticker.10", std::bind(&Housekeeping::Metrics, this, _1, _2));
   MyEvents.RegisterEvent(TAG,"ticker.300", std::bind(&Housekeeping::TimeLogger, this, _1, _2));
+
+#ifdef CONFIG_OVMS_COMP_ADC
+  MyEvents.RegisterEvent(TAG, "config.changed", std::bind(&Housekeeping::ConfigChanged, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "config.mounted", std::bind(&Housekeeping::ConfigChanged, this, _1, _2));
+  ConfigChanged("config.mounted", nullptr);
+#endif
 
   // Fire off the event that causes us to be called back in Events tasks context
   MyEvents.SignalEvent("housekeeping.init", NULL);
@@ -272,6 +276,21 @@ void Housekeeping::Init(std::string event, void* data)
 
   Metrics(event,data); // Causes the metrics to be produced
   }
+
+#ifdef CONFIG_OVMS_COMP_ADC
+void Housekeeping::ConfigChanged(std::string event, void* data)
+  {
+  OvmsConfigParam* param = (OvmsConfigParam*) data;
+
+  if (!param || param->GetName() == "system.adc")
+    {
+    // Allow the user to adjust the ADC conversion factor
+    float f = MyConfig.GetParamValueFloat("system.adc","factor12v");
+    if (f == 0) f = 195.7;
+    aux_factor = f;
+    }
+  }
+#endif
 
 void Housekeeping::Metrics(std::string event, void* data)
   {

--- a/vehicle/OVMS.V3/main/ovms_housekeeping.h
+++ b/vehicle/OVMS.V3/main/ovms_housekeeping.h
@@ -47,6 +47,9 @@ class Housekeeping
     void Init(std::string event, void* data);
     void Metrics(std::string event, void* data);
     void TimeLogger(std::string event, void* data);
+#ifdef CONFIG_OVMS_COMP_ADC
+    void ConfigChanged(std::string event, void* data);
+#endif
 
   protected:
     TimerHandle_t m_timer1;

--- a/vehicle/OVMS.V3/main/ovms_utils.h
+++ b/vehicle/OVMS.V3/main/ovms_utils.h
@@ -839,6 +839,37 @@ class ovms_callback_register_t
         return m_n == 0;
         }
     };
+
+  template <typename T>
+  class average_util_t<T, 2>
+    {
+    private:
+      static const T _INVALID = ~T(0);
+      T m_avg;
+    public:
+      average_util_t() : m_avg(_INVALID)
+        {
+        }
+
+      void add(T val)
+        {
+        if (m_avg==_INVALID)
+          m_avg = val;
+        else
+          m_avg = (val + m_avg) >> 1;
+        }
+      T get() const { return (m_avg == _INVALID)?0:m_avg; }
+      operator T() const { return get(); }
+      void reset()
+        {
+        m_avg = _INVALID;
+        }
+      bool isEmpty() const
+        {
+        return m_avg == _INVALID;
+        }
+    };
+
   /* Assists in maintaining smoothed average for a period.
    * T should be an integer type
    * N needs to be a power of 2


### PR DESCRIPTION
Moved the battery monitor from the Ioniq5 implementation.

Added internal support for enable/disable and extended run-time config.

Add duktape support for aux battery monitor

Add cli support as well.