### PR TITLE
Fix Server V3 client sending messages every minute

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,21 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- OVMS Server v3: Ability to define less frequent MQTT communication to save data charges and power
+  Events:
+    Excludes clock.* events from being published at the start of every minute.
+  New configs:
+    [server.v3] events.legacy_topic  -- Whether to publish every event on the legacy /event topic as well as
+                                        the MQTT-style topic. Defaults to true to preserve existing behaviour.
+                                        Recommended to set to false if you don't use the legacy topic.
+    [server.v3] updatetime.keepalive -- Max number of seconds to allow the MQTT connection to be idle before
+                                        sending PINGREQ. Should be set slightly shorter than the network's
+                                        NAT timeout and the timeout of your MQTT server. If these are unknown
+                                        you can use trial and error. Symptoms of keepalive being too high are
+                                        a lack of metric updates after a certain point, or "Disconnected from
+                                        OVMS Server V3" appearing in the log. In previous releases this used
+                                        the Mongoose default of 60. New default value 1740 aligns with
+                                        observed Hologram timeout of 1800.
 - Metrics
   add new Standard Metrics
     v.b.capacity          -- Main battery usable capacity [kWh]

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -82,6 +82,7 @@ static void OvmsServerV3MongooseCallback(struct mg_connection *nc, int ev, void 
         opts.will_topic = MyOvmsServerV3->m_will_topic.c_str();
         opts.will_message = "no";
         opts.flags |= MG_MQTT_WILL_RETAIN;
+	opts.keep_alive = MyOvmsServerV3->m_updatetime_keepalive;
         mg_set_protocol_mqtt(nc);
         mg_send_mqtt_handshake_opt(nc, MyOvmsServerV3->m_vehicleid.c_str(), opts);
         }
@@ -207,6 +208,7 @@ OvmsServerV3::OvmsServerV3(const char* name)
   m_updatetime_on = m_updatetime_idle;
   m_updatetime_charging = m_updatetime_idle;
   m_updatetime_sendall = 0;
+  m_updatetime_keepalive = 29*60;
   m_notify_info_pending = false;
   m_notify_error_pending = false;
   m_notify_alert_pending = false;
@@ -841,6 +843,7 @@ void OvmsServerV3::ConfigChanged(OvmsConfigParam* param)
   m_updatetime_on = MyConfig.GetParamValueInt("server.v3", "updatetime.on", m_updatetime_idle);
   m_updatetime_charging = MyConfig.GetParamValueInt("server.v3", "updatetime.charging", m_updatetime_idle);
   m_updatetime_sendall = MyConfig.GetParamValueInt("server.v3", "updatetime.sendall", 0);
+  m_updatetime_keepalive = MyConfig.GetParamValueInt("server.v3", "updatetime.keepalive", 29*60);
   m_metrics_filter.LoadFilters(MyConfig.GetParamValue("server.v3", "metrics.include"),
                                MyConfig.GetParamValue("server.v3", "metrics.exclude"));
   }
@@ -1134,6 +1137,7 @@ void OvmsServerV3Init::AutoInit()
 void OvmsServerV3Init::EventListener(std::string event, void* data)
   {
   if (event.compare(0,7,"ticker.") == 0) return; // Skip ticker.* events
+  if (event.compare(0,5,"clock") == 0) return; // Skip clock events
   if (event.compare("system.event") == 0) return; // Skip event
   if (event.compare("system.wifi.scan.done") == 0) return; // Skip event
 

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -209,6 +209,7 @@ OvmsServerV3::OvmsServerV3(const char* name)
   m_updatetime_charging = m_updatetime_idle;
   m_updatetime_sendall = 0;
   m_updatetime_keepalive = 29*60;
+  m_legacy_event_topic = true;
   m_notify_info_pending = false;
   m_notify_error_pending = false;
   m_notify_alert_pending = false;
@@ -537,10 +538,14 @@ void OvmsServerV3::IncomingEvent(std::string event, void* data)
 
   std::string topic(m_topic_prefix);
 
-  // Legacy: publish event name on fixed topic
   topic.append("event");
-  mg_mqtt_publish(m_mgconn, topic.c_str(), m_msgid++,
-    MG_MQTT_QOS(0), event.c_str(), event.length());
+
+  // Legacy: publish event name on fixed topic
+  if (m_legacy_event_topic)
+    {
+    mg_mqtt_publish(m_mgconn, topic.c_str(), m_msgid++,
+      MG_MQTT_QOS(0), event.c_str(), event.length());
+    }
 
   // Publish MQTT style event topic, payload reserved for event data serialization:
   topic.append("/");
@@ -844,6 +849,7 @@ void OvmsServerV3::ConfigChanged(OvmsConfigParam* param)
   m_updatetime_charging = MyConfig.GetParamValueInt("server.v3", "updatetime.charging", m_updatetime_idle);
   m_updatetime_sendall = MyConfig.GetParamValueInt("server.v3", "updatetime.sendall", 0);
   m_updatetime_keepalive = MyConfig.GetParamValueInt("server.v3", "updatetime.keepalive", 29*60);
+  m_legacy_event_topic = MyConfig.GetParamValueBool("server.v3", "events.legacy_topic", true);
   m_metrics_filter.LoadFilters(MyConfig.GetParamValue("server.v3", "metrics.include"),
                                MyConfig.GetParamValue("server.v3", "metrics.exclude"));
   }
@@ -1137,7 +1143,7 @@ void OvmsServerV3Init::AutoInit()
 void OvmsServerV3Init::EventListener(std::string event, void* data)
   {
   if (event.compare(0,7,"ticker.") == 0) return; // Skip ticker.* events
-  if (event.compare(0,5,"clock") == 0) return; // Skip clock events
+  if (event.compare(0,6,"clock.") == 0) return; // Skip clock.* events
   if (event.compare("system.event") == 0) return; // Skip event
   if (event.compare("system.wifi.scan.done") == 0) return; // Skip event
 

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -109,6 +109,7 @@ class OvmsServerV3 : public OvmsServer
     int m_updatetime_charging;
     int m_updatetime_sendall;
     int m_updatetime_keepalive;
+    bool m_legacy_event_topic;
 
     bool m_connection_available;
     bool m_notify_info_pending;

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -108,6 +108,7 @@ class OvmsServerV3 : public OvmsServer
     int m_updatetime_on;
     int m_updatetime_charging;
     int m_updatetime_sendall;
+    int m_updatetime_keepalive;
 
     bool m_connection_available;
     bool m_notify_info_pending;


### PR DESCRIPTION
OVMS is a brilliant system, but I noticed that it was sending MQTT messages every minute, even when configured with updatetimes that were much longer than that. This activity consumes Hologram allowance and power unnecessarily.

The first step in fixing this is to filter out "clock" events, on the basis that they are of no use to anyone:
2024-11-10T22:52:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event', ... (10 bytes))
2024-11-10T22:52:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event/clock/2252', ... (0 bytes))
2024-11-10T22:53:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event', ... (10 bytes))
2024-11-10T22:53:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event/clock/2253', ... (0 bytes))
2024-11-10T22:54:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event', ... (10 bytes))
2024-11-10T22:54:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event/clock/2254', ... (0 bytes))
2024-11-10T22:55:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event', ... (10 bytes))
2024-11-10T22:55:00: Received PUBLISH from leaf (d0, q0, r0, m0, 'ovms/event/clock/2255', ... (0 bytes))

The second step is to amend Mongoose's keepalive timer, which defaults to 60 seconds. This timer generates these messages:
2024-11-16T12:11:06: Received PINGREQ from leaf
2024-11-16T12:11:06: Sending PINGRESP to leaf

This PR adds a new config parameter updatetime.keepalive, which is passed through to Mongoose.

I did some testing and identified that Hologram's TCP timeout is 30 minutes. For that reason, in this PR the default keepalive is set to 29 minutes in the hope that will be most sensible for most users. When OVMS metrics are published, Mongoose resets the keepalive timer so if the user has configured updatetimes less than that, PINGREQs will never need to be sent.

I'm happy to make changes to the PR if you'd prefer something a little different.