### PR TITLE
DBC Parser - Fix yacc warnings

### DIFF
--- a/vehicle/OVMS.V3/components/dbc/src/dbc_parser.y
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc_parser.y
@@ -105,10 +105,10 @@ dbcSignal* current_signal = NULL;
 %token T_PAR_OPEN
 %token T_PAR_CLOSE
 %token T_COMMA
-%token T_ID
-%token T_STRING_VAL
-%token T_INT_VAL
-%token T_DOUBLE_VAL
+%token <string> T_ID
+%token <string> T_STRING_VAL
+%token <number> T_INT_VAL
+%token <double_val> T_DOUBLE_VAL
 
 %token T_VERSION
 
@@ -155,9 +155,9 @@ dbcSignal* current_signal = NULL;
 %token T_SG_MUL_VAL
 %token T_DUMMY_NODE_VECTOR
 
-%type <string>                    T_ID T_STRING_VAL version_section signal_mux
-%type <number>                    T_INT_VAL signal_endian signal_sign signal_start signal_length
-%type <double_val>                T_DOUBLE_VAL double_val signal_scale signal_offset signal_min signal_max
+%type <string>                    version_section signal_mux
+%type <number>                    signal_endian signal_sign signal_start signal_length
+%type <double_val>                double_val signal_scale signal_offset signal_min signal_max
 %%
 
 dbc:


### PR DESCRIPTION
There are some warnings in the %type definitions for yacc which I believe this fixes.

I'm not knowledgeable about  yacc/flex files, however I believe this is a valid fix.  