### PR TITLE
zoe docs

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/docs/index.rst
@@ -4,7 +4,7 @@ Renault Zoe
 
 Vehicle Type: **RZ**
 
-This vehicle type supports the Renault Zoe(PH1) and Kangoo(2011 - ~2019). The newer Zoe ph2 and Kangoo are not supported yet.
+This vehicle type supports the Renault Zoe(PH1) 22kWh-40kWh (2012 - 2019) and Kangoo 22kWh-33kWh (2011 - ~2019).
 
 ----------------
 Support Overview
@@ -45,4 +45,3 @@ Using Cabin Pre-heat/cool
 -------------------------
 
 Climate control on is only supported. It starts the 5 minute booster. After 5 minutes it switches off automatically. For IOS users it is started via Homelink 1
-

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/docs/index.rst
@@ -4,7 +4,8 @@ Renault Zoe Phase 2 (OBD port)
 
 Vehicle Type: **RZ2O**
 
-This vehicle type supports the Renault Zoe(PH2) e.g ZE50 through OBD connection. 
+This vehicle type supports the Renault Zoe(PH2) ZE50 52kWh (2019-2024) through ODB2 connection. 
+
 All values are read-only, no control possible because of CAN Gateway.
 
 ----------------


### PR DESCRIPTION
Improve Renault Zoe docs:

- Remove the note that PH2 is not supported 
- Clarify which models are PH1 and PH2