### PR TITLE
Dbc use metric units when setting values

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,8 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- DBC Files
+  Add unit support
 - OVMS Server v3: Ability to define less frequent MQTT communication to save data charges and power
   Events:
     Excludes clock.* events from being published at the start of every minute.

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
@@ -52,7 +52,7 @@ static const char *TAG = "dbc";
 // Helper functions
 
 static inline uint64_t
-dbc_extract_bits(uint8_t *candata, unsigned int bpos, unsigned int align, unsigned int shifter, unsigned int pos)
+dbc_extract_bits(const uint8_t *candata, unsigned int bpos, unsigned int align, unsigned int shifter, unsigned int pos)
   {
   uint64_t val = (uint64_t)candata[bpos/8];
   unsigned int mask = (1 << shifter) - 1;
@@ -60,7 +60,7 @@ dbc_extract_bits(uint8_t *candata, unsigned int bpos, unsigned int align, unsign
   }
 
 static uint64_t
-dbc_extract_bits_little_endian(uint8_t *candata, unsigned int bpos, unsigned int bits)
+dbc_extract_bits_little_endian(const uint8_t *candata, unsigned int bpos, unsigned int bits)
   {
   unsigned int pos, aligner, shifter;
   uint64_t val = 0;
@@ -83,7 +83,7 @@ dbc_extract_bits_little_endian(uint8_t *candata, unsigned int bpos, unsigned int
   }
 
 static uint64_t
-dbc_extract_bits_big_endian(uint8_t *candata, unsigned int bpos, unsigned int bits)
+dbc_extract_bits_big_endian(const uint8_t *candata, unsigned int bpos, unsigned int bits)
   {
   unsigned int pos, aligner, slicer;
   uint64_t val = 0;
@@ -147,7 +147,7 @@ void dbcCommentTable::RemoveComment(std::string comment)
   m_entrymap.remove(comment);
   }
 
-bool dbcCommentTable::HasComment(std::string comment)
+bool dbcCommentTable::HasComment(std::string comment) const
   {
   auto it = std::find(m_entrymap.begin(), m_entrymap.end(), comment);
   return (it != m_entrymap.end());
@@ -160,9 +160,9 @@ void dbcCommentTable::EmptyContent()
 
 void dbcCommentTable::WriteFile(dbcOutputCallback callback,
                                 void* param,
-                                std::string prefix)
+                                std::string prefix) const
   {
-  for (dbcCommentList_t::iterator it=m_entrymap.begin();
+  for (dbcCommentList_t::const_iterator it=m_entrymap.begin();
        it != m_entrymap.end();
        ++it)
     {
@@ -215,10 +215,10 @@ int dbcNewSymbolTable::GetCount()
   return m_entrymap.size();
   }
 
-void dbcNewSymbolTable::WriteFile(dbcOutputCallback callback, void* param)
+void dbcNewSymbolTable::WriteFile(dbcOutputCallback callback, void* param) const
   {
   callback(param,"NS_ :");
-  for (dbcNewSymbolList_t::iterator it=m_entrymap.begin();
+  for (dbcNewSymbolList_t::const_iterator it=m_entrymap.begin();
        it != m_entrymap.end();
        ++it)
     {
@@ -327,10 +327,10 @@ void dbcNodeTable::EmptyContent()
   m_entrymap.clear();
   }
 
-void dbcNodeTable::WriteFile(dbcOutputCallback callback, void* param)
+void dbcNodeTable::WriteFile(dbcOutputCallback callback, void* param) const
   {
   callback(param, "BU_ :");
-  for (dbcNodeEntry_t::iterator it = m_entrymap.begin();
+  for (dbcNodeEntry_t::const_iterator it = m_entrymap.begin();
        it != m_entrymap.end();
        it++)
     {
@@ -340,10 +340,10 @@ void dbcNodeTable::WriteFile(dbcOutputCallback callback, void* param)
   callback(param,"\n\n");
   }
 
-void dbcNodeTable::WriteFileComments(dbcOutputCallback callback, void* param)
+void dbcNodeTable::WriteFileComments(dbcOutputCallback callback, void* param) const
   {
   std::string prefix;
-  for (dbcNodeEntry_t::iterator it=m_entrymap.begin();
+  for (dbcNodeEntry_t::const_iterator it=m_entrymap.begin();
        it != m_entrymap.end();
        ++it)
     {
@@ -397,7 +397,7 @@ void dbcBitTiming::SetBaud(const uint32_t baudrate, const uint32_t btr1, const u
   m_btr2 = btr2;
   }
 
-void dbcBitTiming::WriteFile(dbcOutputCallback callback, void* param)
+void dbcBitTiming::WriteFile(dbcOutputCallback callback, void* param) const
   {
   callback(param, "BS_ : ");
   if (m_baudrate != 0)
@@ -443,13 +443,13 @@ void dbcValueTable::RemoveValue(uint32_t id)
     m_entrymap.erase(search);
   }
 
-bool dbcValueTable::HasValue(uint32_t id)
+bool dbcValueTable::HasValue(uint32_t id) const
   {
   auto search = m_entrymap.find(id);
   return (search != m_entrymap.end());
   }
 
-std::string dbcValueTable::GetValue(uint32_t id)
+std::string dbcValueTable::GetValue(uint32_t id) const
   {
   auto search = m_entrymap.find(id);
   if (search != m_entrymap.end())
@@ -458,7 +458,7 @@ std::string dbcValueTable::GetValue(uint32_t id)
     return std::string("");
   }
 
-const std::string& dbcValueTable::GetName()
+const std::string& dbcValueTable::GetName() const
   {
   return m_name;
   }
@@ -473,7 +473,7 @@ void dbcValueTable::SetName(const char* name)
   m_name = std::string(name);
   }
 
-int dbcValueTable::GetCount()
+int dbcValueTable::GetCount() const
   {
   return m_entrymap.size();
   }
@@ -488,7 +488,7 @@ void dbcValueTable::EmptyContent()
   m_entrymap.clear();
   }
 
-void dbcValueTable::WriteFile(dbcOutputCallback callback, void* param, const char* prefix)
+void dbcValueTable::WriteFile(dbcOutputCallback callback, void* param, const char* prefix) const
   {
   if (prefix != NULL)
     {
@@ -499,7 +499,7 @@ void dbcValueTable::WriteFile(dbcOutputCallback callback, void* param, const cha
     callback(param, "VAL_TABLE_ ");
     callback(param, m_name.c_str());
     }
-  for (dbcValueTableEntry_t::iterator it = m_entrymap.begin();
+  for (dbcValueTableEntry_t::const_iterator it = m_entrymap.begin();
        it != m_entrymap.end();
        it++)
     {
@@ -552,7 +552,7 @@ dbcValueTable* dbcValueTableTable::FindValueTable(std::string name)
 
 void dbcValueTableTable::EmptyContent()
   {
-  dbcValueTableTableEntry_t::iterator it=m_entrymap.begin();
+  dbcValueTableTableEntry_t::const_iterator it=m_entrymap.begin();
   while (it!=m_entrymap.end())
     {
     delete it->second;
@@ -561,11 +561,11 @@ void dbcValueTableTable::EmptyContent()
   m_entrymap.clear();
   }
 
-void dbcValueTableTable::WriteFile(dbcOutputCallback callback, void* param)
+void dbcValueTableTable::WriteFile(dbcOutputCallback callback, void* param) const
   {
   if (m_entrymap.size() > 0)
     {
-    for (dbcValueTableTableEntry_t::iterator itt = m_entrymap.begin();
+    for (dbcValueTableTableEntry_t::const_iterator itt = m_entrymap.begin();
          itt != m_entrymap.end();
          itt++)
       itt->second->WriteFile(callback, param, NULL);
@@ -641,17 +641,17 @@ void dbcSignal::RemoveValue(uint32_t id)
   m_values.RemoveValue(id);
   }
 
-bool dbcSignal::HasValue(uint32_t id)
+bool dbcSignal::HasValue(uint32_t id) const
   {
   return m_values.HasValue(id);
   }
 
-std::string dbcSignal::GetValue(uint32_t id)
+std::string dbcSignal::GetValue(uint32_t id) const
   {
   return m_values.GetValue(id);
   }
 
-const std::string& dbcSignal::GetName()
+const std::string& dbcSignal::GetName() const
   {
   return m_name;
   }
@@ -670,12 +670,12 @@ void dbcSignal::SetName(const char* name)
   SetName(std::string(name));
   }
 
-bool dbcSignal::IsMultiplexor()
+bool dbcSignal::IsMultiplexor() const
   {
   return (m_mux.multiplexed == DBC_MUX_MULTIPLEXOR);
   }
 
-bool dbcSignal::IsMultiplexSwitch()
+bool dbcSignal::IsMultiplexSwitch() const
   {
   return (m_mux.multiplexed == DBC_MUX_MULTIPLEXED);
   }
@@ -685,7 +685,7 @@ void dbcSignal::SetMultiplexor()
   m_mux.multiplexed = DBC_MUX_MULTIPLEXOR;
   }
 
-uint32_t dbcSignal::GetMultiplexSwitchvalue()
+uint32_t dbcSignal::GetMultiplexSwitchvalue() const
   {
   return m_mux.switchvalue;
   }
@@ -718,42 +718,42 @@ bool dbcSignal::ClearMultiplexed()
     }
   }
 
-int dbcSignal::GetStartBit()
+int dbcSignal::GetStartBit() const
   {
   return m_start_bit;
   }
 
-int dbcSignal::GetSignalSize()
+int dbcSignal::GetSignalSize() const
   {
   return m_signal_size;
   }
 
-dbcByteOrder_t dbcSignal::GetByteOrder()
+dbcByteOrder_t dbcSignal::GetByteOrder() const
   {
   return m_byte_order;
   }
 
-dbcValueType_t dbcSignal::GetValueType()
+dbcValueType_t dbcSignal::GetValueType() const
   {
   return m_value_type;
   }
 
-dbcNumber dbcSignal::GetFactor()
+dbcNumber dbcSignal::GetFactor() const
   {
   return m_factor;
   }
 
-dbcNumber dbcSignal::GetOffset()
+dbcNumber dbcSignal::GetOffset() const
   {
   return m_offset;
   }
 
-dbcNumber dbcSignal::GetMinimum()
+dbcNumber dbcSignal::GetMinimum() const
   {
   return m_minimum;
   }
 
-dbcNumber dbcSignal::GetMaximum()
+dbcNumber dbcSignal::GetMaximum() const
   {
   return m_maximum;
   }
@@ -798,7 +798,7 @@ void dbcSignal::SetMinMax(const double minimum, const double maximum)
   m_maximum = maximum;
   }
 
-const std::string& dbcSignal::GetUnit()
+const std::string& dbcSignal::GetUnit() const
   {
   return m_unit;
   }
@@ -818,7 +818,7 @@ void dbcSignal::Encode(dbcNumber* source, CAN_frame_t* msg)
   // TODO: An efficient encoding of the signal
   }
 
-dbcNumber dbcSignal::Decode(CAN_frame_t* msg)
+dbcNumber dbcSignal::Decode(const CAN_frame_t* msg) const
   {
   uint64_t val;
   dbcNumber result;
@@ -853,12 +853,12 @@ void dbcSignal::AssignMetric(OvmsMetric* metric)
   m_metric = metric;
   }
 
-OvmsMetric* dbcSignal::GetMetric()
+OvmsMetric* dbcSignal::GetMetric() const
   {
   return m_metric;
   }
 
-void dbcSignal::WriteFile(dbcOutputCallback callback, void* param)
+void dbcSignal::WriteFile(dbcOutputCallback callback, void* param) const
   {
   std::ostringstream ss;
 
@@ -911,7 +911,7 @@ void dbcSignal::WriteFile(dbcOutputCallback callback, void* param)
 
 void dbcSignal::WriteFileComments(dbcOutputCallback callback,
                                   void* param,
-                                  std::string messageid)
+                                  std::string messageid) const
   {
   std::string prefix("CM_ SG_ ");
   prefix.append(messageid);
@@ -923,7 +923,7 @@ void dbcSignal::WriteFileComments(dbcOutputCallback callback,
 
 void dbcSignal::WriteFileValues(dbcOutputCallback callback,
                                   void* param,
-                                  std::string messageid)
+                                  std::string messageid) const
   {
   if (m_values.GetCount()>0)
     {
@@ -973,7 +973,7 @@ void dbcMessage::RemoveComment(const std::string& comment)
   m_comments.RemoveComment(comment);
   }
 
-bool dbcMessage::HasComment(const std::string& comment)
+bool dbcMessage::HasComment(const std::string& comment) const
   {
   return m_comments.HasComment(comment);
   }
@@ -1007,7 +1007,7 @@ dbcSignal* dbcMessage::FindSignal(std::string name)
   return NULL;
     }
 
-void dbcMessage::Count(int* signals, int* bits, int* covered)
+void dbcMessage::Count(int* signals, int* bits, int* covered) const
   {
   *bits = m_size*8;
   *signals = 0;
@@ -1019,22 +1019,22 @@ void dbcMessage::Count(int* signals, int* bits, int* covered)
     }
   }
 
-uint32_t dbcMessage::GetID()
+uint32_t dbcMessage::GetID() const
   {
   return m_id;
   }
 
-CAN_frame_format_t dbcMessage::GetFormat()
+CAN_frame_format_t dbcMessage::GetFormat() const
   {
   return ((m_id & 0x80000000) == 0)?CAN_frame_std:CAN_frame_ext;
   }
 
-bool dbcMessage::IsExtended()
+bool dbcMessage::IsExtended() const
   {
   return ((m_id & 0x80000000) != 0);
   }
 
-bool dbcMessage::IsStandard()
+bool dbcMessage::IsStandard() const
   {
   return ((m_id & 0x80000000) == 0);
   }
@@ -1044,7 +1044,7 @@ void dbcMessage::SetID(const uint32_t id)
   m_id = id;
   }
 
-int dbcMessage::GetSize()
+int dbcMessage::GetSize() const
   {
   return m_size;
   }
@@ -1054,7 +1054,7 @@ void dbcMessage::SetSize(const int size)
   m_size = size;
   }
 
-const std::string& dbcMessage::GetName()
+const std::string& dbcMessage::GetName() const
   {
   return m_name;
   }
@@ -1069,7 +1069,7 @@ void dbcMessage::SetName(const char* name)
   m_name = std::string(name);
   }
 
-const std::string& dbcMessage::GetTransmitterNode()
+const std::string& dbcMessage::GetTransmitterNode() const
   {
   return m_transmitter_node;
   }
@@ -1084,12 +1084,12 @@ void dbcMessage::SetTransmitterNode(const char* node)
   m_transmitter_node = std::string(node);
   }
 
-bool dbcMessage::IsMultiplexor()
+bool dbcMessage::IsMultiplexor() const
   {
-  return (m_multiplexor != NULL);
+  return (GetMultiplexorSignal() != NULL);
   }
 
-dbcSignal* dbcMessage::GetMultiplexorSignal()
+dbcSignal* dbcMessage::GetMultiplexorSignal() const
   {
   return m_multiplexor;
   }
@@ -1103,7 +1103,7 @@ void dbcMessage::SetMultiplexorSignal(dbcSignal* signal)
     }
   }
 
-void dbcMessage::WriteFile(dbcOutputCallback callback, void* param)
+void dbcMessage::WriteFile(dbcOutputCallback callback, void* param) const
   {
   std::ostringstream ss;
   ss << "BO_ ";
@@ -1125,7 +1125,7 @@ void dbcMessage::WriteFile(dbcOutputCallback callback, void* param)
   callback(param, "\n");
   }
 
-void dbcMessage::WriteFileComments(dbcOutputCallback callback, void* param)
+void dbcMessage::WriteFileComments(dbcOutputCallback callback, void* param) const
   {
   std::ostringstream ss;
   ss << m_id;
@@ -1141,7 +1141,7 @@ void dbcMessage::WriteFileComments(dbcOutputCallback callback, void* param)
     }
   }
 
-void dbcMessage::WriteFileValues(dbcOutputCallback callback, void* param)
+void dbcMessage::WriteFileValues(dbcOutputCallback callback, void* param) const
   {
   std::ostringstream ss;
   ss << m_id;
@@ -1177,7 +1177,7 @@ void dbcMessageTable::RemoveMessage(uint32_t id, bool free)
     }
   }
 
-dbcMessage* dbcMessageTable::FindMessage(uint32_t id)
+dbcMessage* dbcMessageTable::FindMessage(uint32_t id) const
   {
   auto search = m_entrymap.find(id);
   if (search != m_entrymap.end())
@@ -1186,7 +1186,7 @@ dbcMessage* dbcMessageTable::FindMessage(uint32_t id)
     return NULL;
   }
 
-dbcMessage* dbcMessageTable::FindMessage(CAN_frame_format_t format, uint32_t id)
+dbcMessage* dbcMessageTable::FindMessage(CAN_frame_format_t format, uint32_t id) const
   {
   if (format == CAN_frame_ext)
     id |= 0x80000000;
@@ -1200,13 +1200,13 @@ dbcMessage* dbcMessageTable::FindMessage(CAN_frame_format_t format, uint32_t id)
     return NULL;
   }
 
-void dbcMessageTable::Count(int* messages, int* signals, int* bits, int* covered)
+void dbcMessageTable::Count(int* messages, int* signals, int* bits, int* covered) const
   {
   *messages = 0;
   *signals = 0;
   *bits = 0;
   *covered = 0;
-  for (dbcMessageEntry_t::iterator itt = m_entrymap.begin();
+  for (dbcMessageEntry_t::const_iterator itt = m_entrymap.begin();
        itt != m_entrymap.end();
        itt++)
     {
@@ -1230,23 +1230,23 @@ void dbcMessageTable::EmptyContent()
   m_entrymap.clear();
   }
 
-void dbcMessageTable::WriteFile(dbcOutputCallback callback, void* param)
+void dbcMessageTable::WriteFile(dbcOutputCallback callback, void* param) const
   {
-  for (dbcMessageEntry_t::iterator itt = m_entrymap.begin();
+  for (dbcMessageEntry_t::const_iterator itt = m_entrymap.begin();
        itt != m_entrymap.end();
        itt++)
     itt->second->WriteFile(callback, param);
   }
 
-void dbcMessageTable::WriteFileComments(dbcOutputCallback callback, void* param)
+void dbcMessageTable::WriteFileComments(dbcOutputCallback callback, void* param) const
   {
-  for (dbcMessageEntry_t::iterator it=m_entrymap.begin();
+  for (dbcMessageEntry_t::const_iterator it=m_entrymap.begin();
        it != m_entrymap.end();
        ++it)
     {
     it->second->WriteFileComments(callback, param);
     }
-  for (dbcMessageEntry_t::iterator it=m_entrymap.begin();
+  for (dbcMessageEntry_t::const_iterator it=m_entrymap.begin();
        it != m_entrymap.end();
        ++it)
     {
@@ -1254,9 +1254,9 @@ void dbcMessageTable::WriteFileComments(dbcOutputCallback callback, void* param)
     }
   }
 
-void dbcMessageTable::WriteSummary(dbcOutputCallback callback, void* param)
+void dbcMessageTable::WriteSummary(dbcOutputCallback callback, void* param) const
   {
-  for (dbcMessageEntry_t::iterator itt = m_entrymap.begin();
+  for (dbcMessageEntry_t::const_iterator itt = m_entrymap.begin();
        itt != m_entrymap.end();
        itt++)
     itt->second->WriteFile(callback, param);
@@ -1344,7 +1344,7 @@ bool dbcfile::LoadString(const char* name, const char* source, size_t length)
   return result;
   }
 
-void dbcfile::WriteFile(dbcOutputCallback callback, void* param)
+void dbcfile::WriteFile(dbcOutputCallback callback, void* param) const
   {
   callback(param,"VERSION \"");
   callback(param,m_version.c_str());
@@ -1360,7 +1360,7 @@ void dbcfile::WriteFile(dbcOutputCallback callback, void* param)
   m_messages.WriteFileComments(callback, param);
   }
 
-void dbcfile::WriteSummary(dbcOutputCallback callback, void* param)
+void dbcfile::WriteSummary(dbcOutputCallback callback, void* param) const
   {
   callback(param,"Path:    ");
   callback(param,m_path.c_str());
@@ -1373,7 +1373,7 @@ void dbcfile::WriteSummary(dbcOutputCallback callback, void* param)
   m_messages.WriteSummary(callback, param);
   }
 
-std::string dbcfile::Status()
+std::string dbcfile::Status() const
   {
   std::ostringstream ss;
   int messages, signals, bits, covered;
@@ -1400,17 +1400,17 @@ std::string dbcfile::Status()
   return ss.str();
   }
 
-std::string dbcfile::GetName()
+std::string dbcfile::GetName() const
   {
   return m_name;
   }
 
-std::string dbcfile::GetPath()
+std::string dbcfile::GetPath() const
   {
   return m_path;
   }
 
-std::string dbcfile::GetVersion()
+std::string dbcfile::GetVersion() const
   {
   return m_version;
   }
@@ -1425,7 +1425,7 @@ void dbcfile::UnlockFile()
   m_locks--;
   }
 
-bool dbcfile::IsLocked()
+bool dbcfile::IsLocked() const
   {
   return (m_locks > 0);
   }

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.h
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.h
@@ -82,13 +82,13 @@ class dbcCommentTable
     void AddComment(std::string comment);
     void AddComment(const char* comment);
     void RemoveComment(std::string comment);
-    bool HasComment(std::string comment);
+    bool HasComment(std::string comment) const;
 
   public:
     void EmptyContent();
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param, std::string prefix);
+    void WriteFile(dbcOutputCallback callback, void* param, std::string prefix) const;
 
   public:
     dbcCommentList_t m_entrymap;
@@ -112,7 +112,7 @@ class dbcNewSymbolTable
     int GetCount();
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param);
+    void WriteFile(dbcOutputCallback callback, void* param) const;
 
   public:
     dbcNewSymbolList_t m_entrymap;
@@ -163,8 +163,8 @@ class dbcNodeTable
     void EmptyContent();
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param);
-    void WriteFileComments(dbcOutputCallback callback, void* param);
+    void WriteFile(dbcOutputCallback callback, void* param) const;
+    void WriteFileComments(dbcOutputCallback callback, void* param) const;
 
   public:
     dbcNodeEntry_t m_entrymap;
@@ -184,7 +184,7 @@ class dbcBitTiming
     void SetBaud(const uint32_t baudrate, const uint32_t btr1, const uint32_t btr2);
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param);
+    void WriteFile(dbcOutputCallback callback, void* param) const;
 
   protected:
     uint32_t m_baudrate;
@@ -205,18 +205,18 @@ class dbcValueTable
     void AddValue(uint32_t id, std::string value);
     void AddValue(uint32_t id, const char* value);
     void RemoveValue(uint32_t id);
-    bool HasValue(uint32_t id);
-    std::string GetValue(uint32_t id);
-    const std::string& GetName();
+    bool HasValue(uint32_t id) const;
+    std::string GetValue(uint32_t id) const;
+    const std::string& GetName() const;
     void SetName(const std::string& name);
     void SetName(const char* name);
-    int GetCount();
+    int GetCount() const;
 
   public:
     void EmptyContent();
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param, const char* prefix);
+    void WriteFile(dbcOutputCallback callback, void* param, const char* prefix) const;
 
   public:
     dbcValueTableEntry_t m_entrymap;
@@ -242,7 +242,7 @@ class dbcValueTableTable
     void EmptyContent();
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param);
+    void WriteFile(dbcOutputCallback callback, void* param) const;
 
   public:
     dbcValueTableTableEntry_t m_entrymap;
@@ -266,27 +266,27 @@ class dbcSignal
     bool HasComment(std::string comment);
     void AddValue(uint32_t id, std::string value);
     void RemoveValue(uint32_t id);
-    bool HasValue(uint32_t id);
-    std::string GetValue(uint32_t id);
+    bool HasValue(uint32_t id) const;
+    std::string GetValue(uint32_t id) const;
 
   public:
-    const std::string& GetName();
+    const std::string& GetName() const;
     void SetName(const std::string& name);
     void SetName(const char* name);
-    bool IsMultiplexor();
-    bool IsMultiplexSwitch();
+    bool IsMultiplexor() const;
+    bool IsMultiplexSwitch() const;
     void SetMultiplexor();
-    uint32_t GetMultiplexSwitchvalue();
+    uint32_t GetMultiplexSwitchvalue() const;
     bool SetMultiplexed(const uint32_t switchvalue);
     bool ClearMultiplexed();
-    int GetStartBit();
-    int GetSignalSize();
-    dbcByteOrder_t GetByteOrder();
-    dbcValueType_t GetValueType();
-    dbcNumber GetFactor();
-    dbcNumber GetOffset();
-    dbcNumber GetMinimum();
-    dbcNumber GetMaximum();
+    int GetStartBit() const;
+    int GetSignalSize() const;
+    dbcByteOrder_t GetByteOrder() const;
+    dbcValueType_t GetValueType() const;
+    dbcNumber GetFactor() const;
+    dbcNumber GetOffset() const;
+    dbcNumber GetMinimum() const;
+    dbcNumber GetMaximum() const;
     void SetStartSize(const int startbit, const int size);
     void SetByteOrder(const dbcByteOrder_t order);
     void SetValueType(const dbcValueType_t type);
@@ -294,22 +294,24 @@ class dbcSignal
     void SetFactorOffset(const double factor, const double offset);
     void SetMinMax(const dbcNumber minimum, const dbcNumber maximum);
     void SetMinMax(const double minimum, const double maximum);
-    const std::string& GetUnit();
+    const std::string& GetUnit() const;
     void SetUnit(const std::string& unit);
     void SetUnit(const char* unit);
 
   public:
     void Encode(dbcNumber* source, CAN_frame_t* msg);
-    dbcNumber Decode(CAN_frame_t* msg);
+
+    dbcNumber Decode(const CAN_frame_t* msg) const;
 
   public:
     void AssignMetric(OvmsMetric* metric);
-    OvmsMetric* GetMetric();
+    OvmsMetric* GetMetric() const;
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param);
-    void WriteFileComments(dbcOutputCallback callback, void* param, std::string messageid);
-    void WriteFileValues(dbcOutputCallback callback, void* param, std::string messageid);
+    void WriteFile(dbcOutputCallback callback, void* param) const;
+    void WriteFileComments(dbcOutputCallback callback, void* param, std::string messageid) const;
+    void WriteFileValues(dbcOutputCallback callback, void* param, std::string messageid) const;
+    void WriteFileExtended(dbcOutputCallback callback, void* param, std::string messageid) const;
 
   public:
     dbcReceiverList_t m_receivers;
@@ -344,34 +346,35 @@ class dbcMessage
     void RemoveSignal(dbcSignal* signal, bool free=false);
     void RemoveAllSignals(bool free=false);
     dbcSignal* FindSignal(std::string name);
-    void Count(int* signals, int* bits, int* covered);
+    void Count(int* signals, int* bits, int* covered) const;
 
   public:
     void AddComment(const std::string& comment);
     void AddComment(const char* comment);
     void RemoveComment(const std::string& comment);
-    bool HasComment(const std::string& comment);
-    uint32_t GetID();
-    CAN_frame_format_t GetFormat();
-    bool IsExtended();
-    bool IsStandard();
+    bool HasComment(const std::string& comment) const;
+    uint32_t GetID() const;
+    CAN_frame_format_t GetFormat() const;
+    bool IsExtended() const;
+    bool IsStandard() const;
     void SetID(const uint32_t id);
-    int GetSize();
+    int GetSize() const;
     void SetSize(const int size);
-    const std::string& GetName();
+    const std::string& GetName() const;
     void SetName(const std::string& name);
     void SetName(const char* name);
-    const std::string& GetTransmitterNode();
+    const std::string& GetTransmitterNode() const;
     void SetTransmitterNode(std::string node);
     void SetTransmitterNode(const char* node);
-    bool IsMultiplexor();
-    dbcSignal* GetMultiplexorSignal();
+    bool IsMultiplexor() const;
+    dbcSignal* GetMultiplexorSignal() const;
     void SetMultiplexorSignal(dbcSignal* signal);
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param);
-    void WriteFileComments(dbcOutputCallback callback, void* param);
-    void WriteFileValues(dbcOutputCallback callback, void* param);
+    void WriteFile(dbcOutputCallback callback, void* param) const;
+    void WriteFileComments(dbcOutputCallback callback, void* param) const;
+    void WriteFileValues(dbcOutputCallback callback, void* param) const;
+    void WriteFileExtended(dbcOutputCallback callback, void* param) const;
 
   public:
     dbcSignalList_t m_signals;
@@ -395,18 +398,18 @@ class dbcMessageTable
   public:
     void AddMessage(uint32_t id, dbcMessage* message);
     void RemoveMessage(uint32_t id, bool free=false);
-    dbcMessage* FindMessage(uint32_t id);
-    dbcMessage* FindMessage(CAN_frame_format_t format, uint32_t id);
-    void Count(int* messages, int* signals, int* bits, int* covered);
+    dbcMessage* FindMessage(uint32_t id) const;
+    dbcMessage* FindMessage(CAN_frame_format_t format, uint32_t id) const;
+    void Count(int* messages, int* signals, int* bits, int* covered) const;
 
   public:
     void EmptyContent();
 
   public:
-    void WriteFile(dbcOutputCallback callback, void* param);
-    void WriteFileComments(dbcOutputCallback callback, void* param);
-    void WriteFileValues(dbcOutputCallback callback, void* param);
-    void WriteSummary(dbcOutputCallback callback, void* param);
+    void WriteFile(dbcOutputCallback callback, void* param) const;
+    void WriteFileComments(dbcOutputCallback callback, void* param) const;
+    void WriteFileValues(dbcOutputCallback callback, void* param) const;
+    void WriteSummary(dbcOutputCallback callback, void* param) const;
 
   public:
     dbcMessageEntry_t m_entrymap;
@@ -424,17 +427,17 @@ class dbcfile
   public:
     bool LoadFile(const char* name, const char* path, FILE *fd=NULL);
     bool LoadString(const char* name, const char* source, size_t length);
-    void WriteFile(dbcOutputCallback callback, void* param);
-    void WriteSummary(dbcOutputCallback callback, void* param);
-    std::string Status();
-    std::string GetName();
-    std::string GetPath();
-    std::string GetVersion();
+    void WriteFile(dbcOutputCallback callback, void* param) const;
+    void WriteSummary(dbcOutputCallback callback, void* param) const;
+    std::string Status() const;
+    std::string GetName() const;
+    std::string GetPath() const;
+    std::string GetVersion() const;
 
   public:
     void LockFile();
     void UnlockFile();
-    bool IsLocked();
+    bool IsLocked() const;
 
   public:
     std::string m_name;

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.h
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.h
@@ -297,11 +297,15 @@ class dbcSignal
     const std::string& GetUnit() const;
     void SetUnit(const std::string& unit);
     void SetUnit(const char* unit);
+    metric_unit_t GetMetricUnit() const
+      {
+      return m_metric_unit;
+      }
 
   public:
     void Encode(dbcNumber* source, CAN_frame_t* msg);
 
-    dbcNumber Decode(const CAN_frame_t* msg) const;
+    dbcNumber Decode(const uint8_t* msg, uint8_t size) const;
 
   public:
     void AssignMetric(OvmsMetric* metric);
@@ -330,6 +334,8 @@ class dbcSignal
     dbcNumber m_minimum;
     dbcNumber m_maximum;
     std::string m_unit;
+    metric_unit_t m_metric_unit;
+
     OvmsMetric* m_metric;
   };
 
@@ -439,6 +445,7 @@ class dbcfile
     void UnlockFile();
     bool IsLocked() const;
 
+    void DecodeSignal(CAN_frame_format_t format, uint32_t msg_id, const uint8_t* msg, uint8_t size) const;
   public:
     std::string m_name;
     std::string m_path;

--- a/vehicle/OVMS.V3/components/dbc/src/dbc_number.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc_number.cpp
@@ -64,22 +64,22 @@ void dbcNumber::Clear()
   m_type = DBC_NUMBER_NONE;
   }
 
-bool dbcNumber::IsDefined()
+bool dbcNumber::IsDefined() const
   {
   return (m_type != DBC_NUMBER_NONE);
   }
 
-bool dbcNumber::IsSignedInteger()
+bool dbcNumber::IsSignedInteger() const
   {
   return (m_type == DBC_NUMBER_INTEGER_SIGNED);
   }
 
-bool dbcNumber::IsUnsignedInteger()
+bool dbcNumber::IsUnsignedInteger() const
   {
   return (m_type == DBC_NUMBER_INTEGER_UNSIGNED);
   }
 
-bool dbcNumber::IsDouble()
+bool dbcNumber::IsDouble() const
   {
   return (m_type == DBC_NUMBER_DOUBLE);
   }
@@ -132,7 +132,7 @@ void dbcNumber::Cast(uint32_t value, dbcNumberType_t type)
     }
   }
 
-int32_t dbcNumber::GetSignedInteger()
+int32_t dbcNumber::GetSignedInteger() const
   {
   switch (m_type)
     {
@@ -151,7 +151,7 @@ int32_t dbcNumber::GetSignedInteger()
     }
   }
 
-uint32_t dbcNumber::GetUnsignedInteger()
+uint32_t dbcNumber::GetUnsignedInteger() const
   {
   switch (m_type)
     {
@@ -170,7 +170,7 @@ uint32_t dbcNumber::GetUnsignedInteger()
     }
   }
 
-double dbcNumber::GetDouble()
+double dbcNumber::GetDouble() const
   {
   switch (m_type)
     {
@@ -357,17 +357,17 @@ dbcNumber dbcNumber::operator+(const dbcNumber& value)
   return dbcNumber((uint32_t)0);
   }
 
-bool dbcNumber::operator==(const int32_t value)
+bool dbcNumber::operator==(const int32_t value) const
   {
   return ((m_type == DBC_NUMBER_INTEGER_SIGNED)&&(m_value.sintval==value));
   }
 
-bool dbcNumber::operator==(const uint32_t value)
+bool dbcNumber::operator==(const uint32_t value) const
   {
   return ((m_type == DBC_NUMBER_INTEGER_UNSIGNED)&&(m_value.uintval==value));
   }
 
-bool dbcNumber::operator==(const double value)
+bool dbcNumber::operator==(const double value) const
   {
   return ((m_type == DBC_NUMBER_DOUBLE)&&(m_value.doubleval==value));
   }

--- a/vehicle/OVMS.V3/components/dbc/src/dbc_number.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc_number.cpp
@@ -359,15 +359,45 @@ dbcNumber dbcNumber::operator+(const dbcNumber& value)
 
 bool dbcNumber::operator==(const int32_t value) const
   {
-  return ((m_type == DBC_NUMBER_INTEGER_SIGNED)&&(m_value.sintval==value));
+  switch (m_type)
+    {
+    case DBC_NUMBER_INTEGER_SIGNED:
+      return m_value.sintval == value;
+    case DBC_NUMBER_INTEGER_UNSIGNED:
+      return (value >= 0) && (uint32_t(value) == m_value.uintval);
+    case DBC_NUMBER_DOUBLE:
+      return double(value) == m_value.doubleval;
+    default:
+      return false;
+    }
   }
 
 bool dbcNumber::operator==(const uint32_t value) const
   {
-  return ((m_type == DBC_NUMBER_INTEGER_UNSIGNED)&&(m_value.uintval==value));
+  switch (m_type)
+    {
+    case DBC_NUMBER_INTEGER_SIGNED:
+      return (m_value.sintval >= 0) && (value == uint32_t(m_value.sintval));
+    case DBC_NUMBER_INTEGER_UNSIGNED:
+      return m_value.uintval == value;
+    case DBC_NUMBER_DOUBLE:
+      return double(value) == m_value.doubleval;
+    default:
+      return false;
+    }
   }
 
 bool dbcNumber::operator==(const double value) const
   {
-  return ((m_type == DBC_NUMBER_DOUBLE)&&(m_value.doubleval==value));
+  switch (m_type)
+    {
+    case DBC_NUMBER_INTEGER_SIGNED:
+      return (value == double(m_value.sintval));
+    case DBC_NUMBER_INTEGER_UNSIGNED:
+      return (value == double(m_value.uintval));
+    case DBC_NUMBER_DOUBLE:
+      return value == m_value.doubleval;
+    default:
+      return false;
+    }
   }

--- a/vehicle/OVMS.V3/components/dbc/src/dbc_number.h
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc_number.h
@@ -54,17 +54,17 @@ class dbcNumber
 
   public:
     void Clear();
-    bool IsDefined();
-    bool IsSignedInteger();
-    bool IsUnsignedInteger();
-    bool IsDouble();
+    bool IsDefined() const;
+    bool IsSignedInteger() const;
+    bool IsUnsignedInteger() const;
+    bool IsDouble() const;
     void Set(int32_t value);
     void Set(uint32_t value);
     void Set(double value);
     void Cast(uint32_t value, dbcNumberType_t type);
-    int32_t GetSignedInteger();
-    uint32_t GetUnsignedInteger();
-    double GetDouble();
+    int32_t GetSignedInteger() const;
+    uint32_t GetUnsignedInteger() const;
+    double GetDouble() const;
     friend std::ostream& operator<<(std::ostream& os, const dbcNumber& me);
     dbcNumber& operator=(const int32_t value);
     dbcNumber& operator=(const uint32_t value);
@@ -72,9 +72,9 @@ class dbcNumber
     dbcNumber& operator=(const dbcNumber& value);
     dbcNumber operator*(const dbcNumber& value);
     dbcNumber operator+(const dbcNumber& value);
-    bool operator==(const int32_t value);
-    bool operator==(const uint32_t value);
-    bool operator==(const double value);
+    bool operator==(const int32_t value) const;
+    bool operator==(const uint32_t value) const;
+    bool operator==(const double value) const;
 
   protected:
     dbcNumberType_t m_type;

--- a/vehicle/OVMS.V3/components/retools/src/retools.cpp
+++ b/vehicle/OVMS.V3/components/retools/src/retools.cpp
@@ -272,7 +272,7 @@ std::string re::GetKey(CAN_frame_t* frame)
         {
         // We have a multiplexed signal
         dbcSignal* s = m->GetMultiplexorSignal();
-        dbcNumber muxn = s->Decode(frame);
+        dbcNumber muxn = s->Decode(frame->data.u8, 8);
         uint32_t mux = muxn.GetUnsignedInteger();
         char b[8];
         sprintf(b,":%04" PRIx32,mux);
@@ -493,7 +493,7 @@ void re_dbc_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
             uint32_t muxval;
             if (mux)
               {
-              dbcNumber r = mux->Decode(&it->second->last);
+              dbcNumber r = mux->Decode(it->second->last.data.u8, 8);
               muxval = r.GetSignedInteger();
               std::ostringstream ss;
               ss << "  dbc/mux/";
@@ -508,7 +508,7 @@ void re_dbc_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, 
               {
               if ((mux==NULL)||(sig->GetMultiplexSwitchvalue() == muxval))
                 {
-                dbcNumber r = sig->Decode(&it->second->last);
+                dbcNumber r = sig->Decode(it->second->last.data.u8, 8);
                 std::ostringstream ss;
                 ss << "  dbc/";
                 ss << sig->GetName();

--- a/vehicle/OVMS.V3/components/vehicle_dbc/src/vehicle_dbc.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_dbc/src/vehicle_dbc.cpp
@@ -84,30 +84,7 @@ void OvmsVehicleDBC::IncomingFrame(canbus* bus, CAN_frame_t* frame)
   {
   dbcfile* dbc = bus->GetDBC();
   if (dbc==NULL) return;
-
-  dbcMessage* msg = dbc->m_messages.FindMessage(frame->FIR.B.FF, frame->MsgID);
-  if (msg)
-    {
-    dbcSignal* mux = msg->GetMultiplexorSignal();
-    uint32_t muxval;
-    if (mux)
-      {
-      dbcNumber r = mux->Decode(frame);
-      muxval = r.GetSignedInteger();
-      }
-    for (dbcSignal* sig : msg->m_signals)
-      {
-      OvmsMetric* m = sig->GetMetric();
-      if (m)
-        {
-        if ((mux==NULL)||(sig->GetMultiplexSwitchvalue() == muxval))
-          {
-          dbcNumber r = sig->Decode(frame);
-          m->SetValue(r);
-          }
-        }
-      }
-    }
+  dbc->DecodeSignal(frame->FIR.B.FF, frame->MsgID, frame->data.u8, 8);
   }
 
 OvmsVehiclePureDBC::OvmsVehiclePureDBC()

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -1561,7 +1561,7 @@ bool OvmsMetric::SetValue(std::string value, metric_unit_t units)
   return false;
   }
 
-bool OvmsMetric::SetValue(dbcNumber& value)
+bool OvmsMetric::SetValue(const dbcNumber& value, metric_unit_t units)
   {
   return false;
   }
@@ -1988,9 +1988,9 @@ bool OvmsMetricInt::SetValue(std::string value, metric_unit_t units)
   return SetValue(nvalue, units);
   }
 
-bool OvmsMetricInt::SetValue(dbcNumber& value)
+bool OvmsMetricInt::SetValue(const dbcNumber& value, metric_unit_t units)
   {
-  return SetValue(value.GetSignedInteger());
+  return SetValue(value.GetSignedInteger(), units);
   }
 
 void OvmsMetricInt::Clear()
@@ -2147,9 +2147,9 @@ bool OvmsMetricBool::SetValue(std::string value, metric_unit_t units)
     }
   }
 
-bool OvmsMetricBool::SetValue(dbcNumber& value)
+bool OvmsMetricBool::SetValue(const dbcNumber& value, metric_unit_t units)
   {
-  return SetValue((bool)value.GetUnsignedInteger());
+  return SetValue((bool)value.GetUnsignedInteger(), units);
   }
 
 void OvmsMetricBool::Clear()
@@ -2312,9 +2312,9 @@ bool OvmsMetricFloat::SetValue(std::string value, metric_unit_t units)
   return SetValue(nvalue, units);
   }
 
-bool OvmsMetricFloat::SetValue(dbcNumber& value)
+bool OvmsMetricFloat::SetValue(const dbcNumber& value, metric_unit_t units)
   {
-  return SetValue((float)value.GetDouble());
+  return SetValue((float)value.GetDouble(), units);
   }
 
 void OvmsMetricFloat::Clear()
@@ -2684,9 +2684,9 @@ bool OvmsMetricInt64::SetValue(std::string value, metric_unit_t units)
   return SetValue(nvalue, units);
   }
 
-bool OvmsMetricInt64::SetValue(dbcNumber& value)
+bool OvmsMetricInt64::SetValue(const dbcNumber& value, metric_unit_t units)
   {
-  return SetValue(value.GetSignedInteger());
+  return SetValue(value.GetSignedInteger(), units);
   }
 
 void OvmsMetricInt64::Clear()
@@ -2716,7 +2716,7 @@ const char* OvmsMetricUnitName(metric_unit_t units)
   return unit_info[unit_i].UnitCode;
   }
 
-metric_unit_t OvmsMetricUnitFromName(const char* unit, bool allowUniquePrefix)
+static metric_unit_t match_metric_unit(const char* unit, bool allowUniquePrefix,bool fromName)
   {
   if (unit == NULL || unit[0] == '\0')
     return Native;
@@ -2725,7 +2725,8 @@ metric_unit_t OvmsMetricUnitFromName(const char* unit, bool allowUniquePrefix)
   int unit_len = strlen(unit);
   for (metric_unit_t metric = MetricUnitFirst; metric <= MetricUnitLast; metric = metric_unit_t(1+(uint8_t)metric))
     {
-    const char * name = unit_info[(uint8_t)metric].UnitCode;
+    const OvmsUnitInfo &info = unit_info[(uint8_t)metric];
+    const char * name = fromName ? info.UnitCode : info.Label;
     if (name == NULL)
       continue;
 
@@ -2742,6 +2743,14 @@ metric_unit_t OvmsMetricUnitFromName(const char* unit, bool allowUniquePrefix)
       }
     }
   return res;
+  }
+metric_unit_t OvmsMetricUnitFromName(const char* unit, bool allowUniquePrefix)
+  {
+  return match_metric_unit(unit, allowUniquePrefix, true);
+  }
+metric_unit_t OvmsMetricUnitFromLabel(const char* unit)
+  {
+  return match_metric_unit(unit, false, false);
   }
 
 const char *OvmsMetricUnit_FindUniquePrefix(const char* token)

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -1570,12 +1570,12 @@ void OvmsMetric::operator=(std::string value)
   {
   }
 
-uint32_t OvmsMetric::LastModified()
+uint32_t OvmsMetric::LastModified() const
   {
   return m_lastmodified;
   }
 
-uint32_t OvmsMetric::Age()
+uint32_t OvmsMetric::Age() const
   {
   return monotonictime - m_lastmodified;
   }
@@ -1595,7 +1595,7 @@ void OvmsMetric::SetModified(bool changed)
     }
   }
 
-bool OvmsMetric::IsUnitSend(size_t modifier)
+bool OvmsMetric::IsUnitSend(size_t modifier) const
   {
     return m_sendunit & (1ul << modifier);
   }
@@ -1619,17 +1619,17 @@ void OvmsMetric::SetUnitSendAll()
   m_sendunit = ULONG_MAX;
   }
 
-bool OvmsMetric::IsDefined()
+bool OvmsMetric::IsDefined() const
   {
   return (m_defined != NeverDefined);
   }
 
-bool OvmsMetric::IsFirstDefined()
+bool OvmsMetric::IsFirstDefined() const
   {
   return (m_defined == FirstDefined);
   }
 
-bool OvmsMetric::IsPersistent()
+bool OvmsMetric::IsPersistent() const
   {
   return m_persist;
   }
@@ -1678,7 +1678,7 @@ bool OvmsMetric::IsFresh()
   }
 
 
-bool OvmsMetric::IsModified(size_t modifier)
+bool OvmsMetric::IsModified(size_t modifier) const
   {
   return m_modified & 1ul << modifier;
   }

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -172,6 +172,7 @@ const metric_group_t MetricGroupLast = GrpAccelShort;
 extern const char* OvmsMetricUnitLabel(metric_unit_t units);
 extern const char* OvmsMetricUnitName(metric_unit_t units);
 extern metric_unit_t OvmsMetricUnitFromName(const char* unit, bool allowUniquePrefix = false);
+extern metric_unit_t OvmsMetricUnitFromLabel(const char* unit);
 int OvmsMetricUnit_Validate(OvmsWriter* writer, int argc, const char* token, bool complete, metric_group_t group = GrpNone);
 const char *OvmsMetricUnit_FindUniquePrefix(const char* token);
 
@@ -234,7 +235,7 @@ class OvmsMetric
     virtual void DukPush(DukContext &dc, metric_unit_t units = Other);
 #endif
     virtual bool SetValue(std::string value, metric_unit_t units = Other);
-    virtual bool SetValue(dbcNumber& value);
+    virtual bool SetValue(const dbcNumber& value, metric_unit_t units = Other);
     virtual void operator=(std::string value);
     virtual bool CheckPersist();
     virtual void RefreshPersist();
@@ -300,7 +301,7 @@ class OvmsMetricBool : public OvmsMetric
     bool SetValue(bool value);
     void operator=(bool value) { SetValue(value); }
     bool SetValue(std::string value, metric_unit_t units = Other) override;
-    bool SetValue(dbcNumber& value) override;
+    bool SetValue(const dbcNumber& value, metric_unit_t units = Other) override;
     void operator=(std::string value) override { SetValue(value); }
     void Clear() override;
     bool CheckPersist() override;
@@ -328,7 +329,7 @@ class OvmsMetricInt : public OvmsMetric
     bool SetValue(int value, metric_unit_t units = Other);
     void operator=(int value) { SetValue(value); }
     bool SetValue(std::string value, metric_unit_t units = Other) override;
-    bool SetValue(dbcNumber& value) override;
+    bool SetValue(const dbcNumber& value, metric_unit_t units = Other) override;
     void operator=(std::string value) override { SetValue(value); }
     void Clear() override;
     bool CheckPersist() override;
@@ -357,7 +358,7 @@ class OvmsMetricFloat : public OvmsMetric
     bool SetValue(float value, metric_unit_t units = Other);
     void operator=(float value) { SetValue(value); }
     bool SetValue(std::string value, metric_unit_t units = Other) override;
-    bool SetValue(dbcNumber& value) override;
+    bool SetValue(const dbcNumber& value, metric_unit_t units = Other) override;
     void operator=(std::string value) override { SetValue(value); }
     void Clear() override;
     bool CheckPersist() override;
@@ -1112,7 +1113,7 @@ class OvmsMetricInt64 : public OvmsMetric64
     // Bring other overridden SetValue into scope from  OVMSMetric64
     using OvmsMetric64::SetValue;
     bool SetValue(int64_t value, metric_unit_t units = Other);
-    bool SetValue(dbcNumber& value) override;
+    bool SetValue(const dbcNumber& value, metric_unit_t units = Other) override;
     bool SetValue(std::string value, metric_unit_t units = Other) override;
 
     // Bring other overridden = operator into scope from  OVMSMetric64

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -241,11 +241,11 @@ class OvmsMetric
     virtual bool IsString() { return false; };
     virtual void Clear();
 
-    uint32_t LastModified();
-    uint32_t Age();
-    bool IsDefined();
-    bool IsFirstDefined();
-    bool IsPersistent();
+    uint32_t LastModified() const;
+    uint32_t Age() const;
+    bool IsDefined() const;
+    bool IsFirstDefined() const;
+    bool IsPersistent() const;
     bool IsStale();
     bool IsFresh();
     void SetStale(bool stale)
@@ -256,16 +256,16 @@ class OvmsMetric
       {
       m_autostale = seconds;
       }
-    metric_unit_t GetUnits()
+    metric_unit_t GetUnits() const
       {
       return m_units;
       }
-    bool IsModified(size_t modifier);
+    bool IsModified(size_t modifier) const;
     bool IsModifiedAndClear(size_t modifier);
     void ClearModified(size_t modifier);
     void SetModified(bool changed=true);
 
-    bool IsUnitSend(size_t modifier);
+    bool IsUnitSend(size_t modifier) const;
     bool IsUnitSendAndClear(size_t modifier);
     void ClearUnitSend(size_t modifier);
     void SetUnitSend(size_t modifier);


### PR DESCRIPTION
Uses the units in the DBC file, and converts them to Ovms Units so unit conversions can be done when setting the metric values.

Supports the ovms metric name and metric label.

There is some re-factoring done here of the Decode function pulling it back to the dbcFile