### PR TITLE
Poller tweaks for handling queue getting overrun

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/can.h
+++ b/vehicle/OVMS.V3/components/can/src/can.h
@@ -228,6 +228,10 @@ class canfilter
     bool IsFiltered(const CAN_frame_t* p_frame);
     bool IsFiltered(canbus* bus);
     std::string Info();
+    bool HasFilters()
+      {
+      return !m_filters.empty();
+      }
 
   protected:
     CAN_filter_list_t m_filters;

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -1288,21 +1288,13 @@ void OvmsPollers::PollerTask()
     if (xQueueReceive(m_pollqueue, &entry, (portTickType)portMAX_DELAY)!=pdTRUE)
       continue;
 
-    for (int istx = 0; istx < 2; ++istx)
-      {
-      uint32_t ovf_count = Atomic_Get(m_overflow_count[istx]);
-      if (ovf_count > 0)
-        {
-        ESP_LOGI(TAG, "Poller[Frame]: %s Task Queue Overflow Run %" PRIu32, ( istx ? "TX" : "RX"), ovf_count);
-        Atomic_Subtract( m_overflow_count[istx], ovf_count);
-        }
-      }
     IFTRACE(Times)
       {
       if (entry.entry_type == OvmsPoller::OvmsPollEntryType::PollState)
         {
         // Make sure the every second (ish), we have caught up on averages-by-period measurements.
         uint64_t curtime = esp_timer_get_time();
+        OvmsMutexLock lock(&m_stats_mutex);
         for (auto it = m_poll_time_stats.begin(); it != m_poll_time_stats.end(); ++it)
           it->second.catchup(curtime);
         }
@@ -1317,6 +1309,7 @@ void OvmsPollers::PollerTask()
         }
       if (entry.entry_Command.cmd == OvmsPoller::OvmsPollCommand::ResetTimer)
         {
+        OvmsMutexLock lock(&m_stats_mutex);
         if (entry.entry_Command.parameter == 2)
           {
           for (auto it = m_poll_time_stats.begin(); it != m_poll_time_stats.end(); ++it)
@@ -1338,17 +1331,20 @@ void OvmsPollers::PollerTask()
     if (m_shut_down)
       break;
 
-    timer_util_t timer(
-      [&entry,this](uint64_t start, uint64_t finish)
-        {
-        IFTRACE(Times)
+    std::unique_ptr<timer_util_t> timer;
+
+    IFTRACE(Times)
+      timer = std::unique_ptr<timer_util_t>(new timer_util_t(
+        [&entry,this](uint64_t start, uint64_t finish)
           {
-          int32_t diff = finish-start;
-          poller_key_t key(entry);
-          m_poll_time_stats[key].add_time(diff, finish);
+            {
+            int32_t diff = finish-start;
+            poller_key_t key(entry);
+            OvmsMutexLock lock(&m_stats_mutex);
+            m_poll_time_stats[key].add_time(diff, finish);
+            }
           }
-        }
-      );
+        ));
 
     m_poll_last = monotonictime;
     switch (entry.entry_type)
@@ -1371,6 +1367,16 @@ void OvmsPollers::PollerTask()
         }
         break;
       case OvmsPoller::OvmsPollEntryType::Poll:
+        {
+        for (int istx = 0; istx < 2; ++istx)
+          {
+          uint32_t ovf_count = Atomic_Get(m_overflow_count[istx]);
+          if (ovf_count > 0)
+            {
+            ESP_LOGI(TAG, "Poller[Frame]: %s Task Queue Overflow Run %" PRIu32, ( istx ? "TX" : "RX"), ovf_count);
+            Atomic_Subtract( m_overflow_count[istx], ovf_count);
+            }
+          }
         if (!m_user_paused && !m_paused)
           {
           // Must not lock mutex while calling.
@@ -1399,6 +1405,7 @@ void OvmsPollers::PollerTask()
               }
             }
           }
+        }
         break;
       case OvmsPoller::OvmsPollEntryType::Command:
         switch (entry.entry_Command.cmd)
@@ -2088,7 +2095,14 @@ bool OvmsPollers::LoadTimesTrace( metric_unit_t ratio_unit, times_trace_t &trace
   uint32_t avg_time_sum_us = 0;
   uint32_t avg_utlzn_sum_us = 0;
   uint32_t avg_count_sum = 0;
-  for (auto it = m_poll_time_stats.begin(); it != m_poll_time_stats.end(); ++it)
+  std::list<std::pair<poller_key_t, average_value_t> > copy;
+  // Lock for the shortest time possible... copy the current values.
+  m_stats_mutex.Lock();
+  for (const auto &val : m_poll_time_stats)
+    copy.push_back(val);
+  m_stats_mutex.Unlock();
+
+  for (auto it = copy.begin(); it != copy.end(); ++it)
     {
     average_value_t &cur = it->second;
     uint16_t max_val = cur.max_val;

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -729,6 +729,9 @@ class OvmsPollers : public InternalRamAllocated {
     typedef enum {trace_Off = 0x00, trace_Poller = 0x1, trace_TXRX = 0x2, trace_Times = 0x4, trace_All= 0x3} tracetype_t;
     uint8_t           m_trace;                // Current Trace flags.
     uint32_t          m_overflow_count[2];    // Keep track of overflows.
+                                              //
+    OvmsMutex         m_filter_mutex;
+    canfilter         m_filter;
 
     void PollerTxCallback(const CAN_frame_t* frame, bool success);
     void PollerRxCallback(const CAN_frame_t* frame, bool success);
@@ -792,6 +795,12 @@ class OvmsPollers : public InternalRamAllocated {
     bool IsTracingTimes() { return (m_trace & trace_Times) != 0; }
     typedef std::function<void(canbus*, void *)> PollCallback;
     typedef std::function<void(const CAN_frame_t &)> FrameCallback;
+
+    // CAN RX filtering.
+    void ClearFilters();
+    void AddFilter(uint8_t bus, uint32_t id_from=0, uint32_t id_to=UINT32_MAX);
+    void AddFilter(const char* filterstring);
+    bool RemoveFilter(uint8_t bus, uint32_t id_from=0, uint32_t id_to=UINT32_MAX);
   private:
     ovms_callback_register_t<PollCallback> m_runfinished_callback, m_pollstateticker_callback;
     ovms_callback_register_t<FrameCallback> m_framerx_callback;

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -843,6 +843,7 @@ class OvmsPollers : public InternalRamAllocated {
     };
     // Store for timing for different packet types.
     std::map<poller_key_t, average_value_t, poller_key_less_t> m_poll_time_stats;
+    OvmsMutex m_stats_mutex;
 
   public:
     void RegisterRunFinished(const std::string &name, PollCallback fn) { m_runfinished_callback.Register(name, fn);}

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -732,6 +732,7 @@ class OvmsPollers : public InternalRamAllocated {
                                               //
     OvmsMutex         m_filter_mutex;
     canfilter         m_filter;
+    bool              m_filtered;
 
     void PollerTxCallback(const CAN_frame_t* frame, bool success);
     void PollerRxCallback(const CAN_frame_t* frame, bool success);


### PR DESCRIPTION
- Add mutexes for handling timing.  Keeping locks as small as possible even when reporting.
- Add non-blocking mutex for filters on incoming RX messages to poll