### PR TITLE
Update and expand functionality of zoe ph2 integration

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/docs/index.rst
@@ -4,9 +4,8 @@ Renault Zoe Phase 2 (OBD port)
 
 Vehicle Type: **RZ2O**
 
-This vehicle type supports the Renault Zoe(PH2) ZE50 52kWh (2019-2024) through ODB2 connection. 
+This vehicle type supports the Renault Zoe(PH2) with 41 or 52kWh battery (2019-2024) through ODB2 connection. 
 
-All values are read-only, no control possible because of CAN Gateway.
 
 ----------------
 Support Overview
@@ -28,8 +27,8 @@ BMS v+t Display             Yes
 TPMS Display Zoe            Yes (Pressure and temperature)
 Charge Status Display       Yes
 Charge Interruption Alerts  Yes
-Charge Control              No (planned, but access to CAN after gw neccessary)
-Cabin Pre-heat/cool Control No (planned, but access to CAN after gw neccessary)
+Charge Control              No
+Cabin Pre-heat/cool Control Yes*
 Lock/Unlock Vehicle         Yes (display only)
 Valet Mode Control          No
 =========================== ==============
@@ -40,11 +39,25 @@ Others:
 Door open/close                     Yes (exclude hood)
 Battery full charge cycles          Yes
 Battery max charge, recd pwr        Yes
-Trip counter from Car               No (was included, but datapoint is extremly unreliable)
-Battery lifetime gauges             Yes (Charged, Recd and Used kWh)
+Trip counter from Car               No
+Battery lifetime gauges             Yes
 Heat pump power, rpm and hp press.  Yes
-Aux power gauges                    Yes (testing needed)
-Charge type                         Yes (DC charge, testing needed)
-Headlights Status                   Yes (lowbeam)
+Aux power gauges                    No
+Charge type                         Yes (DC charge testing needed)
+Headlights Status                   Yes (lowbeam only)
 Charge efficiency calculation       Yes (but only for AC, pf is measured with power analyzer and included as statics)
 =================================== ==============
+
+-------------------
+Pre-heat / climate
+-------------------
+
+If you want to preheat your car, you need to connect CAN2 from the OVMS module to the V-CAN.
+The V-CAN can be grabbed at the BCM or Can-Gateway ECU for example.
+
+------------
+TCU removal
+------------
+
+If you want to remove your TCU for privacy or other reasons, you need to wait for another integration which uses V-CAN connection to detect vehicle state.
+If you remove your TCU the OVMS will not detect car wake up.

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/BCM_pids.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/BCM_pids.cpp
@@ -25,201 +25,247 @@
 
 #include "vehicle_renaultzoe_ph2_obd.h"
 
-void OvmsVehicleRenaultZoePh2OBD::IncomingBCM(uint16_t type, uint16_t pid, const char* data, uint16_t len) {  
-  switch (pid) {
-    case 0x6300: {  // TPMS pressure - front left
-      if ((CAN_UINT(0) * 7.5) < 7672) {
-        StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FL, (float)CAN_UINT(0) * 7.5 / 10, kPa);
-      }
-      //ESP_LOGD(TAG, "6300 BCM tpms pressure FL: %f", CAN_UINT(0) * 7.5);
-      break;
+void OvmsVehicleRenaultZoePh2OBD::IncomingBCM(uint16_t type, uint16_t pid, const char *data, uint16_t len)
+{
+  switch (pid)
+  {
+  case 0x6300:
+  { // TPMS pressure - front left
+    if ((CAN_UINT(0) * 7.5) < 7672)
+    {
+      StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FL, (float)CAN_UINT(0) * 7.5 / 10, kPa);
     }
-    case 0x6301: {  // TPMS pressure - front right
-      if ((CAN_UINT(0) * 7.5) < 7672) {
-        StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FR, (float)CAN_UINT(0) * 7.5 / 10, kPa);
-      }
-      //ESP_LOGD(TAG, "6301 BCM tpms pressure FR: %f", CAN_UINT(0) * 7.5);
-      break;
+    // ESP_LOGD(TAG, "6300 BCM tpms pressure FL: %f", CAN_UINT(0) * 7.5);
+    break;
+  }
+  case 0x6301:
+  { // TPMS pressure - front right
+    if ((CAN_UINT(0) * 7.5) < 7672)
+    {
+      StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FR, (float)CAN_UINT(0) * 7.5 / 10, kPa);
     }
-    case 0x6302: {  // TPMS pressure - rear left
-      if ((CAN_UINT(0) * 7.5) < 7672) {
-        StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RL, (float)CAN_UINT(0) * 7.5 / 10, kPa);
-      }
-      //ESP_LOGD(TAG, "6302 BCM tpms pressure RL: %f", CAN_UINT(0) * 7.5);
-      break;
+    // ESP_LOGD(TAG, "6301 BCM tpms pressure FR: %f", CAN_UINT(0) * 7.5);
+    break;
+  }
+  case 0x6302:
+  { // TPMS pressure - rear left
+    if ((CAN_UINT(0) * 7.5) < 7672)
+    {
+      StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RL, (float)CAN_UINT(0) * 7.5 / 10, kPa);
     }
-    case 0x6303: {  // TPMS pressure - rear right
-      if ((CAN_UINT(0) * 7.5) < 7672) {
-        StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RR, (float)CAN_UINT(0) * 7.5 / 10, kPa);
-      }
-      //ESP_LOGD(TAG, "6303 BCM tpms pressure RR: %f", CAN_UINT(0) * 7.5);
-      break;
+    // ESP_LOGD(TAG, "6302 BCM tpms pressure RL: %f", CAN_UINT(0) * 7.5);
+    break;
+  }
+  case 0x6303:
+  { // TPMS pressure - rear right
+    if ((CAN_UINT(0) * 7.5) < 7672)
+    {
+      StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RR, (float)CAN_UINT(0) * 7.5 / 10, kPa);
     }
-    case 0x6310: {  // TPMS temp - front left
-      if (CAN_BYTE(0) < 127) {
-        StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_FL, CAN_BYTE(0) - 30, Celcius);
-      }
-      //ESP_LOGD(TAG, "6310 BCM tpms temp FL: %d", CAN_NIB(0));
-      break;
+    // ESP_LOGD(TAG, "6303 BCM tpms pressure RR: %f", CAN_UINT(0) * 7.5);
+    break;
+  }
+  case 0x6310:
+  { // TPMS temp - front left
+    if (CAN_BYTE(0) < 127)
+    {
+      StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_FL, CAN_BYTE(0) - 30, Celcius);
     }
-    case 0x6311: {  // TPMS temp - front right
-      if (CAN_BYTE(0) < 127) {
-        StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_FR, CAN_BYTE(0) - 30, Celcius);
-      }
-      //ESP_LOGD(TAG, "6311 BCM tpms temp FR: %d", CAN_NIBL(0));
-      break;
+    // ESP_LOGD(TAG, "6310 BCM tpms temp FL: %d", CAN_NIB(0));
+    break;
+  }
+  case 0x6311:
+  { // TPMS temp - front right
+    if (CAN_BYTE(0) < 127)
+    {
+      StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_FR, CAN_BYTE(0) - 30, Celcius);
     }
-    case 0x6312: {  // TPMS temp - rear left
-      if (CAN_BYTE(0) < 127) {
-        StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_RL, CAN_BYTE(0) - 30, Celcius);
-      }
-      //ESP_LOGD(TAG, "6312 BCM tpms temp RL: %d", CAN_NIBH(0));
-      break;
+    // ESP_LOGD(TAG, "6311 BCM tpms temp FR: %d", CAN_NIBL(0));
+    break;
+  }
+  case 0x6312:
+  { // TPMS temp - rear left
+    if (CAN_BYTE(0) < 127)
+    {
+      StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_RL, CAN_BYTE(0) - 30, Celcius);
     }
-    case 0x6313: {  // TPMS temp - rear right
-      if (CAN_BYTE(0) < 127) {
-        StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_RR, CAN_BYTE(0) - 30, Celcius);
-      }
-      //ESP_LOGD(TAG, "6313 BCM tpms temp RR: %d", CAN_BYTE(0));
-      break;
+    // ESP_LOGD(TAG, "6312 BCM tpms temp RL: %d", CAN_NIBH(0));
+    break;
+  }
+  case 0x6313:
+  { // TPMS temp - rear right
+    if (CAN_BYTE(0) < 127)
+    {
+      StandardMetrics.ms_v_tpms_temp->SetElemValue(MS_V_TPMS_IDX_RR, CAN_BYTE(0) - 30, Celcius);
     }
-    case 0x4109: {  // TPMS alert - front left
-      if (CAN_UINT(0) == 0) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FL, 0);
-      }
-      if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FL, 2);
-      }
-      if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6 ) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FL, 1);
-      }
-      //ESP_LOGD(TAG, "40FF BCM tpms alert FL: %d", CAN_UINT(0));
-      break;
+    // ESP_LOGD(TAG, "6313 BCM tpms temp RR: %d", CAN_BYTE(0));
+    break;
+  }
+  case 0x4109:
+  { // TPMS alert - front left
+    if (CAN_UINT(0) == 0)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FL, 0);
     }
-    case 0x410A: {  // TPMS alert - front right
-      if (CAN_UINT(0) == 0) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FR, 0);
-      }
-      if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FR, 2);
-      }
-      if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6 ) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FR, 1);
-      }
-      //ESP_LOGD(TAG, "40FF BCM tpms alert FR: %d", CAN_UINT(0));
-      break;
+    if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FL, 2);
     }
-    case 0x410B: {  // TPMS alert - rear left
-      if (CAN_UINT(0) == 0) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RL, 0);
-      }
-      if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RL, 2);
-      }
-      if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6 ) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RL, 1);
-      }
-      //ESP_LOGD(TAG, "40FF BCM tpms alert RL: %d", CAN_UINT(0));
-      break;
+    if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FL, 1);
     }
-    case 0x410C: {  // TPMS alert - rear right
-      if (CAN_UINT(0) == 0) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RR, 0);
-      }
-      if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RR, 2);
-      }
-      if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6 ) {
-        StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RR, 1);
-      }
-      //ESP_LOGD(TAG, "40FF BCM tpms alert RR: %d", CAN_UINT(0));
-      break;
+    // ESP_LOGD(TAG, "40FF BCM tpms alert FL: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x410A:
+  { // TPMS alert - front right
+    if (CAN_UINT(0) == 0)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FR, 0);
     }
-    case 0x8004: {  //Car secure aka vehicle locked 
-      StandardMetrics.ms_v_env_locked->SetValue((bool)CAN_UINT(0));
-      //ESP_LOGD(TAG, "8004 BCM Car Secure S: %d", CAN_UINT(0));
-      break;
+    if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FR, 2);
     }
-    case 0x6026: {  //Front left door
-      StandardMetrics.ms_v_door_fl->SetValue((bool)CAN_UINT(0));
-      //ESP_LOGD(TAG, "6026 BCM Front left door: %d", CAN_UINT(0));
-      break;
+    if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_FR, 1);
     }
-    case 0x6027: {  //Front right door
-      StandardMetrics.ms_v_door_fr->SetValue((bool)CAN_UINT(0));
-      //ESP_LOGD(TAG, "6027 BCM Front right door: %d", CAN_UINT(0));
-      break;
+    // ESP_LOGD(TAG, "40FF BCM tpms alert FR: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x410B:
+  { // TPMS alert - rear left
+    if (CAN_UINT(0) == 0)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RL, 0);
     }
-    case 0x61B2: {  //Rear left door
-      StandardMetrics.ms_v_door_rl->SetValue((bool)CAN_UINT(0));
-      //ESP_LOGD(TAG, "61B2 BCM Rear left door: %d", CAN_UINT(0));
-      break;
+    if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RL, 2);
     }
-    case 0x61B3: {  //Rear right door
-      StandardMetrics.ms_v_door_rr->SetValue((bool)CAN_UINT(0));
-      //ESP_LOGD(TAG, "61B3 Rear right door: %d", CAN_UINT(0));
-      break;
+    if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RL, 1);
     }
-    case 0x609B: {  //Tailgate
-      StandardMetrics.ms_v_door_trunk->SetValue((bool)CAN_UINT(0));
-      //ESP_LOGD(TAG, "609B Tailgate: %d", CAN_UINT(0));
-      break;
+    // ESP_LOGD(TAG, "40FF BCM tpms alert RL: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x410C:
+  { // TPMS alert - rear right
+    if (CAN_UINT(0) == 0)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RR, 0);
     }
-    case 0x4186: {  //Low beam lights
-      StandardMetrics.ms_v_env_headlights->SetValue((bool)CAN_UINT(0));
-      /*if ((bool)CAN_UINT(0)) {
-        ESP_LOGD(TAG, "4186 Low beam lights: active");
-      } else {
-        ESP_LOGD(TAG, "4186 Low beam lights: inactive");
-      }*/
-      break;
+    if (CAN_UINT(0) == 1 || CAN_UINT(0) == 3 || CAN_UINT(0) == 5 || CAN_UINT(0) == 7)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RR, 2);
     }
-    case 0x60C6: {  //Ignition relay (switch)
-      /*if ((bool)CAN_UINT(0)) {
-        ESP_LOGD(TAG, "60C6 Ignition relay: active");
-      } else {
-        ESP_LOGD(TAG, "60C6 Ignition relay: inactive");
-      }*/
-      if (!CarIsCharging) { //Igniton while charging
-        StandardMetrics.ms_v_env_on->SetValue((bool)CAN_UINT(0));
-        StandardMetrics.ms_v_env_awake->SetValue((bool)CAN_UINT(0));
-      }
-      break;
+    if (CAN_UINT(0) == 2 || CAN_UINT(0) == 4 || CAN_UINT(0) == 6)
+    {
+      StandardMetrics.ms_v_tpms_alert->SetElemValue(MS_V_TPMS_IDX_RR, 1);
     }
-    case 0x4060: {  //Vehicle identificaftion number
-        zoe_vin[0] = CAN_BYTE(0);
-        zoe_vin[1] = CAN_BYTE(1);
-        zoe_vin[2] = CAN_BYTE(2);
-        zoe_vin[3] = CAN_BYTE(3);
-        zoe_vin[4] = CAN_BYTE(4);
-        zoe_vin[5] = CAN_BYTE(5);
-        zoe_vin[6] = CAN_BYTE(6);
-        zoe_vin[7] = CAN_BYTE(7);
-        zoe_vin[8] = CAN_BYTE(8);
-        zoe_vin[9] = CAN_BYTE(9);
-        zoe_vin[10] = CAN_BYTE(10);
-        zoe_vin[11] = CAN_BYTE(11);
-        zoe_vin[12] = CAN_BYTE(12);
-        zoe_vin[13] = CAN_BYTE(13);
-        zoe_vin[14] = CAN_BYTE(14);
-        zoe_vin[15] = CAN_BYTE(15);
-        zoe_vin[16] = CAN_BYTE(16);
-        zoe_vin[17] = 0;
-        StandardMetrics.ms_v_vin->SetValue((string) zoe_vin);
-      break;
+    // ESP_LOGD(TAG, "40FF BCM tpms alert RR: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x8004:
+  { // Car secure aka vehicle locked
+    StandardMetrics.ms_v_env_locked->SetValue((bool)CAN_UINT(0));
+    // ESP_LOGD(TAG, "8004 BCM Car Secure S: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x6026:
+  { // Front left door
+    StandardMetrics.ms_v_door_fl->SetValue((bool)CAN_UINT(0));
+    // ESP_LOGD(TAG, "6026 BCM Front left door: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x6027:
+  { // Front right door
+    StandardMetrics.ms_v_door_fr->SetValue((bool)CAN_UINT(0));
+    // ESP_LOGD(TAG, "6027 BCM Front right door: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x61B2:
+  { // Rear left door
+    StandardMetrics.ms_v_door_rl->SetValue((bool)CAN_UINT(0));
+    // ESP_LOGD(TAG, "61B2 BCM Rear left door: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x61B3:
+  { // Rear right door
+    StandardMetrics.ms_v_door_rr->SetValue((bool)CAN_UINT(0));
+    // ESP_LOGD(TAG, "61B3 Rear right door: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x609B:
+  { // Tailgate
+    StandardMetrics.ms_v_door_trunk->SetValue((bool)CAN_UINT(0));
+    // ESP_LOGD(TAG, "609B Tailgate: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x4186:
+  { // Low beam lights
+    StandardMetrics.ms_v_env_headlights->SetValue((bool)CAN_UINT(0));
+    /*if ((bool)CAN_UINT(0)) {
+      ESP_LOGD(TAG, "4186 Low beam lights: active");
+    } else {
+      ESP_LOGD(TAG, "4186 Low beam lights: inactive");
+    }*/
+    break;
+  }
+  case 0x60C6:
+  { // Ignition relay (switch)
+    /*if ((bool)CAN_UINT(0)) {
+      ESP_LOGD(TAG, "60C6 Ignition relay: active");
+    } else {
+      ESP_LOGD(TAG, "60C6 Ignition relay: inactive");
+    }*/
+    if (!CarIsCharging)
+    { // Igniton while charging
+      StandardMetrics.ms_v_env_on->SetValue((bool)CAN_UINT(0));
+      StandardMetrics.ms_v_env_awake->SetValue((bool)CAN_UINT(0));
     }
+    break;
+  }
+  case 0x4060:
+  { // Vehicle identificaftion number
+    zoe_vin[0] = CAN_BYTE(0);
+    zoe_vin[1] = CAN_BYTE(1);
+    zoe_vin[2] = CAN_BYTE(2);
+    zoe_vin[3] = CAN_BYTE(3);
+    zoe_vin[4] = CAN_BYTE(4);
+    zoe_vin[5] = CAN_BYTE(5);
+    zoe_vin[6] = CAN_BYTE(6);
+    zoe_vin[7] = CAN_BYTE(7);
+    zoe_vin[8] = CAN_BYTE(8);
+    zoe_vin[9] = CAN_BYTE(9);
+    zoe_vin[10] = CAN_BYTE(10);
+    zoe_vin[11] = CAN_BYTE(11);
+    zoe_vin[12] = CAN_BYTE(12);
+    zoe_vin[13] = CAN_BYTE(13);
+    zoe_vin[14] = CAN_BYTE(14);
+    zoe_vin[15] = CAN_BYTE(15);
+    zoe_vin[16] = CAN_BYTE(16);
+    zoe_vin[17] = 0;
+    StandardMetrics.ms_v_vin->SetValue((string)zoe_vin);
+    break;
+  }
 
-    default: {
-      char *buf = NULL;
-      size_t rlen = len, offset = 0;
-      do {
-        rlen = FormatHexDump(&buf, data + offset, rlen, 16);
-        offset += 16;
-        ESP_LOGW(TAG, "OBD2: unhandled reply from BCM [%02x %02x]: %s", type, pid, buf ? buf : "-");
-      } while (rlen);
-      if (buf)
-        free(buf);
-      break;
-    }
+  default:
+  {
+    char *buf = NULL;
+    size_t rlen = len, offset = 0;
+    do
+    {
+      rlen = FormatHexDump(&buf, data + offset, rlen, 16);
+      offset += 16;
+      ESP_LOGW(TAG, "OBD2: unhandled reply from BCM [%02x %02x]: %s", type, pid, buf ? buf : "-");
+    } while (rlen);
+    if (buf)
+      free(buf);
+    break;
+  }
   }
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/EVC_pids.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/EVC_pids.cpp
@@ -25,238 +25,308 @@
 
 #include "vehicle_renaultzoe_ph2_obd.h"
 
-void OvmsVehicleRenaultZoePh2OBD::IncomingEVC(uint16_t type, uint16_t pid, const char* data, uint16_t len) {
-	switch (pid) {
-    case 0x2006: {  //Odometer (Total Vehicle Distance)
-      StandardMetrics.ms_v_pos_odometer->SetValue((float) CAN_UINT24(0), Kilometers);
-      //ESP_LOGD(TAG, "2006 EVC ms_v_pos_odometer: %d", CAN_UINT24(0));
-      break;
+void OvmsVehicleRenaultZoePh2OBD::IncomingEVC(uint16_t type, uint16_t pid, const char *data, uint16_t len)
+{
+  switch (pid)
+  {
+  case 0x2006:
+  { // Odometer (Total Vehicle Distance)
+    StandardMetrics.ms_v_pos_odometer->SetValue((float)CAN_UINT24(0), Kilometers);
+    // ESP_LOGD(TAG, "2006 EVC ms_v_pos_odometer: %d", CAN_UINT24(0));
+    break;
+  }
+  case 0x2003:
+  { // Vehicle Speed
+    StandardMetrics.ms_v_pos_speed->SetValue((float)(CAN_UINT(0) * 0.01), KphPS);
+    // ESP_LOGD(TAG, "2003 EVC ms_v_pos_speed: %f", CAN_UINT(0) * 0.01);
+    break;
+  }
+  case 0x2005:
+  { // 12V Battery Voltage
+    StandardMetrics.ms_v_charge_12v_voltage->SetValue((float)(CAN_UINT(0) * 0.01), Volts);
+    // ESP_LOGD(TAG, "2005 EVC ms_v_charge_12v_voltage: %f", CAN_UINT(0) * 0.01);
+    break;
+  }
+  case 0x21CF:
+  { // Inverter status
+    // ESP_LOGD(TAG, "21CF EVC mt_inv_status: %d", CAN_NIBL(0));
+    if (CAN_NIBL(0) == 1)
+    {
+      mt_inv_status->SetValue("Inverter off");
     }
-    case 0x2003: { //Vehicle Speed
-      StandardMetrics.ms_v_pos_speed->SetValue((float) (CAN_UINT(0) * 0.01), KphPS);
-      //ESP_LOGD(TAG, "2003 EVC ms_v_pos_speed: %f", CAN_UINT(0) * 0.01);
-      break;
+    else if (CAN_NIBL(0) == 2)
+    {
+      mt_inv_status->SetValue("Inverter on");
+      StandardMetrics.ms_v_door_chargeport->SetValue(false);
     }
-    case 0x2005: { //12V Battery Voltage
-      StandardMetrics.ms_v_charge_12v_voltage->SetValue((float) (CAN_UINT(0) * 0.01), Volts);
-      //ESP_LOGD(TAG, "2005 EVC ms_v_charge_12v_voltage: %f", CAN_UINT(0) * 0.01);
-      break;
+    else if (CAN_NIBL(0) == 3)
+    {
+      mt_inv_status->SetValue("Inverter decharging");
     }
-    case 0x21CF: { //Inverter status
-      //ESP_LOGD(TAG, "21CF EVC mt_inv_status: %d", CAN_NIBL(0));
-      if (CAN_NIBL(0) == 1) {
-        mt_inv_status->SetValue("Inverter off");
-
-      } else if (CAN_NIBL(0) == 2) {
-        mt_inv_status->SetValue("Inverter on");
-        StandardMetrics.ms_v_door_chargeport->SetValue(false);
-      } else if (CAN_NIBL(0) == 3) {
-        mt_inv_status->SetValue("Inverter decharging");
-      }  else if (CAN_NIBL(0) == 4) {
-        mt_inv_status->SetValue("Inverter alternator mode");
-      }  else if (CAN_NIBL(0) == 5) {
-        mt_inv_status->SetValue("Inverter ready to sleep");
-      }  else {
-        mt_inv_status->SetValue("Inverter state unknown");
-      }
-      break;
+    else if (CAN_NIBL(0) == 4)
+    {
+      mt_inv_status->SetValue("Inverter alternator mode");
     }
-    case 0x2218: {  // Ambient temperature
-      StandardMetrics.ms_v_env_temp->SetValue((float) (CAN_UINT(0) * 0.1 - 273), Celcius);
-      //ESP_LOGD(TAG, "2218 EVC ms_v_env_temp: %f", (CAN_UINT(0) * 0.1 - 273));
-      break;
+    else if (CAN_NIBL(0) == 5)
+    {
+      mt_inv_status->SetValue("Inverter ready to sleep");
     }
-    case 0x2A09: {  // Power consumption by consumer
-      mt_bat_aux_power_consumer->SetValue((float) CAN_UINT(0) * 10, Watts);
-      //ESP_LOGD(TAG, "2A09 EVC mt_bat_aux_power_consumer: %d", CAN_UINT(0) * 10);
-      break;
+    else
+    {
+      mt_inv_status->SetValue("Inverter state unknown");
     }
-    case 0x2191: {  // Power consumption by ptc
-      mt_bat_aux_power_ptc->SetValue((float) CAN_UINT(0) * 10, Watts);
-      //ESP_LOGD(TAG, "2191 EVC mt_bat_aux_power_ptc: %d", CAN_UINT(0) * 10);
-      break;
-    }
-    case 0x2B85: {  // Charge plug preset
-      //ESP_LOGD(TAG, "2B85 EVC Charge plug present: %d", CAN_NIBL(0));
-      if (CAN_NIBL(0) == 1) {
+    break;
+  }
+  case 0x2218:
+  { // Ambient temperature
+    StandardMetrics.ms_v_env_temp->SetValue((float)(CAN_UINT(0) * 0.1 - 273), Celcius);
+    // ESP_LOGD(TAG, "2218 EVC ms_v_env_temp: %f", (CAN_UINT(0) * 0.1 - 273));
+    break;
+  }
+  case 0x2B85:
+  { // Charge plug preset
+    // ESP_LOGD(TAG, "2B85 EVC Charge plug present: %d", CAN_NIBL(0));
+    if (CAN_NIBL(0) == 1)
+    {
       StandardMetrics.ms_v_charge_pilot->SetValue(true);
-      if (!CarPluggedIn) {
+      if (!CarPluggedIn)
+      {
         ESP_LOGI(TAG, "Charge cable plugged in");
         CarPluggedIn = true;
-        }
       }
-      if (CAN_NIBL(0) == 0) {
+    }
+    if (CAN_NIBL(0) == 0)
+    {
       StandardMetrics.ms_v_charge_pilot->SetValue(false);
-      if (CarPluggedIn) {
+      if (CarPluggedIn)
+      {
         ESP_LOGI(TAG, "Charge cable plugged out");
         CarPluggedIn = false;
         StandardMetrics.ms_v_door_chargeport->SetValue(false);
-        }
       }
-      break;
     }
-    case 0x2B6D: {  // Charge MMI States, will be polled every 30s even car is off, because free frames are unreliable
-      //ESP_LOGD(TAG, "2B6D Charge MMI States RAW: %d", CAN_NIBL(0));
-      if (CAN_NIBL(0) == 0) {
+    break;
+  }
+  case 0x2B6D:
+  { // Charge MMI States
+    // ESP_LOGD(TAG, "2B6D Charge MMI States RAW: %d", CAN_NIBL(0));
+    if (CAN_NIBL(0) == 0)
+    {
       StandardMetrics.ms_v_charge_state->SetValue("stopped");
       StandardMetrics.ms_v_charge_substate->SetValue("stopped");
       StandardMetrics.ms_v_charge_inprogress->SetValue(false);
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : No Charge");
-      }
-      if (CAN_NIBL(0) == 1) {
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : No Charge");
+    }
+    if (CAN_NIBL(0) == 1)
+    {
       StandardMetrics.ms_v_charge_state->SetValue("timerwait");
       StandardMetrics.ms_v_charge_substate->SetValue("timerwait");
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : Waiting for a planned charge");
-      }
-      if (CAN_NIBL(0) == 2) {
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : Waiting for a planned charge");
+    }
+    if (CAN_NIBL(0) == 2)
+    {
       StandardMetrics.ms_v_charge_state->SetValue("done");
       StandardMetrics.ms_v_charge_substate->SetValue("stopped");
       StandardMetrics.ms_v_charge_inprogress->SetValue(false);
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : Ended charge");
-      }
-      if (CAN_NIBL(0) == 3) {
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : Ended charge");
+    }
+    if (CAN_NIBL(0) == 3)
+    {
       StandardMetrics.ms_v_charge_state->SetValue("charging");
       StandardMetrics.ms_v_charge_substate->SetValue("onrequest");
       StandardMetrics.ms_v_charge_inprogress->SetValue(true);
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : Charge in progress");
-      }
-      if (CAN_NIBL(0) == 4) {
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : Charge in progress");
+    }
+    if (CAN_NIBL(0) == 4)
+    {
       StandardMetrics.ms_v_charge_state->SetValue("stopped");
       StandardMetrics.ms_v_charge_substate->SetValue("interrupted");
       StandardMetrics.ms_v_charge_inprogress->SetValue(false);
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : Charge failure");
-      }
-      if (CAN_NIBL(0) == 5) {
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : Charge failure");
+    }
+    if (CAN_NIBL(0) == 5)
+    {
       StandardMetrics.ms_v_charge_state->SetValue("stopped");
       StandardMetrics.ms_v_charge_substate->SetValue("powerwait");
       StandardMetrics.ms_v_charge_inprogress->SetValue(false);
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : Waiting for current charge");
-      }
-      if (CAN_NIBL(0) == 6) {
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : Waiting for current charge");
+    }
+    if (CAN_NIBL(0) == 6)
+    {
       StandardMetrics.ms_v_door_chargeport->SetValue(true);
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : Chargeport opened");
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : Chargeport opened");
       ESP_LOGI(TAG, "Chargedoor opened");
-      }
-      if (CAN_NIBL(0) == 8) {
+    }
+    if (CAN_NIBL(0) == 8)
+    {
       StandardMetrics.ms_v_charge_state->SetValue("prepare");
       StandardMetrics.ms_v_charge_substate->SetValue("powerwait");
       StandardMetrics.ms_v_charge_inprogress->SetValue(false);
-      //ESP_LOGD(TAG, "2B6D Charge MMI States : Charge preparation");
-      }
-      if (!mt_bus_awake->AsBool()) {
-        ZoeWakeUp();
-      }
-      break;
+      // ESP_LOGD(TAG, "2B6D Charge MMI States : Charge preparation");
     }
-    case 0x2B7A: {  // Charge type
-      //ESP_LOGD(TAG, "2B7A EVC Charge type: %d", (CAN_NIBL(0)));
-      if (CAN_NIBL(0) == 0) {
-        StandardMetrics.ms_v_charge_type->SetValue("undefined");
-      }
-      if (CAN_NIBL(0) == 1 || CAN_NIBL(0) == 2) {
-        StandardMetrics.ms_v_charge_type->SetValue("type2");
-        StandardMetrics.ms_v_charge_mode->SetValue("standard");
-      }
-      if (CAN_NIBL(0) == 3) {
-        StandardMetrics.ms_v_charge_type->SetValue("chademo");
-        StandardMetrics.ms_v_charge_mode->SetValue("performance");
-      }
-      if (CAN_NIBL(0) == 4) {
-        StandardMetrics.ms_v_charge_type->SetValue("ccs");
-        StandardMetrics.ms_v_charge_mode->SetValue("performance");
-      }
-      break;
+    if (!mt_bus_awake->AsBool())
+    {
+      ZoeWakeUp();
     }
-    case 0x3064: {  // Motor rpm
-      StandardMetrics.ms_v_mot_rpm->SetValue((float) (CAN_UINT(0)));
-      //ESP_LOGD(TAG, "3064 EVC ms_v_mot_rpm: %d", (CAN_UINT(0)));
-      break;
+    break;
+  }
+  case 0x2B7A:
+  { // Charge type
+    // ESP_LOGD(TAG, "2B7A EVC Charge type: %d", (CAN_NIBL(0)));
+    if (CAN_NIBL(0) == 0)
+    {
+      StandardMetrics.ms_v_charge_type->SetValue("undefined");
     }
-    case 0x300F: {  // AC charging power available
-      mt_main_power_available->SetValue((float) (CAN_UINT(0) * 0.025), kW);
-      //ESP_LOGD(TAG, "300F EVC mt_main_power_available: %f", (CAN_UINT(0) * 0.025));
-      break;
+    if (CAN_NIBL(0) == 1 || CAN_NIBL(0) == 2)
+    {
+      StandardMetrics.ms_v_charge_type->SetValue("type2");
+      StandardMetrics.ms_v_charge_mode->SetValue("standard");
     }
-    case 0x300D: {  // AC input current
-      StandardMetrics.ms_v_charge_current->SetValue((float) (CAN_UINT(0) * 0.1), Amps);
-      //Power factor measured with a Janitza UMG512 Class A power analyser to get more precision
-      //Only three phases measurement at the moment
-      if (StandardMetrics.ms_v_charge_current->AsFloat() > 19.0f) { 
-        ACInputPowerFactor = 1.0;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 18.0f) {
-        ACInputPowerFactor = 0.997;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 17.0f) {
-        ACInputPowerFactor = 0.99;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 16.0f) {
-        ACInputPowerFactor = 0.978;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 15.0f) {
-        ACInputPowerFactor = 0.948;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 14.0f) {
-        ACInputPowerFactor = 0.931;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 13.0f) {
-        ACInputPowerFactor = 0.916;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 12.0f) {
-        ACInputPowerFactor = 0.902;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 11.0f) {
-        ACInputPowerFactor = 0.888;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 10.0f) {
-        ACInputPowerFactor = 0.905;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 9.0f) {
-        ACInputPowerFactor = 0.929;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 8.0f) {
-        ACInputPowerFactor = 0.901;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() > 7.0f) {
-        ACInputPowerFactor = 0.775;
-      } else if (StandardMetrics.ms_v_charge_current->AsFloat() < 6.0f && StandardMetrics.ms_v_charge_inprogress->AsBool(false)) {
-        ACInputPowerFactor = 0.05;
-      }
-      if (StandardMetrics.ms_v_charge_type->AsString() == "type2" && mt_main_phases_num->AsFloat() == 3 && StandardMetrics.ms_v_charge_inprogress->AsBool(false)) {
-        StandardMetrics.ms_v_charge_power->SetValue((StandardMetrics.ms_v_charge_current->AsFloat() * StandardMetrics.ms_v_charge_voltage->AsFloat() * ACInputPowerFactor * 1.732f) * 0.001, kW);
-      } else if (StandardMetrics.ms_v_charge_type->AsString() == "type2" && (mt_main_phases_num->AsFloat() == 2 || mt_main_phases_num->AsFloat() == 1)) {
-        StandardMetrics.ms_v_charge_power->SetValue((StandardMetrics.ms_v_charge_current->AsFloat() * StandardMetrics.ms_v_charge_voltage->AsFloat() * ACInputPowerFactor) * 0.001, kW);
-      } else if (StandardMetrics.ms_v_charge_type->AsString() == "type2") {
-        StandardMetrics.ms_v_charge_power->SetValue(0);
-      }
-      //ESP_LOGD(TAG, "300D EVC mt_main_current: %f", (CAN_UINT(0) * 0.1));
-      break;
+    if (CAN_NIBL(0) == 3)
+    {
+      StandardMetrics.ms_v_charge_type->SetValue("chademo");
+      StandardMetrics.ms_v_charge_mode->SetValue("performance");
     }
-    case 0x300B: {  // AC phases used
-      //ESP_LOGD(TAG, "300B EVC mt_main_phases: %d", (CAN_NIBL(0)));
-      if (CAN_NIBL(0) == 0) {
-        mt_main_phases->SetValue("one phase");
-        mt_main_phases_num->SetValue(1);
-      }
-      if (CAN_NIBL(0) == 1) {
-        mt_main_phases->SetValue("two phase");
-        mt_main_phases_num->SetValue(2);
-      }
-      if (CAN_NIBL(0) == 2) {
-        mt_main_phases->SetValue("three phase");
-        mt_main_phases_num->SetValue(3);
-      }
-      if (CAN_NIBL(0) == 3) {
-        mt_main_phases->SetValue("not detected");
-        mt_main_phases_num->SetValue(0);
-      }
-      break;
+    if (CAN_NIBL(0) == 4)
+    {
+      StandardMetrics.ms_v_charge_type->SetValue("ccs");
+      StandardMetrics.ms_v_charge_mode->SetValue("performance");
     }
-    case 0x2B8A: {  // AC mains voltage
-      StandardMetrics.ms_v_charge_voltage->SetValue((float) (CAN_UINT(0) * 0.5), Volts);
-      //ESP_LOGD(TAG, "2B8A EVC ms_v_charge_voltage: %f", (CAN_UINT(0) * 0.5));
-      break;
+    break;
+  }
+  case 0x3064:
+  { // Motor rpm
+    StandardMetrics.ms_v_mot_rpm->SetValue((float)(CAN_UINT(0)));
+    // ESP_LOGD(TAG, "3064 EVC ms_v_mot_rpm: %d", (CAN_UINT(0)));
+    break;
+  }
+  case 0x300F:
+  { // AC charging power available
+    mt_main_power_available->SetValue((float)(CAN_UINT(0) * 0.025), kW);
+    // ESP_LOGD(TAG, "300F EVC mt_main_power_available: %f", (CAN_UINT(0) * 0.025));
+    break;
+  }
+  case 0x300D:
+  { // AC input current
+    StandardMetrics.ms_v_charge_current->SetValue((float)(CAN_UINT(0) * 0.1), Amps);
+    // Power factor measured with a Janitza UMG512 Class A power analyser to get more precision
+    // Only three phases measurement at the moment
+    if (StandardMetrics.ms_v_charge_current->AsFloat() > 19.0f)
+    {
+      ACInputPowerFactor = 1.0;
     }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 18.0f)
+    {
+      ACInputPowerFactor = 0.997;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 17.0f)
+    {
+      ACInputPowerFactor = 0.99;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 16.0f)
+    {
+      ACInputPowerFactor = 0.978;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 15.0f)
+    {
+      ACInputPowerFactor = 0.948;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 14.0f)
+    {
+      ACInputPowerFactor = 0.931;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 13.0f)
+    {
+      ACInputPowerFactor = 0.916;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 12.0f)
+    {
+      ACInputPowerFactor = 0.902;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 11.0f)
+    {
+      ACInputPowerFactor = 0.888;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 10.0f)
+    {
+      ACInputPowerFactor = 0.905;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 9.0f)
+    {
+      ACInputPowerFactor = 0.929;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 8.0f)
+    {
+      ACInputPowerFactor = 0.901;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() > 7.0f)
+    {
+      ACInputPowerFactor = 0.775;
+    }
+    else if (StandardMetrics.ms_v_charge_current->AsFloat() < 6.0f && StandardMetrics.ms_v_charge_inprogress->AsBool(false))
+    {
+      ACInputPowerFactor = 0.05;
+    }
+    if (StandardMetrics.ms_v_charge_type->AsString() == "type2" && mt_main_phases_num->AsFloat() == 3 && StandardMetrics.ms_v_charge_inprogress->AsBool(false))
+    {
+      StandardMetrics.ms_v_charge_power->SetValue((StandardMetrics.ms_v_charge_current->AsFloat() * StandardMetrics.ms_v_charge_voltage->AsFloat() * ACInputPowerFactor * 1.732f) * 0.001, kW);
+    }
+    else if (StandardMetrics.ms_v_charge_type->AsString() == "type2" && (mt_main_phases_num->AsFloat() == 2 || mt_main_phases_num->AsFloat() == 1))
+    {
+      StandardMetrics.ms_v_charge_power->SetValue((StandardMetrics.ms_v_charge_current->AsFloat() * StandardMetrics.ms_v_charge_voltage->AsFloat() * ACInputPowerFactor) * 0.001, kW);
+    }
+    else if (StandardMetrics.ms_v_charge_type->AsString() == "type2")
+    {
+      StandardMetrics.ms_v_charge_power->SetValue(0);
+    }
+    // ESP_LOGD(TAG, "300D EVC mt_main_current: %f", (CAN_UINT(0) * 0.1));
+    break;
+  }
+  case 0x300B:
+  { // AC phases used
+    // ESP_LOGD(TAG, "300B EVC mt_main_phases: %d", (CAN_NIBL(0)));
+    if (CAN_NIBL(0) == 0)
+    {
+      mt_main_phases->SetValue("one phase");
+      mt_main_phases_num->SetValue(1);
+    }
+    if (CAN_NIBL(0) == 1)
+    {
+      mt_main_phases->SetValue("two phase");
+      mt_main_phases_num->SetValue(2);
+    }
+    if (CAN_NIBL(0) == 2)
+    {
+      mt_main_phases->SetValue("three phase");
+      mt_main_phases_num->SetValue(3);
+    }
+    if (CAN_NIBL(0) == 3)
+    {
+      mt_main_phases->SetValue("not detected");
+      mt_main_phases_num->SetValue(0);
+    }
+    break;
+  }
+  case 0x2B8A:
+  { // AC mains voltage
+    StandardMetrics.ms_v_charge_voltage->SetValue((float)(CAN_UINT(0) * 0.5), Volts);
+    // ESP_LOGD(TAG, "2B8A EVC ms_v_charge_voltage: %f", (CAN_UINT(0) * 0.5));
+    break;
+  }
 
-    default: {
-      char *buf = NULL;
-      size_t rlen = len, offset = 0;
-      do {
-        rlen = FormatHexDump(&buf, data + offset, rlen, 16);
-        offset += 16;
-        ESP_LOGW(TAG, "OBD2: unhandled reply from EVC [%02x %02x]: %s", type, pid, buf ? buf : "-");
-      } while (rlen);
-      if (buf)
-        free(buf);
-      break;
-    }
-	}
+  default:
+  {
+    char *buf = NULL;
+    size_t rlen = len, offset = 0;
+    do
+    {
+      rlen = FormatHexDump(&buf, data + offset, rlen, 16);
+      offset += 16;
+      ESP_LOGW(TAG, "OBD2: unhandled reply from EVC [%02x %02x]: %s", type, pid, buf ? buf : "-");
+    } while (rlen);
+    if (buf)
+      free(buf);
+    break;
+  }
+  }
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/HVAC_pids.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/HVAC_pids.cpp
@@ -24,69 +24,84 @@
 */
 #include "vehicle_renaultzoe_ph2_obd.h"
 
-void OvmsVehicleRenaultZoePh2OBD::IncomingHVAC(uint16_t type, uint16_t pid, const char* data, uint16_t len) {
-	switch (pid) {
-    case 0x4009: { //Cabin temperature
-      StandardMetrics.ms_v_env_cabintemp->SetValue(float((CAN_UINT(0) - 400) / 10), Celcius);
-      //ESP_LOGD(TAG, "4361 HVAC ms_v_env_cabintemp: %f", float((CAN_UINT(0) - 400) / 10));
-      break;
+void OvmsVehicleRenaultZoePh2OBD::IncomingHVAC(uint16_t type, uint16_t pid, const char *data, uint16_t len)
+{
+  switch (pid)
+  {
+  case 0x4009:
+  { // Cabin temperature
+    StandardMetrics.ms_v_env_cabintemp->SetValue(float((CAN_UINT(0) - 400) / 10), Celcius);
+    // ESP_LOGD(TAG, "4361 HVAC ms_v_env_cabintemp: %f", float((CAN_UINT(0) - 400) / 10));
+    break;
+  }
+  case 0x4360:
+  { // Cabin setpoint
+    StandardMetrics.ms_v_env_cabinsetpoint->SetValue(float(((CAN_NIBL(0) + 32) / 2)), Celcius);
+    // ESP_LOGD(TAG, "4360 HVAC ms_v_env_cabinsetpoint: %d", (CAN_NIBL(0) + 32) / 2);
+    break;
+  }
+  case 0x43D8:
+  { // Compressor speed
+    mt_hvac_compressor_speed->SetValue(float(CAN_UINT(0)));
+    // ESP_LOGD(TAG, "43D8 HVAC mt_hvac_compressor_speed: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x4402:
+  { // Compressor state
+    if (CAN_NIBL(0) == 1)
+    {
+      mt_hvac_compressor_mode->SetValue("AC mode");
+      StandardMetrics.ms_v_env_hvac->SetValue(true);
     }
-    case 0x4360: { //Cabin setpoint
-      StandardMetrics.ms_v_env_cabinsetpoint->SetValue(float(((CAN_NIBL(0) + 32) / 2)), Celcius);
-      //ESP_LOGD(TAG, "4360 HVAC ms_v_env_cabinsetpoint: %d", (CAN_NIBL(0) + 32) / 2);
-      break;
+    if (CAN_NIBL(0) == 2)
+    {
+      mt_hvac_compressor_mode->SetValue("De-ICE mode");
+      StandardMetrics.ms_v_env_hvac->SetValue(true);
     }
-    case 0x43D8: { //Compressor speed
-      mt_hvac_compressor_speed->SetValue(float(CAN_UINT(0)));
-      //ESP_LOGD(TAG, "43D8 HVAC mt_hvac_compressor_speed: %d", CAN_UINT(0));
-      break;
+    if (CAN_NIBL(0) == 4)
+    {
+      mt_hvac_compressor_mode->SetValue("Heat pump mode");
+      StandardMetrics.ms_v_env_hvac->SetValue(true);
     }
-    case 0x4402: { //Compressor state
-      if (CAN_NIBL(0) == 1) {
-        mt_hvac_compressor_mode->SetValue("AC mode");
-        StandardMetrics.ms_v_env_hvac->SetValue(true);
-      }
-      if (CAN_NIBL(0) == 2) {
-        mt_hvac_compressor_mode->SetValue("De-ICE mode");
-        StandardMetrics.ms_v_env_hvac->SetValue(true);
-      }
-      if (CAN_NIBL(0) == 4) {
-        mt_hvac_compressor_mode->SetValue("Heat pump mode");
-        StandardMetrics.ms_v_env_hvac->SetValue(true);
-      }
-      if (CAN_NIBL(0) == 6) {
-        mt_hvac_compressor_mode->SetValue("Demisting mode");
-        StandardMetrics.ms_v_env_hvac->SetValue(true);
-      }
-      if (CAN_NIBL(0) == 7) {
-        mt_hvac_compressor_mode->SetValue("idle");
-        StandardMetrics.ms_v_env_hvac->SetValue(false);
-      }
-      //ESP_LOGD(TAG, "%d HVAC mt_hvac_compressor_mode: %d", pid,  CAN_UINT(0));
-      break;
+    if (CAN_NIBL(0) == 6)
+    {
+      mt_hvac_compressor_mode->SetValue("Demisting mode");
+      StandardMetrics.ms_v_env_hvac->SetValue(true);
     }
-    case 0x4369: { //Compressor pressure
-      mt_hvac_compressor_pressure->SetValue(float(CAN_UINT(0) * 0.1));
-      //ESP_LOGD(TAG, "%d HVAC mt_hvac_compressor_pressure: %f", pid,  CAN_UINT(0) * 0.1);
-      break;
+    if (CAN_NIBL(0) == 7)
+    {
+      mt_hvac_compressor_mode->SetValue("idle");
+      StandardMetrics.ms_v_env_hvac->SetValue(false);
     }
-    case 0x4436: { //Compressor power
-      mt_hvac_compressor_power->SetValue(float(CAN_UINT(0) * 25.0 / 100.0));
-      //ESP_LOGD(TAG, "%d HVAC mt_hvac_compressor_power: %f", pid,  CAN_UINT(0) * 25.0 / 100.0);
-      break;
-    }
+    // ESP_LOGD(TAG, "%d HVAC mt_hvac_compressor_mode: %d", pid,  CAN_UINT(0));
+    break;
+  }
+  case 0x4369:
+  { // Compressor pressure
+    mt_hvac_compressor_pressure->SetValue(float(CAN_UINT(0) * 0.1));
+    // ESP_LOGD(TAG, "%d HVAC mt_hvac_compressor_pressure: %f", pid,  CAN_UINT(0) * 0.1);
+    break;
+  }
+  case 0x4436:
+  { // Compressor power
+    mt_hvac_compressor_power->SetValue(float(CAN_UINT(0) * 25.0 / 100.0));
+    // ESP_LOGD(TAG, "%d HVAC mt_hvac_compressor_power: %f", pid,  CAN_UINT(0) * 25.0 / 100.0);
+    break;
+  }
 
-    default: {
-      char *buf = NULL;
-      size_t rlen = len, offset = 0;
-      do {
-        rlen = FormatHexDump(&buf, data + offset, rlen, 16);
-        offset += 16;
-        ESP_LOGW(TAG, "OBD2: unhandled reply from HVAC [%02x %02x]: %s", type, pid, buf ? buf : "-");
-      } while (rlen);
-      if (buf)
-        free(buf);
-      break;
-    }
-	}
+  default:
+  {
+    char *buf = NULL;
+    size_t rlen = len, offset = 0;
+    do
+    {
+      rlen = FormatHexDump(&buf, data + offset, rlen, 16);
+      offset += 16;
+      ESP_LOGW(TAG, "OBD2: unhandled reply from HVAC [%02x %02x]: %s", type, pid, buf ? buf : "-");
+    } while (rlen);
+    if (buf)
+      free(buf);
+    break;
+  }
+  }
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/INV_pids.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/INV_pids.cpp
@@ -25,49 +25,58 @@
 
 #include "vehicle_renaultzoe_ph2_obd.h"
 
-void OvmsVehicleRenaultZoePh2OBD::IncomingINV(uint16_t type, uint16_t pid, const char* data, uint16_t len) {
-  switch (pid) {
-    case 0x700C: { // Inverter temperature
-      StandardMetrics.ms_v_inv_temp->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
-      //ESP_LOGD(TAG, "700C INV ms_v_inv_temp RAW: %f", float(CAN_UINT24(0)));
-      //ESP_LOGD(TAG, "700C INV ms_v_inv_temp: %f", float((CAN_UINT24(0) * 0.001953125) - 40));
-      break;
-    }
-    case 0x700F: {	// Motor, Stator1 temperature
-      StandardMetrics.ms_v_mot_temp->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
-      mt_mot_temp_stator1->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
-      //ESP_LOGD(TAG, "700F INV ms_v_mot_temp: %f", float((CAN_UINT24(0) * 0.001953125) - 40));
-      break;
-    }
-    case 0x7010: {  // Stator 2 temperature
-      mt_mot_temp_stator2->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
-      //ESP_LOGD(TAG, "7010 INV mt_mot_temp_stator2: %f", float((CAN_UINT24(0) * 0.001953125) - 40));
-      break;
-    }
-    case 0x2004: {  // Battery voltage sense
-      mt_inv_hv_voltage->SetValue(float(CAN_UINT(0) * 0.03125), Volts);
-      //ESP_LOGD(TAG, "2004 INV mt_inv_hv_voltage: %f", float(CAN_UINT(0) * 0.03125));
-      StandardMetrics.ms_v_inv_power->SetValue(float (mt_inv_hv_voltage->AsFloat() * mt_inv_hv_current->AsFloat()) * 0.001);
-      break;
-    }
-    case 0x7049: {  // Battery current sense
-      mt_inv_hv_current->SetValue(float((CAN_UINT(0) * 0.03125) - 500), Amps);
-      //ESP_LOGD(TAG, "7049 INV mt_inv_hv_current: %f", float(CAN_UINT(0) * 0.003125) - 500);
-      StandardMetrics.ms_v_inv_power->SetValue(float (mt_inv_hv_current->AsFloat() * mt_inv_hv_voltage->AsFloat()) * 0.001);
-      break;
-    }
+void OvmsVehicleRenaultZoePh2OBD::IncomingINV(uint16_t type, uint16_t pid, const char *data, uint16_t len)
+{
+  switch (pid)
+  {
+  case 0x700C:
+  { // Inverter temperature
+    StandardMetrics.ms_v_inv_temp->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
+    // ESP_LOGD(TAG, "700C INV ms_v_inv_temp RAW: %f", float(CAN_UINT24(0)));
+    // ESP_LOGD(TAG, "700C INV ms_v_inv_temp: %f", float((CAN_UINT24(0) * 0.001953125) - 40));
+    break;
+  }
+  case 0x700F:
+  { // Motor, Stator1 temperature
+    StandardMetrics.ms_v_mot_temp->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
+    mt_mot_temp_stator1->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
+    // ESP_LOGD(TAG, "700F INV ms_v_mot_temp: %f", float((CAN_UINT24(0) * 0.001953125) - 40));
+    break;
+  }
+  case 0x7010:
+  { // Stator 2 temperature
+    mt_mot_temp_stator2->SetValue(float((CAN_UINT24(0) * 0.001953125) - 40), Celcius);
+    // ESP_LOGD(TAG, "7010 INV mt_mot_temp_stator2: %f", float((CAN_UINT24(0) * 0.001953125) - 40));
+    break;
+  }
+  case 0x2004:
+  { // Battery voltage sense
+    mt_inv_hv_voltage->SetValue(float(CAN_UINT(0) * 0.03125), Volts);
+    // ESP_LOGD(TAG, "2004 INV mt_inv_hv_voltage: %f", float(CAN_UINT(0) * 0.03125));
+    StandardMetrics.ms_v_inv_power->SetValue(float(mt_inv_hv_voltage->AsFloat() * mt_inv_hv_current->AsFloat()) * 0.001);
+    break;
+  }
+  case 0x7049:
+  { // Battery current sense
+    mt_inv_hv_current->SetValue(float((CAN_UINT(0) * 0.03125) - 500), Amps);
+    // ESP_LOGD(TAG, "7049 INV mt_inv_hv_current: %f", float(CAN_UINT(0) * 0.003125) - 500);
+    StandardMetrics.ms_v_inv_power->SetValue(float(mt_inv_hv_current->AsFloat() * mt_inv_hv_voltage->AsFloat()) * 0.001);
+    break;
+  }
 
-    default: {
-      char *buf = NULL;
-      size_t rlen = len, offset = 0;
-      do {
-        rlen = FormatHexDump(&buf, data + offset, rlen, 16);
-        offset += 16;
-        ESP_LOGW(TAG, "OBD2: unhandled reply from INV [%02x %02x]: %s", type, pid, buf ? buf : "-");
-      } while (rlen);
-      if (buf)
-        free(buf);
-      break;
-    }
+  default:
+  {
+    char *buf = NULL;
+    size_t rlen = len, offset = 0;
+    do
+    {
+      rlen = FormatHexDump(&buf, data + offset, rlen, 16);
+      offset += 16;
+      ESP_LOGW(TAG, "OBD2: unhandled reply from INV [%02x %02x]: %s", type, pid, buf ? buf : "-");
+    } while (rlen);
+    if (buf)
+      free(buf);
+    break;
+  }
   }
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/LBC_pids.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/LBC_pids.cpp
@@ -25,628 +25,761 @@
 
 #include "vehicle_renaultzoe_ph2_obd.h"
 
-void OvmsVehicleRenaultZoePh2OBD::IncomingLBC(uint16_t type, uint16_t pid, const char* data, uint16_t len) {
-	switch (pid) {
-    case 0x9005: { //Battery voltage
-      StandardMetrics.ms_v_bat_voltage->SetValue((float) (CAN_UINT(0) * 0.1), Volts);
-      //ESP_LOGD(TAG, "9005 LBC ms_v_bat_voltage: %f", CAN_UINT(0) * 0.1);
-      StandardMetrics.ms_v_bat_power->SetValue(((CAN_UINT(0) * 0.1) * StandardMetrics.ms_v_bat_current->AsFloat()) * 0.001);
-      break;
-    }
-    case 0x925D: { //Battery current
-      StandardMetrics.ms_v_bat_current->SetValue((float) ((CAN_UINT(0) * 0.03125 - 1020) * -1.0f), Amps);
-      //ESP_LOGD(TAG, "925D LBC ms_v_bat_current: %f", (CAN_UINT(0) * 0.03125 - 1020));
-      StandardMetrics.ms_v_bat_power->SetValue((((CAN_UINT(0) * 0.03125 - 1020) * -1.0f) * StandardMetrics.ms_v_bat_voltage->AsFloat()) * 0.001);
-      break;
-    }
-    case 0x9012: { //Battery average temperature
-      StandardMetrics.ms_v_bat_temp->SetValue((float) (CAN_UINT(0)  * 0.0625 - 40), Celcius);
-      //ESP_LOGD(TAG, "9012 LBC ms_v_bat_temp: %f", (CAN_UINT(0)  * 0.0625 - 40));
-      break;
-    }
-    case 0x9002: { //Battery SOC
-      //StandardMetrics.ms_v_bat_soc->SetValue((float) (CAN_UINT(0)) * 0.01, Percentage);
-      float bat_soc = CAN_UINT(0) * 0.01;
+void OvmsVehicleRenaultZoePh2OBD::IncomingLBC(uint16_t type, uint16_t pid, const char *data, uint16_t len)
+{
+  switch (pid)
+  {
+  case 0x9005:
+  { // Battery voltage
+    StandardMetrics.ms_v_bat_voltage->SetValue((float)(CAN_UINT(0) * 0.1), Volts);
+    // ESP_LOGD(TAG, "9005 LBC ms_v_bat_voltage: %f", CAN_UINT(0) * 0.1);
+    StandardMetrics.ms_v_bat_power->SetValue(((CAN_UINT(0) * 0.1) * StandardMetrics.ms_v_bat_current->AsFloat()) * 0.001);
+    break;
+  }
+  case 0x925D:
+  { // Battery current
+    StandardMetrics.ms_v_bat_current->SetValue((float)((CAN_UINT(0) * 0.03125 - 1020) * -1.0f), Amps);
+    // ESP_LOGD(TAG, "925D LBC ms_v_bat_current: %f", (CAN_UINT(0) * 0.03125 - 1020));
+    StandardMetrics.ms_v_bat_power->SetValue((((CAN_UINT(0) * 0.03125 - 1020) * -1.0f) * StandardMetrics.ms_v_bat_voltage->AsFloat()) * 0.001);
+    break;
+  }
+  case 0x9012:
+  { // Battery average temperature
+    StandardMetrics.ms_v_bat_temp->SetValue((float)(CAN_UINT(0) * 0.0625 - 40), Celcius);
+    // ESP_LOGD(TAG, "9012 LBC ms_v_bat_temp: %f", (CAN_UINT(0)  * 0.0625 - 40));
+    break;
+  }
+  case 0x9002:
+  { // Battery SOC
+    // StandardMetrics.ms_v_bat_soc->SetValue((float) (CAN_UINT(0)) * 0.01, Percentage);
+    float bat_soc = CAN_UINT(0) * 0.01;
 
-      if ( bat_soc < 100.0f ) {
-       StandardMetrics.ms_v_bat_soc->SetValue(bat_soc + (bat_soc * 0.03), Percentage);
-        } else {
-        StandardMetrics.ms_v_bat_soc->SetValue(100.0f, Percentage);
-        }
-
-      StandardMetrics.ms_v_bat_cac->SetValue(Bat_cell_capacity * CAN_UINT(0) * 0.0001);
-
-      //ESP_LOGD(TAG, "9002 LBC mt_bat_lbc_soc: %f", bat_soc);
-      //ESP_LOGD(TAG, "9002 LBC mt_bat_lbc_soc calculated: %f", bat_soc + (bat_soc * 0.03));
-      break;
-    }
-    case 0x9003: { //Battery SOH
-      StandardMetrics.ms_v_bat_soh->SetValue((float) (CAN_UINT(0) * 0.01), Percentage);
-      //ESP_LOGD(TAG, "9003 LBC ms_v_bat_soh: %f", CAN_UINT(0) * 0.01);
-      break;
-    }
-    case 0x9243: { //Battery energy charged kWh
-      StandardMetrics.ms_v_charge_kwh_grid_total->SetValue((float) (CAN_UINT32(0) * 0.001), kWh);
-      //ESP_LOGD(TAG, "9243 LBC ms_v_charge_kwh_grid_total: %f", CAN_UINT32(0) * 0.001);
-      break;
-    }
-    case 0x9245: { //Battery energy discharged kWh
-      StandardMetrics.ms_v_bat_energy_used_total->SetValue((float) (CAN_UINT32(0) * 0.001), kWh);
-      //ESP_LOGD(TAG, "9244 LBC ms_v_bat_energy_used_total: %f", CAN_UINT32(0) * 0.001);
-      break;
-    }
-    case 0x9247: { //Battery energy regenerated kWh
-      StandardMetrics.ms_v_bat_energy_recd_total->SetValue((float) (CAN_UINT32(0) * 0.001), kWh);
-      //ESP_LOGD(TAG, "9246 LBC ms_v_bat_energy_recd_total: %f", CAN_UINT32(0) * 0.001);
-      break;
-    }
-    case 0x9210: { //Number of charge cycles
-      mt_bat_cycles->SetValue(CAN_UINT(0));
-      //ESP_LOGD(TAG, "9210 LBC mt_bat_cycles: %d", CAN_UINT(0));
-      break;
-    }
-    case 0x9018: { //Max charge power
-      mt_bat_max_charge_power->SetValue((float) (CAN_UINT(0) * 0.01), kW);
-      //ESP_LOGD(TAG, "9018 LBC mt_bat_max_charge_power: %f", CAN_UINT(0) * 0.01);
-      break;
-    }
-    case 0x91C8: { //Available charge in kWh
-      mt_bat_available_energy->SetValue(float(CAN_UINT24(0) * 0.001), kWh);
-      //ESP_LOGD(TAG, "91C8 LBC mt_bat_available_energy: %f", CAN_UINT24(0) * 0.001);
-      break;
-    }
-    case 0x9131: {
-      BmsSetCellTemperature(0, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9132: {
-      BmsSetCellTemperature(1, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9133: {
-      BmsSetCellTemperature(2, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9134: {
-      BmsSetCellTemperature(3, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9135: {
-      BmsSetCellTemperature(4, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9136: {
-      BmsSetCellTemperature(5, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9137: {
-      BmsSetCellTemperature(6, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9138: {
-      BmsSetCellTemperature(7, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9139: {
-      BmsSetCellTemperature(8, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x913A: {
-      BmsSetCellTemperature(9, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x913B: {
-      BmsSetCellTemperature(10, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x913C: {
-      BmsSetCellTemperature(11, CAN_UINT(0) * 0.0625 - 40);
-      //ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
-      break;
-    }
-    case 0x9021: {
-      BmsSetCellVoltage(0, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9022: {
-      BmsSetCellVoltage(1, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9023: {
-      BmsSetCellVoltage(2, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9024: {
-      BmsSetCellVoltage(3, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9025: {
-      BmsSetCellVoltage(4, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9026: {
-      BmsSetCellVoltage(5, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9027: {
-      BmsSetCellVoltage(6, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9028: {
-      BmsSetCellVoltage(7, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9029: {
-      BmsSetCellVoltage(8, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x902A: {
-      BmsSetCellVoltage(9, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x902B: {
-      BmsSetCellVoltage(10, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x902C: {
-      BmsSetCellVoltage(11, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x902D: {
-      BmsSetCellVoltage(12, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x902E: {
-      BmsSetCellVoltage(13, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x902F: {
-      BmsSetCellVoltage(14, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9030: {
-      BmsSetCellVoltage(15, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9031: {
-      BmsSetCellVoltage(16, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9032: {
-      BmsSetCellVoltage(17, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9033: {
-      BmsSetCellVoltage(18, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9034: {
-      BmsSetCellVoltage(19, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9035: {
-      BmsSetCellVoltage(20, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9036: {
-      BmsSetCellVoltage(21, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9037: {
-      BmsSetCellVoltage(22, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9038: {
-      BmsSetCellVoltage(23, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9039: {
-      BmsSetCellVoltage(24, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x903A: {
-      BmsSetCellVoltage(25, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x903B: {
-      BmsSetCellVoltage(26, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x903C: {
-      BmsSetCellVoltage(27, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x903D: {
-      BmsSetCellVoltage(28, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x903E: {
-      BmsSetCellVoltage(29, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x903F: {
-      BmsSetCellVoltage(30, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9041: {
-      BmsSetCellVoltage(31, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9042: {
-      BmsSetCellVoltage(32, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9043: {
-      BmsSetCellVoltage(33, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9044: {
-      BmsSetCellVoltage(34, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9045: {
-      BmsSetCellVoltage(35, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9046: {
-      BmsSetCellVoltage(36, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9047: {
-      BmsSetCellVoltage(37, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9048: {
-      BmsSetCellVoltage(38, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9049: {
-      BmsSetCellVoltage(39, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x904A: {
-      BmsSetCellVoltage(40, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x904B: {
-      BmsSetCellVoltage(41, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x904C: {
-      BmsSetCellVoltage(42, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x904D: {
-      BmsSetCellVoltage(43, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x904E: {
-      BmsSetCellVoltage(44, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x904F: {
-      BmsSetCellVoltage(45, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9050: {
-      BmsSetCellVoltage(46, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9051: {
-      BmsSetCellVoltage(47, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9052: {
-      BmsSetCellVoltage(48, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9053: {
-      BmsSetCellVoltage(49, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9054: {
-      BmsSetCellVoltage(50, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9055: {
-      BmsSetCellVoltage(51, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9056: {
-      BmsSetCellVoltage(52, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9057: {
-      BmsSetCellVoltage(53, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9058: {
-      BmsSetCellVoltage(54, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9059: {
-      BmsSetCellVoltage(55, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x905A: {
-      BmsSetCellVoltage(56, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x905B: {
-      BmsSetCellVoltage(57, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x905C: {
-      BmsSetCellVoltage(58, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x905D: {
-      BmsSetCellVoltage(59, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x905E: {
-      BmsSetCellVoltage(60, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x905F: {
-      BmsSetCellVoltage(61, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9061: {
-      BmsSetCellVoltage(62, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9062: {
-      BmsSetCellVoltage(63, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9063: {
-      BmsSetCellVoltage(64, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9064: {
-      BmsSetCellVoltage(65, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9065: {
-      BmsSetCellVoltage(66, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9066: {
-      BmsSetCellVoltage(67, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9067: {
-      BmsSetCellVoltage(68, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9068: {
-      BmsSetCellVoltage(69, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9069: {
-      BmsSetCellVoltage(70, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x906A: {
-      BmsSetCellVoltage(71, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x906B: {
-      BmsSetCellVoltage(72, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x906C: {
-      BmsSetCellVoltage(73, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x906D: {
-      BmsSetCellVoltage(74, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x906E: {
-      BmsSetCellVoltage(75, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x906F: {
-      BmsSetCellVoltage(76, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9070: {
-      BmsSetCellVoltage(77, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9071: {
-      BmsSetCellVoltage(78, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9072: {
-      BmsSetCellVoltage(79, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9073: {
-      BmsSetCellVoltage(80, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9074: {
-      BmsSetCellVoltage(81, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9075: {
-      BmsSetCellVoltage(82, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9076: {
-      BmsSetCellVoltage(83, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9077: {
-      BmsSetCellVoltage(84, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9078: {
-      BmsSetCellVoltage(85, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9079: {
-      BmsSetCellVoltage(86, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x907A: {
-      BmsSetCellVoltage(87, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x907B: {
-      BmsSetCellVoltage(88, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x907C: {
-      BmsSetCellVoltage(89, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x907D: {
-      BmsSetCellVoltage(90, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x907E: {
-      BmsSetCellVoltage(91, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x907F: {
-      BmsSetCellVoltage(92, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9081: {
-      BmsSetCellVoltage(93, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9082: {
-      BmsSetCellVoltage(94, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
-    }
-    case 0x9083: {
-      BmsSetCellVoltage(95, CAN_UINT(0) * 0.001);
-      //ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
-      break;
+    if (bat_soc < 100.0f)
+    {
+      StandardMetrics.ms_v_bat_soc->SetValue(bat_soc + (bat_soc * 0.03), Percentage);
+    }
+    else
+    {
+      StandardMetrics.ms_v_bat_soc->SetValue(100.0f, Percentage);
     }
 
-    default: {
-      char *buf = NULL;
-      size_t rlen = len, offset = 0;
-      do {
-        rlen = FormatHexDump(&buf, data + offset, rlen, 16);
-        offset += 16;
-        ESP_LOGW(TAG, "OBD2: unhandled reply from LBC [%02x %02x]: %s", type, pid, buf ? buf : "-");
-      } while (rlen);
-      if (buf)
-        free(buf);
-      break;
-    }
-	}
+    StandardMetrics.ms_v_bat_cac->SetValue(Bat_cell_capacity_Ah * CAN_UINT(0) * 0.0001);
+    StandardMetrics.ms_v_bat_capacity->SetValue((m_battery_capacity / 1000) * StandardMetrics.ms_v_bat_soh->AsFloat(0) * CAN_UINT(0) * 0.000001);
+
+    // ESP_LOGD(TAG, "9002 LBC mt_bat_lbc_soc: %f", bat_soc);
+    // ESP_LOGD(TAG, "9002 LBC mt_bat_lbc_soc calculated: %f", bat_soc + (bat_soc * 0.03));
+    break;
+  }
+  case 0x9003:
+  { // Battery SOH
+    StandardMetrics.ms_v_bat_soh->SetValue((float)(CAN_UINT(0) * 0.01), Percentage);
+    StandardMetrics.ms_v_bat_health->SetValue(
+      ((float)(CAN_UINT(0) * 0.01) >= 90.0f) ? "excellent"
+    : ((float)(CAN_UINT(0) * 0.01) >= 80.0f) ? "good"
+    : ((float)(CAN_UINT(0) * 0.01) >= 70.0f)   ? "average"
+    : ((float)(CAN_UINT(0) * 0.01) >= 60.0f)   ? "poor"
+    : "consider replacement");
+    // ESP_LOGD(TAG, "9003 LBC ms_v_bat_soh: %f", CAN_UINT(0) * 0.01);
+    break;
+  }
+  case 0x9243:
+  { // Battery energy charged kWh
+    StandardMetrics.ms_v_charge_kwh_grid_total->SetValue((float)(CAN_UINT32(0) * 0.001), kWh);
+    // ESP_LOGD(TAG, "9243 LBC ms_v_charge_kwh_grid_total: %f", CAN_UINT32(0) * 0.001);
+    break;
+  }
+  case 0x9245:
+  { // Battery energy discharged kWh
+    StandardMetrics.ms_v_bat_energy_used_total->SetValue((float)(CAN_UINT32(0) * 0.001), kWh);
+    // ESP_LOGD(TAG, "9244 LBC ms_v_bat_energy_used_total: %f", CAN_UINT32(0) * 0.001);
+    break;
+  }
+  case 0x9247:
+  { // Battery energy regenerated kWh
+    StandardMetrics.ms_v_bat_energy_recd_total->SetValue((float)(CAN_UINT32(0) * 0.001), kWh);
+    // ESP_LOGD(TAG, "9246 LBC ms_v_bat_energy_recd_total: %f", CAN_UINT32(0) * 0.001);
+    break;
+  }
+  case 0x9210:
+  { // Number of charge cycles
+    mt_bat_cycles->SetValue(CAN_UINT(0));
+    // ESP_LOGD(TAG, "9210 LBC mt_bat_cycles: %d", CAN_UINT(0));
+    break;
+  }
+  case 0x9018:
+  { // Max charge power
+    mt_bat_max_charge_power->SetValue((float)(CAN_UINT(0) * 0.01), kW);
+    // ESP_LOGD(TAG, "9018 LBC mt_bat_max_charge_power: %f", CAN_UINT(0) * 0.01);
+    break;
+  }
+  case 0x91C8:
+  { // Available charge in kWh
+    mt_bat_available_energy->SetValue(float(CAN_UINT24(0) * 0.001), kWh);
+    // ESP_LOGD(TAG, "91C8 LBC mt_bat_available_energy: %f", CAN_UINT24(0) * 0.001);
+    break;
+  }
+  case 0x9131:
+  {
+    BmsSetCellTemperature(0, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9132:
+  {
+    BmsSetCellTemperature(1, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9133:
+  {
+    BmsSetCellTemperature(2, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9134:
+  {
+    BmsSetCellTemperature(3, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9135:
+  {
+    BmsSetCellTemperature(4, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9136:
+  {
+    BmsSetCellTemperature(5, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9137:
+  {
+    BmsSetCellTemperature(6, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9138:
+  {
+    BmsSetCellTemperature(7, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9139:
+  {
+    BmsSetCellTemperature(8, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x913A:
+  {
+    BmsSetCellTemperature(9, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x913B:
+  {
+    BmsSetCellTemperature(10, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x913C:
+  {
+    BmsSetCellTemperature(11, CAN_UINT(0) * 0.0625 - 40);
+    // ESP_LOGD(TAG, "%x: %f C", pid, CAN_UINT(0) * 0.0625 - 40);
+    break;
+  }
+  case 0x9021:
+  {
+    BmsSetCellVoltage(0, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9022:
+  {
+    BmsSetCellVoltage(1, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9023:
+  {
+    BmsSetCellVoltage(2, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9024:
+  {
+    BmsSetCellVoltage(3, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9025:
+  {
+    BmsSetCellVoltage(4, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9026:
+  {
+    BmsSetCellVoltage(5, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9027:
+  {
+    BmsSetCellVoltage(6, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9028:
+  {
+    BmsSetCellVoltage(7, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9029:
+  {
+    BmsSetCellVoltage(8, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x902A:
+  {
+    BmsSetCellVoltage(9, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x902B:
+  {
+    BmsSetCellVoltage(10, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x902C:
+  {
+    BmsSetCellVoltage(11, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x902D:
+  {
+    BmsSetCellVoltage(12, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x902E:
+  {
+    BmsSetCellVoltage(13, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x902F:
+  {
+    BmsSetCellVoltage(14, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9030:
+  {
+    BmsSetCellVoltage(15, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9031:
+  {
+    BmsSetCellVoltage(16, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9032:
+  {
+    BmsSetCellVoltage(17, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9033:
+  {
+    BmsSetCellVoltage(18, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9034:
+  {
+    BmsSetCellVoltage(19, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9035:
+  {
+    BmsSetCellVoltage(20, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9036:
+  {
+    BmsSetCellVoltage(21, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9037:
+  {
+    BmsSetCellVoltage(22, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9038:
+  {
+    BmsSetCellVoltage(23, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9039:
+  {
+    BmsSetCellVoltage(24, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x903A:
+  {
+    BmsSetCellVoltage(25, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x903B:
+  {
+    BmsSetCellVoltage(26, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x903C:
+  {
+    BmsSetCellVoltage(27, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x903D:
+  {
+    BmsSetCellVoltage(28, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x903E:
+  {
+    BmsSetCellVoltage(29, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x903F:
+  {
+    BmsSetCellVoltage(30, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9041:
+  {
+    BmsSetCellVoltage(31, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9042:
+  {
+    BmsSetCellVoltage(32, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9043:
+  {
+    BmsSetCellVoltage(33, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9044:
+  {
+    BmsSetCellVoltage(34, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9045:
+  {
+    BmsSetCellVoltage(35, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9046:
+  {
+    BmsSetCellVoltage(36, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9047:
+  {
+    BmsSetCellVoltage(37, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9048:
+  {
+    BmsSetCellVoltage(38, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9049:
+  {
+    BmsSetCellVoltage(39, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x904A:
+  {
+    BmsSetCellVoltage(40, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x904B:
+  {
+    BmsSetCellVoltage(41, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x904C:
+  {
+    BmsSetCellVoltage(42, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x904D:
+  {
+    BmsSetCellVoltage(43, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x904E:
+  {
+    BmsSetCellVoltage(44, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x904F:
+  {
+    BmsSetCellVoltage(45, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9050:
+  {
+    BmsSetCellVoltage(46, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9051:
+  {
+    BmsSetCellVoltage(47, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9052:
+  {
+    BmsSetCellVoltage(48, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9053:
+  {
+    BmsSetCellVoltage(49, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9054:
+  {
+    BmsSetCellVoltage(50, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9055:
+  {
+    BmsSetCellVoltage(51, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9056:
+  {
+    BmsSetCellVoltage(52, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9057:
+  {
+    BmsSetCellVoltage(53, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9058:
+  {
+    BmsSetCellVoltage(54, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9059:
+  {
+    BmsSetCellVoltage(55, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x905A:
+  {
+    BmsSetCellVoltage(56, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x905B:
+  {
+    BmsSetCellVoltage(57, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x905C:
+  {
+    BmsSetCellVoltage(58, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x905D:
+  {
+    BmsSetCellVoltage(59, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x905E:
+  {
+    BmsSetCellVoltage(60, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x905F:
+  {
+    BmsSetCellVoltage(61, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9061:
+  {
+    BmsSetCellVoltage(62, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9062:
+  {
+    BmsSetCellVoltage(63, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9063:
+  {
+    BmsSetCellVoltage(64, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9064:
+  {
+    BmsSetCellVoltage(65, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9065:
+  {
+    BmsSetCellVoltage(66, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9066:
+  {
+    BmsSetCellVoltage(67, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9067:
+  {
+    BmsSetCellVoltage(68, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9068:
+  {
+    BmsSetCellVoltage(69, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9069:
+  {
+    BmsSetCellVoltage(70, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x906A:
+  {
+    BmsSetCellVoltage(71, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x906B:
+  {
+    BmsSetCellVoltage(72, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x906C:
+  {
+    BmsSetCellVoltage(73, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x906D:
+  {
+    BmsSetCellVoltage(74, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x906E:
+  {
+    BmsSetCellVoltage(75, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x906F:
+  {
+    BmsSetCellVoltage(76, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9070:
+  {
+    BmsSetCellVoltage(77, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9071:
+  {
+    BmsSetCellVoltage(78, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9072:
+  {
+    BmsSetCellVoltage(79, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9073:
+  {
+    BmsSetCellVoltage(80, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9074:
+  {
+    BmsSetCellVoltage(81, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9075:
+  {
+    BmsSetCellVoltage(82, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9076:
+  {
+    BmsSetCellVoltage(83, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9077:
+  {
+    BmsSetCellVoltage(84, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9078:
+  {
+    BmsSetCellVoltage(85, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9079:
+  {
+    BmsSetCellVoltage(86, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x907A:
+  {
+    BmsSetCellVoltage(87, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x907B:
+  {
+    BmsSetCellVoltage(88, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x907C:
+  {
+    BmsSetCellVoltage(89, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x907D:
+  {
+    BmsSetCellVoltage(90, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x907E:
+  {
+    BmsSetCellVoltage(91, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x907F:
+  {
+    BmsSetCellVoltage(92, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9081:
+  {
+    BmsSetCellVoltage(93, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9082:
+  {
+    BmsSetCellVoltage(94, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+  case 0x9083:
+  {
+    BmsSetCellVoltage(95, CAN_UINT(0) * 0.000976563);
+    // ESP_LOGD(TAG, "%x: %f V", pid, CAN_UINT(0)  * 0.001);
+    break;
+  }
+
+  default:
+  {
+    char *buf = NULL;
+    size_t rlen = len, offset = 0;
+    do
+    {
+      rlen = FormatHexDump(&buf, data + offset, rlen, 16);
+      offset += 16;
+      ESP_LOGW(TAG, "OBD2: unhandled reply from LBC [%02x %02x]: %s", type, pid, buf ? buf : "-");
+    } while (rlen);
+    if (buf)
+      free(buf);
+    break;
+  }
+  }
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/UCM_pids.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/UCM_pids.cpp
@@ -24,26 +24,31 @@
 */
 #include "vehicle_renaultzoe_ph2_obd.h"
 
-void OvmsVehicleRenaultZoePh2OBD::IncomingUCM(uint16_t type, uint16_t pid, const char* data, uint16_t len) {  
-  switch (pid) {
-    case 0x6079: { //12V Battery Current
-      StandardMetrics.ms_v_charge_12v_current->SetValue((float) (CAN_UINT(0) * 0.1), Amps);
-      StandardMetrics.ms_v_bat_12v_current->SetValue((float) (CAN_UINT(0) * 0.1), Amps);
-      //ESP_LOGD(TAG, "6079 UCM ms_v_charge_12v_current: %f", CAN_UINT(0) * 0.1);
-      break;
-    }
+void OvmsVehicleRenaultZoePh2OBD::IncomingUCM(uint16_t type, uint16_t pid, const char *data, uint16_t len)
+{
+  switch (pid)
+  {
+  case 0x6079:
+  { // 12V Battery Current
+    StandardMetrics.ms_v_charge_12v_current->SetValue((float)(CAN_UINT(0) * 0.1), Amps);
+    StandardMetrics.ms_v_bat_12v_current->SetValue((float)(CAN_UINT(0) * 0.1), Amps);
+    // ESP_LOGD(TAG, "6079 UCM ms_v_charge_12v_current: %f", CAN_UINT(0) * 0.1);
+    break;
+  }
 
-    default: {
-      char *buf = NULL;
-      size_t rlen = len, offset = 0;
-      do {
-        rlen = FormatHexDump(&buf, data + offset, rlen, 16);
-        offset += 16;
-        ESP_LOGW(TAG, "OBD2: unhandled reply from UCM [%02x %02x]: %s", type, pid, buf ? buf : "-");
-      } while (rlen);
-      if (buf)
-        free(buf);
-      break;
-    }
+  default:
+  {
+    char *buf = NULL;
+    size_t rlen = len, offset = 0;
+    do
+    {
+      rlen = FormatHexDump(&buf, data + offset, rlen, 16);
+      offset += 16;
+      ESP_LOGW(TAG, "OBD2: unhandled reply from UCM [%02x %02x]: %s", type, pid, buf ? buf : "-");
+    } while (rlen);
+    if (buf)
+      free(buf);
+    break;
+  }
   }
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/ph2_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/ph2_poller.h
@@ -32,193 +32,190 @@
 // Pollstate 2 - POLLSTATE_DRIVING  - car is driving
 // Pollstate 3 - POLLSTATE_CHARGING - car is charging
 static const OvmsPoller::poll_pid_t renault_zoe_polls[] = {
-//***TX-ID, ***RX-ID, ***SID, ***PID, { Polltime (seconds) for Pollstate 0, 1, 2, 3}, ***CAN BUS Interface, ***FRAMETYPE
+    //***TX-ID, ***RX-ID, ***SID, ***PID, { Polltime (seconds) for Pollstate 0, 1, 2, 3}, ***CAN BUS Interface, ***FRAMETYPE
 
-//Motor Inverter
-//{ 0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_EXTDIAG,  { 0, 60, 60, 60 }, 0, ISOTP_EXTFRAME }, // OBD Extended Diagnostic Session
-{ 0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x700C, { 0, 10, 10, 10 }, 0, ISOTP_EXTFRAME },  // Inverter temperature
-{ 0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x700F, { 0, 10, 10, 10 }, 0, ISOTP_EXTFRAME },  // Stator Temperature 1
-{ 0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7010, { 0, 10, 10, 10 }, 0, ISOTP_EXTFRAME },  // Stator Temperature 2
-{ 0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2004, { 0, 60, 3, 60 }, 0, ISOTP_EXTFRAME },  // Battery voltage sense
-{ 0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7049, { 0, 60, 3, 60 }, 0, ISOTP_EXTFRAME },  // Current voltage sense
+    // Motor Inverter
+    //{ 0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_EXTDIAG,  { 0, 60, 60, 60 }, 0, ISOTP_EXTFRAME }, // OBD Extended Diagnostic Session
+    {0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x700C, {0, 10, 10, 10}, 0, ISOTP_EXTFRAME}, // Inverter temperature
+    {0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x700F, {0, 10, 10, 10}, 0, ISOTP_EXTFRAME}, // Stator Temperature 1
+    {0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7010, {0, 10, 10, 10}, 0, ISOTP_EXTFRAME}, // Stator Temperature 2
+    {0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2004, {0, 60, 3, 60}, 0, ISOTP_EXTFRAME},  // Battery voltage sense
+    {0x18dadff1, 0x18daf1df, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7049, {0, 60, 3, 60}, 0, ISOTP_EXTFRAME},  // Current voltage sense
 
-//EVC-HCM-VCM
-//{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_EXTDIAG,  { 0, 60, 60, 60 }, 0, ISOTP_EXTFRAME }, // OBD Extended Diagnostic Session
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, { 0, 10, 10, 300 }, 0, ISOTP_EXTFRAME },  // Odometer
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, { 0, 60, 2, 300 }, 0, ISOTP_EXTFRAME },  // Vehicle Speed
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0, 10, 10, 10 }, 0, ISOTP_EXTFRAME },  // 12Battery Voltage
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x21CF, { 0, 2, 10, 300 }, 0, ISOTP_EXTFRAME },  // Inverter Status
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2218, { 0, 20, 20, 20 }, 0, ISOTP_EXTFRAME },  // Ambient air temperature
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2A09, { 0, 10, 10, 10 }, 0, ISOTP_EXTFRAME },  // Power usage by consumer
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2191, { 0, 10, 10, 10 }, 0, ISOTP_EXTFRAME },  // Power usage by ptc
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B85, { 0, 2, 300, 10 }, 0, ISOTP_EXTFRAME },  // Charge plug present
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B6D, { 0, 2, 300, 10 }, 0, ISOTP_EXTFRAME },  // Charge MMI states
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B7A, { 0, 2, 300, 10 }, 0, ISOTP_EXTFRAME },  // Charge type
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3064, { 0, 10, 3, 10 }, 0, ISOTP_EXTFRAME },  // Motor rpm
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x300F, { 0, 2, 300, 3 }, 0, ISOTP_EXTFRAME },  // AC charging power available
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x300D, { 0, 10, 300, 3 }, 0, ISOTP_EXTFRAME },  // AC mains current
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x300B, { 0, 2, 300, 10 }, 0, ISOTP_EXTFRAME },  // AC phases
-{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B8A, { 0, 2, 300, 10 }, 0, ISOTP_EXTFRAME },  // AC mains voltage
+    // EVC-HCM-VCM
+    //{ 0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_EXTDIAG,  { 0, 60, 60, 60 }, 0, ISOTP_EXTFRAME }, // OBD Extended Diagnostic Session
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, {0, 10, 10, 300}, 0, ISOTP_EXTFRAME}, // Odometer
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, {0, 60, 2, 300}, 0, ISOTP_EXTFRAME},  // Vehicle Speed
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {0, 10, 10, 10}, 0, ISOTP_EXTFRAME},  // 12Battery Voltage
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x21CF, {0, 2, 10, 300}, 0, ISOTP_EXTFRAME},  // Inverter Status
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2218, {0, 20, 20, 20}, 0, ISOTP_EXTFRAME},  // Ambient air temperature
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B85, {0, 2, 300, 10}, 0, ISOTP_EXTFRAME},  // Charge plug present
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B6D, {0, 2, 300, 10}, 0, ISOTP_EXTFRAME},  // Charge MMI states
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B7A, {0, 2, 300, 10}, 0, ISOTP_EXTFRAME},  // Charge type
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3064, {0, 10, 3, 10}, 0, ISOTP_EXTFRAME},   // Motor rpm
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x300F, {0, 2, 300, 3}, 0, ISOTP_EXTFRAME},   // AC charging power available
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x300D, {0, 10, 300, 3}, 0, ISOTP_EXTFRAME},  // AC mains current
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x300B, {0, 2, 300, 10}, 0, ISOTP_EXTFRAME},  // AC phases
+    {0x18dadaf1, 0x18daf1da, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2B8A, {0, 2, 300, 10}, 0, ISOTP_EXTFRAME},  // AC mains voltage
 
-//BCM
-//{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_DEFAULT,  { 0, 60, 60, 60 }, 0, ISOTP_STD }, // OBD Extended Diagnostic Session
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6300, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS pressure - front left
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6301, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS pressure - front right
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6302, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS pressure - rear left
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6303, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS pressure - rear right
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6310, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS temp - front left
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6311, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS temp - front right
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6312, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS temp - rear left
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6313, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS temp - rear right
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4109, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS alert - front left
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x410A, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS alert - front right
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x410B, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS alert - rear left
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x410C, { 0, 300, 300, 300 }, 0, ISOTP_STD },  // TPMS alert - rear right
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x8004, { 0, 3, 3, 3 }, 0, ISOTP_STD },  // Car secure aka vehicle locked
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6026, { 0, 3, 3, 3 }, 0, ISOTP_STD },  // Front left door
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6027, { 0, 3, 3, 3 }, 0, ISOTP_STD },  // Front right door
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x61B2, { 0, 3, 3, 3 }, 0, ISOTP_STD },  // Rear left door
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x61B3, { 0, 3, 3, 3 }, 0, ISOTP_STD },  // Rear right door
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x609B, { 0, 3, 3, 3 }, 0, ISOTP_STD },  // Tailgate
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4186, { 0, 3, 3, 3 }, 0, ISOTP_STD },  // Low beam lights
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x60C6, { 0, 3, 6, 60 }, 0, ISOTP_STD },  // Ignition relay (switch), working but behavior on CHARING testing needed
-{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4060, { 0, 600, 0, 0 }, 0, ISOTP_STD },  // Vehicle identificaftion number
+    // BCM
+    //{ 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_DEFAULT,  { 0, 60, 60, 60 }, 0, ISOTP_STD }, // OBD Extended Diagnostic Session
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6300, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS pressure - front left
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6301, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS pressure - front right
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6302, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS pressure - rear left
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6303, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS pressure - rear right
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6310, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS temp - front left
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6311, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS temp - front right
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6312, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS temp - rear left
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6313, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS temp - rear right
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4109, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS alert - front left
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x410A, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS alert - front right
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x410B, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS alert - rear left
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x410C, {0, 300, 300, 300}, 0, ISOTP_STD}, // TPMS alert - rear right
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x8004, {0, 3, 3, 3}, 0, ISOTP_STD},       // Car secure aka vehicle locked
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6026, {0, 3, 3, 3}, 0, ISOTP_STD},       // Front left door
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6027, {0, 3, 3, 3}, 0, ISOTP_STD},       // Front right door
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x61B2, {0, 3, 3, 3}, 0, ISOTP_STD},       // Rear left door
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x61B3, {0, 3, 3, 3}, 0, ISOTP_STD},       // Rear right door
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x609B, {0, 3, 3, 3}, 0, ISOTP_STD},       // Tailgate
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4186, {0, 3, 3, 3}, 0, ISOTP_STD},       // Low beam lights
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x60C6, {0, 3, 6, 60}, 0, ISOTP_STD},      // Ignition relay (switch), working but behavior on CHARING testing needed
+    {0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4060, {0, 600, 0, 0}, 0, ISOTP_STD},     // Vehicle identificaftion number
 
-//LBC
-//{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_DEFAULT,  { 0, 60, 60, 60 }, 0, ISOTP_EXTFRAME }, // OBD Extended Diagnostic Session
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9002, { 0, 10, 10, 10 }, 0, ISOTP_EXTFRAME },  // SOC
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9003, { 0, 60, 60, 10 }, 0, ISOTP_EXTFRAME },  // SOH
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9005, { 0, 10, 3, 5 }, 0, ISOTP_EXTFRAME },  // Battery Voltage
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x925D, { 0, 10, 3, 5 }, 0, ISOTP_EXTFRAME },  // Battery Current
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9012, { 0, 10, 60, 5 }, 0, ISOTP_EXTFRAME },  // Battery Average Temperature
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x91C8, { 0, 60, 60, 5 }, 0, ISOTP_EXTFRAME },  // Battery Available Energy kWh
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9243, { 0, 60, 60, 10 }, 0, ISOTP_EXTFRAME },  // Energy charged kWh
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9245, { 0, 60, 10, 60 }, 0, ISOTP_EXTFRAME },  // Energy discharged kWh
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9247, { 0, 60, 10, 60 }, 0, ISOTP_EXTFRAME },  // Energy regenerated kWh
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9210, { 0, 60, 60, 60 }, 0, ISOTP_EXTFRAME },  // Number of complete cycles
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9018, { 0, 10, 60, 10 }, 0, ISOTP_EXTFRAME },  // Max Charge Power
-//LBC Cell voltages and temperatures, OBD Grouppoll not working
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9131, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 1
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9132, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 2
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9133, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 3
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9134, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 4
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9135, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 5
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9136, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 6
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9137, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 7
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9138, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 8
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9139, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 9
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x913A, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 10
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x913B, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 11
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x913C, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Pack temperature 12
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9021, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 1
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9022, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 2
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9023, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 3
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9024, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 4
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9025, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 5
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9026, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 6
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9027, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 7
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9028, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 8
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9029, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 9
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902A, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 10
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902B, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 11
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902C, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 12
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902D, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 13
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902E, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 14
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902F, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 15
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9030, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 16
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9031, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 17
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9032, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 18
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9033, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 19
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9034, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 20
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9035, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 21
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9036, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 22
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9037, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 23
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9038, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 24
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9039, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 25
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903A, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 26
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903B, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 27
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903C, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 28
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903D, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 29
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903E, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 30
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903F, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 31
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9041, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 32
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9042, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 33
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9043, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 34
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9044, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 35
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9045, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 36
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9046, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 37
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9047, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 38
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9048, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 39
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9049, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 40
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904A, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 41
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904B, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 42
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904C, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 43
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904D, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 44
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904E, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 45
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904F, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 46
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9050, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 47
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9051, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 48
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9052, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 49
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9053, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 50
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9054, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 51
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9055, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 52
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9056, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 53
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9057, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 54
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9058, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 55
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9059, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 56
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905A, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 57
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905B, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 58
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905C, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 59
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905D, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 60
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905E, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 61
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905F, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 62
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9061, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 63
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9062, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 64
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9063, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 65
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9064, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 66
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9065, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 67
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9066, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 68
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9067, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 69
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9068, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 70
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9069, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 71
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906A, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 72
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906B, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 73
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906C, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 74
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906D, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 75
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906E, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 76
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906F, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 77
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9070, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 78
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9071, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 79
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9072, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 80
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9073, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 81
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9074, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 82
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9075, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 83
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9076, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 84
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9077, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 85
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9078, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 86
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9079, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 87
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907A, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 88
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907B, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 89
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907C, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 90
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907D, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 91
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907E, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 92
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907F, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 93
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9081, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 94
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9082, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 95
-{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9083, { 0, 60, 300, 60 }, 0, ISOTP_EXTFRAME },  // Cell voltage 96
- 
-//HVAC
-//{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_EXTDIAG,  { 0, 60, 60, 60 }, 0, ISOTP_STD }, // OBD Extended Diagnostic Session
-{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4009,  { 0, 10, 60, 10 }, 0, ISOTP_STD }, // Cabin temp
-{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4360,  { 0, 60, 60, 60 }, 0, ISOTP_STD }, // Cabin setpoint
-{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x43D8,  { 0, 10, 10, 5 }, 0, ISOTP_STD },  // Compressor speed
-{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4402,  { 0, 10, 10, 10 }, 0, ISOTP_STD }, // Compressor state
-{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4369,  { 0, 10, 10, 10 }, 0, ISOTP_STD }, // Compressor pressure in BAR
-{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4436,  { 0, 10, 10, 10 }, 0, ISOTP_STD }, // Compressor power
+    // LBC
+    //{ 0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_DEFAULT,  { 0, 60, 60, 60 }, 0, ISOTP_EXTFRAME }, // OBD Extended Diagnostic Session
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9002, {0, 10, 10, 10}, 0, ISOTP_EXTFRAME}, // SOC
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9003, {0, 60, 60, 10}, 0, ISOTP_EXTFRAME}, // SOH
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9005, {0, 10, 3, 5}, 0, ISOTP_EXTFRAME},   // Battery Voltage
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x925D, {0, 10, 3, 5}, 0, ISOTP_EXTFRAME},   // Battery Current
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9012, {0, 10, 60, 5}, 0, ISOTP_EXTFRAME},  // Battery Average Temperature
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x91C8, {0, 60, 60, 5}, 0, ISOTP_EXTFRAME},  // Battery Available Energy kWh
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9243, {0, 60, 60, 10}, 0, ISOTP_EXTFRAME}, // Energy charged kWh
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9245, {0, 60, 10, 60}, 0, ISOTP_EXTFRAME}, // Energy discharged kWh
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9247, {0, 60, 10, 60}, 0, ISOTP_EXTFRAME}, // Energy regenerated kWh
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9210, {0, 60, 60, 60}, 0, ISOTP_EXTFRAME}, // Number of complete cycles
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9018, {0, 10, 60, 10}, 0, ISOTP_EXTFRAME}, // Max Charge Power
+    // LBC Cell voltages and temperatures, OBD Grouppoll not working
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9131, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 1
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9132, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 2
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9133, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 3
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9134, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 4
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9135, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 5
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9136, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 6
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9137, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 7
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9138, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 8
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9139, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 9
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x913A, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 10
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x913B, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 11
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x913C, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Pack temperature 12
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9021, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 1
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9022, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 2
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9023, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 3
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9024, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 4
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9025, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 5
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9026, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 6
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9027, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 7
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9028, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 8
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9029, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 9
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902A, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 10
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902B, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 11
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902C, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 12
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902D, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 13
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902E, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 14
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x902F, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 15
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9030, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 16
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9031, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 17
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9032, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 18
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9033, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 19
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9034, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 20
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9035, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 21
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9036, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 22
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9037, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 23
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9038, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 24
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9039, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 25
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903A, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 26
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903B, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 27
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903C, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 28
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903D, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 29
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903E, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 30
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x903F, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 31
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9041, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 32
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9042, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 33
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9043, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 34
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9044, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 35
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9045, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 36
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9046, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 37
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9047, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 38
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9048, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 39
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9049, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 40
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904A, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 41
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904B, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 42
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904C, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 43
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904D, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 44
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904E, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 45
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x904F, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 46
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9050, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 47
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9051, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 48
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9052, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 49
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9053, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 50
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9054, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 51
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9055, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 52
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9056, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 53
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9057, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 54
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9058, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 55
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9059, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 56
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905A, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 57
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905B, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 58
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905C, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 59
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905D, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 60
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905E, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 61
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x905F, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 62
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9061, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 63
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9062, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 64
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9063, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 65
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9064, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 66
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9065, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 67
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9066, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 68
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9067, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 69
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9068, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 70
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9069, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 71
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906A, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 72
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906B, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 73
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906C, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 74
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906D, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 75
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906E, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 76
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x906F, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 77
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9070, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 78
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9071, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 79
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9072, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 80
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9073, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 81
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9074, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 82
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9075, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 83
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9076, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 84
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9077, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 85
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9078, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 86
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9079, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 87
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907A, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 88
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907B, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 89
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907C, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 90
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907D, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 91
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907E, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 92
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x907F, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 93
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9081, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 94
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9082, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 95
+    {0x18dadbf1, 0x18daf1db, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x9083, {0, 60, 300, 60}, 0, ISOTP_EXTFRAME}, // Cell voltage 96
 
-//UCM
-//{ 0x74D, 0x76D, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_AfterSales,  { 0, 60, 60, 60 }, 0, ISOTP_STD }, // OBD Extended Diagnostic Session
-{ 0x74D, 0x76D, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6079, { 0, 10, 10, 10 }, 0, ISOTP_STD },  // 12V Battery current
+    // HVAC
+    //{ 0x744, 0x764, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_EXTDIAG,  { 0, 60, 60, 60 }, 0, ISOTP_STD }, // OBD Extended Diagnostic Session
+    {0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4009, {0, 10, 60, 10}, 0, ISOTP_STD}, // Cabin temp
+    {0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4360, {0, 60, 60, 60}, 0, ISOTP_STD}, // Cabin setpoint
+    {0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x43D8, {0, 10, 10, 5}, 0, ISOTP_STD},  // Compressor speed
+    {0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4402, {0, 10, 10, 10}, 0, ISOTP_STD}, // Compressor state
+    {0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4369, {0, 10, 10, 10}, 0, ISOTP_STD}, // Compressor pressure in BAR
+    {0x744, 0x764, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x4436, {0, 10, 10, 10}, 0, ISOTP_STD}, // Compressor power
 
-POLL_LIST_END
-};
+    // UCM
+    //{ 0x74D, 0x76D, VEHICLE_POLL_TYPE_OBDIISESSION, SESSION_AfterSales,  { 0, 60, 60, 60 }, 0, ISOTP_STD }, // OBD Extended Diagnostic Session
+    {0x74D, 0x76D, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x6079, {0, 10, 10, 10}, 0, ISOTP_STD}, // 12V Battery current
+
+    POLL_LIST_END};

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/rz2_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/rz2_commands.cpp
@@ -1,0 +1,96 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          9th Feb 2025
+;
+;    (C) 2025       Carsten Schmiemann
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#include "vehicle_renaultzoe_ph2_obd.h"
+
+OvmsVehicle::vehicle_command_t OvmsVehicleRenaultZoePh2OBD::CommandClimateControl(bool climatecontrolon)
+{
+    OvmsVehicle::vehicle_command_t res;
+    ESP_LOGI(TAG, "Request CommandClimateControl %s", climatecontrolon ? "ON" : "OFF");
+
+    if (climatecontrolon)
+    {
+        // Check if Zoe is locked, Zoe ECUs can be alive or not, but must be locked to successful trigger pre-heat
+        if (!StandardMetrics.ms_v_env_locked->AsBool())
+        {
+            ESP_LOGW(TAG, "CommandClimateControl not possible, because vehicle is not locked");
+            res = Fail;
+            return res;
+        }
+        // Check if hvac is already running
+        else if (StandardMetrics.ms_v_env_hvac->AsBool())
+        {
+            ESP_LOGW(TAG, "CommandClimateControl not possible, because HVAC is already running");
+            res = Fail;
+            return res;
+        }
+        else
+        {
+            // BCM wake up car and start preheat on V-CAN (OVMS CAN2) - all in one
+            uint8_t data[8] = {0x74, 0x15, 0xFF, 0x00, 0xA4, 0x84, 0x07, 0x11};
+
+            // Enable CAN2, because we only need it for sending pre-heat command
+            m_can2->Start(CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);
+            m_can2->SetPowerMode(On);
+
+            for (int i = 0; i < 11; i++)
+            {
+                m_can2->WriteStandard(0x46F, 8, data);
+                vTaskDelay(250 / portTICK_PERIOD_MS);
+                ESP_LOGI(TAG, "Send wake-up and pre-heat command to V-CAN (CAN2) (%d/10) ...", i);
+            }
+
+            // Disable CAN2 interface, to save OVMS resources
+            m_can2->SetPowerMode(Off);
+            m_can2->Stop();
+            res = Success;
+        }
+    }
+    else
+    {
+        ESP_LOGI(TAG, "CommandClimateControl stop request currently not implemented.");
+        res = NotImplemented;
+    }
+
+    return res;
+}
+
+OvmsVehicle::vehicle_command_t OvmsVehicleRenaultZoePh2OBD::CommandHomelink(int button, int durationms)
+{
+    // ClimateControl workaround because no AC button for Zoe Ph2 in OVMS app
+    ESP_LOGI(TAG, "CommandHomelink button=%d durationms=%d", button, durationms);
+
+    OvmsVehicle::vehicle_command_t res;
+    if (button == 0)
+    {
+        res = CommandClimateControl(true);
+    }
+    else
+    {
+        res = NotImplemented;
+    }
+
+    return res;
+}

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/rz2_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/rz2_web.cpp
@@ -43,22 +43,25 @@ using namespace std;
 #define _attr(text) (c.encode_html(text).c_str())
 #define _html(text) (c.encode_html(text).c_str())
 
-void OvmsVehicleRenaultZoePh2OBD::WebCfgCommon(PageEntry_t& p, PageContext_t& c)
+void OvmsVehicleRenaultZoePh2OBD::WebCfgCommon(PageEntry_t &p, PageContext_t &c)
 {
   std::string error, rangeideal, battcapacity;
   bool UseBMScalculation;
 
-  if (c.method == "POST") {
-    rangeideal            = c.getvar("rangeideal");
-    battcapacity          = c.getvar("battcapacity");
-    UseBMScalculation     = (c.getvar("UseBMScalculation") == "no");
+  if (c.method == "POST")
+  {
+    rangeideal = c.getvar("rangeideal");
+    battcapacity = c.getvar("battcapacity");
+    UseBMScalculation = (c.getvar("UseBMScalculation") == "no");
 
-    if (!rangeideal.empty()) {
+    if (!rangeideal.empty())
+    {
       int v = atoi(rangeideal.c_str());
       if (v < 90 || v > 500)
         error += "<li data-input=\"rangeideal\">Range Ideal must be of 80…500 km</li>";
     }
-    if (error == "") {
+    if (error == "")
+    {
       // store:
       MyConfig.SetParamValue("xrz2o", "rangeideal", rangeideal);
       MyConfig.SetParamValue("xrz2o", "battcapacity", battcapacity);
@@ -75,10 +78,11 @@ void OvmsVehicleRenaultZoePh2OBD::WebCfgCommon(PageEntry_t& p, PageContext_t& c)
     c.head(400);
     c.alert("danger", error.c_str());
   }
-  else {
+  else
+  {
     // read configuration:
-    rangeideal        = MyConfig.GetParamValue("xrz2o", "rangeideal", "350");
-    battcapacity      = MyConfig.GetParamValue("xrz2o", "battcapacity", "52000");
+    rangeideal = MyConfig.GetParamValue("xrz2o", "rangeideal", "350");
+    battcapacity = MyConfig.GetParamValue("xrz2o", "battcapacity", "52000");
     UseBMScalculation = MyConfig.GetParamValueBool("xrz2o", "UseBMScalculation", false);
     c.head(200);
   }
@@ -95,7 +99,7 @@ void OvmsVehicleRenaultZoePh2OBD::WebCfgCommon(PageEntry_t& p, PageContext_t& c)
   c.input_radio_end("");
 
   c.input_slider("Range Ideal", "rangeideal", 3, "km", -1, atoi(rangeideal.c_str()), 350, 80, 500, 1,
-    "<p>Default 350km. Ideal Range...</p>");
+                 "<p>Default 350km. Ideal Range...</p>");
 
   c.fieldset_start("Battery energy calculation");
 
@@ -119,7 +123,7 @@ void OvmsVehicleRenaultZoePh2OBD::WebCfgCommon(PageEntry_t& p, PageContext_t& c)
 void OvmsVehicleRenaultZoePh2OBD::WebInit()
 {
   MyWebServer.RegisterPage("/xrz2o/battmon", "BMS View", OvmsWebServer::HandleBmsCellMonitor, PageMenu_Vehicle, PageAuth_Cookie);
-  MyWebServer.RegisterPage("/xrz2o/settings", "Setup", WebCfgCommon,  PageMenu_Vehicle, PageAuth_Cookie);
+  MyWebServer.RegisterPage("/xrz2o/settings", "Setup", WebCfgCommon, PageMenu_Vehicle, PageAuth_Cookie);
 }
 
 /**
@@ -131,5 +135,4 @@ void OvmsVehicleRenaultZoePh2OBD::WebDeInit()
   MyWebServer.DeregisterPage("/xrz2o/settings");
 }
 
-
-#endif //CONFIG_OVMS_COMP_WEBSERVER
+#endif // CONFIG_OVMS_COMP_WEBSERVER

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.cpp
@@ -23,7 +23,6 @@
 ; THE SOFTWARE.
 */
 
-
 #include "ovms_log.h"
 
 #include <stdio.h>
@@ -44,341 +43,410 @@
 
 const char *OvmsVehicleRenaultZoePh2OBD::s_tag = "v-zoe-ph2-obd";
 
-OvmsVehicleRenaultZoePh2OBD::OvmsVehicleRenaultZoePh2OBD() {
+OvmsVehicleRenaultZoePh2OBD::OvmsVehicleRenaultZoePh2OBD()
+{
   ESP_LOGI(TAG, "Start Renault Zoe Ph2 (OBD) vehicle module");
 
-  //Init variables supressing push on boot up
+  // Init variables supressing push on boot up
   StandardMetrics.ms_v_type->SetValue("RZ2");
   StandardMetrics.ms_v_charge_inprogress->SetValue(false);
   StandardMetrics.ms_v_charge_pilot->SetValue(false);
   StandardMetrics.ms_v_charge_state->SetValue("stopped");
   StandardMetrics.ms_v_charge_substate->SetValue("stopped");
   StandardMetrics.ms_v_env_on->SetValue(false);
-  
+
   MyConfig.RegisterParam("xrz2o", "Renault Zoe Ph2 (OBD) configuration", true, true);
   ConfigChanged(NULL);
 
   // Init Zoe Ph2 OBD Connection (CAN Gateway)
-  RegisterCanBus(1, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);
+  RegisterCanBus(1, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS); // OBD port on Can Gateway
+  RegisterCanBus(2, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS); // V-CAN direct connection, will be switch on/off by pre-heating
+  // Switch off CAN2 interface, because needed only for pre-heating
+  m_can2->SetPowerMode(Off);
+  m_can2->Stop();
 
   POLLSTATE_OFF;
   ESP_LOGI(TAG, "Pollstate switched to OFF");
-  
+
   PollSetPidList(m_can1, renault_zoe_polls);
   PollSetThrottling(10);
   PollSetResponseSeparationTime(20);
-  
+
   // Renault ZOE specific metrics
-  mt_bus_awake                = MyMetrics.InitBool("zph2.v.bus.awake", SM_STALE_NONE, false);
-  mt_pos_odometer_start       = MyMetrics.InitFloat("zph2.v.pos.odometer.start", SM_STALE_MID, 0, Kilometers, true);
-  mt_bat_used_start           = MyMetrics.InitFloat("zph2.b.used.start", SM_STALE_MID, 0, kWh, true);
-  mt_bat_recd_start           = MyMetrics.InitFloat("zph2.b.recd.start", SM_STALE_MID, 0, kWh, true);
-  mt_bat_chg_start            = MyMetrics.InitFloat("zph2.b.chg.start", SM_STALE_MID, 0, kWh, true);
-  mt_bat_available_energy     = MyMetrics.InitFloat("zph2.b.avail.energy", SM_STALE_NONE, 0, kWh, true);
-  mt_bat_aux_power_consumer   = MyMetrics.InitFloat("zph2.b.aux.power.consumer", SM_STALE_MID, 0, Watts);
-	mt_bat_aux_power_ptc        = MyMetrics.InitFloat("zph2.b.aux.power.ptc", SM_STALE_MID, 0, Watts);
-  mt_bat_max_charge_power     = MyMetrics.InitFloat("zph2.b.max.charge.power", SM_STALE_MID, 0, kW, true);
-  mt_bat_cycles               = MyMetrics.InitFloat("zph2.b.cycles", SM_STALE_MID, 0, Other, true);
-  mt_main_power_available     = MyMetrics.InitFloat("zph2.c.main.power.available", SM_STALE_MIN, 0, kW);
-  mt_main_phases              = MyMetrics.InitString("zph2.c.main.phases", SM_STALE_MIN, 0);
-  mt_main_phases_num          = MyMetrics.InitFloat("zph2.c.main.phases.num", SM_STALE_MIN, 0);
-  mt_inv_status               = MyMetrics.InitString("zph2.m.inverter.status", SM_STALE_NONE, 0);
-  mt_inv_hv_voltage           = MyMetrics.InitFloat("zph2.i.voltage", SM_STALE_MID, 0, Volts, true);
-  mt_inv_hv_current           = MyMetrics.InitFloat("zph2.i.current", SM_STALE_MID, 0, Amps);
-  mt_mot_temp_stator1         = MyMetrics.InitFloat("zph2.m.temp.stator1", SM_STALE_MID, 0, Celcius);
-  mt_mot_temp_stator2         = MyMetrics.InitFloat("zph2.m.temp.stator2", SM_STALE_MID, 0, Celcius);
-  mt_hvac_compressor_speed    = MyMetrics.InitFloat("zph2.h.compressor.speed", SM_STALE_MID, 0);
+  mt_bus_awake = MyMetrics.InitBool("zph2.v.bus.awake", SM_STALE_NONE, false);
+  mt_pos_odometer_start = MyMetrics.InitFloat("zph2.v.pos.odometer.start", SM_STALE_MID, 0, Kilometers, true);
+  mt_bat_used_start = MyMetrics.InitFloat("zph2.b.used.start", SM_STALE_MID, 0, kWh, true);
+  mt_bat_recd_start = MyMetrics.InitFloat("zph2.b.recd.start", SM_STALE_MID, 0, kWh, true);
+  mt_bat_chg_start = MyMetrics.InitFloat("zph2.b.chg.start", SM_STALE_MID, 0, kWh, true);
+  mt_bat_available_energy = MyMetrics.InitFloat("zph2.b.avail.energy", SM_STALE_NONE, 0, kWh, true);
+  mt_bat_max_charge_power = MyMetrics.InitFloat("zph2.b.max.charge.power", SM_STALE_MID, 0, kW, true);
+  mt_bat_cycles = MyMetrics.InitFloat("zph2.b.cycles", SM_STALE_MID, 0, Other, true);
+  mt_main_power_available = MyMetrics.InitFloat("zph2.c.main.power.available", SM_STALE_MIN, 0, kW);
+  mt_main_phases = MyMetrics.InitString("zph2.c.main.phases", SM_STALE_MIN, 0);
+  mt_main_phases_num = MyMetrics.InitFloat("zph2.c.main.phases.num", SM_STALE_MIN, 0);
+  mt_inv_status = MyMetrics.InitString("zph2.m.inverter.status", SM_STALE_NONE, 0);
+  mt_inv_hv_voltage = MyMetrics.InitFloat("zph2.i.voltage", SM_STALE_MID, 0, Volts, true);
+  mt_inv_hv_current = MyMetrics.InitFloat("zph2.i.current", SM_STALE_MID, 0, Amps);
+  mt_mot_temp_stator1 = MyMetrics.InitFloat("zph2.m.temp.stator1", SM_STALE_MID, 0, Celcius);
+  mt_mot_temp_stator2 = MyMetrics.InitFloat("zph2.m.temp.stator2", SM_STALE_MID, 0, Celcius);
+  mt_hvac_compressor_speed = MyMetrics.InitFloat("zph2.h.compressor.speed", SM_STALE_MID, 0);
   mt_hvac_compressor_pressure = MyMetrics.InitFloat("zph2.h.compressor.pressure", SM_STALE_MID, 0);
-  mt_hvac_compressor_power    = MyMetrics.InitFloat("zph2.h.compressor.power", SM_STALE_MID, 0, Watts);
-  mt_hvac_compressor_mode     = MyMetrics.InitString("zph2.h.compressor.mode", SM_STALE_MID, 0, Other);
+  mt_hvac_compressor_power = MyMetrics.InitFloat("zph2.h.compressor.power", SM_STALE_MID, 0, Watts);
+  mt_hvac_compressor_mode = MyMetrics.InitString("zph2.h.compressor.mode", SM_STALE_MID, 0, Other);
 
   // BMS configuration:
-  BmsSetCellArrangementVoltage(96, 1);
-  BmsSetCellArrangementTemperature(12, 1);
-  BmsSetCellLimitsVoltage(2.0, 5.0);
-  BmsSetCellLimitsTemperature(-39, 200);
+  BmsSetCellArrangementVoltage(96, 24);
+  BmsSetCellArrangementTemperature(12, 3);
+  BmsSetCellLimitsVoltage(2.0, 4.5);
+  BmsSetCellLimitsTemperature(-39, 60);
   BmsSetCellDefaultThresholdsVoltage(0.030, 0.050);
-  BmsSetCellDefaultThresholdsTemperature(4.0, 5.0);  
+  BmsSetCellDefaultThresholdsTemperature(4.0, 5.0);
 
-  #ifdef CONFIG_OVMS_COMP_WEBSERVER
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   WebInit();
-  #endif
+#endif
 }
 
-OvmsVehicleRenaultZoePh2OBD::~OvmsVehicleRenaultZoePh2OBD() {
+OvmsVehicleRenaultZoePh2OBD::~OvmsVehicleRenaultZoePh2OBD()
+{
   ESP_LOGI(TAG, "Stop Renault Zoe Ph2 (OBD) vehicle module");
 
-  #ifdef CONFIG_OVMS_COMP_WEBSERVER
+#ifdef CONFIG_OVMS_COMP_WEBSERVER
   WebDeInit();
-  #endif
+#endif
 }
 
-void OvmsVehicleRenaultZoePh2OBD::ConfigChanged(OvmsConfigParam* param) {
+void OvmsVehicleRenaultZoePh2OBD::ConfigChanged(OvmsConfigParam *param)
+{
   if (param && param->GetName() != "xrz2o")
     return;
- 
+
   // get values from config store
-  m_range_ideal               = MyConfig.GetParamValueInt("xrz2o", "rangeideal", 350);
-  m_battery_capacity          = MyConfig.GetParamValueInt("xrz2o", "battcapacity", 52000);
-  m_UseBMScalculation         = MyConfig.GetParamValueBool("xrz2o", "UseBMScalculation", false);
+  m_range_ideal = MyConfig.GetParamValueInt("xrz2o", "rangeideal", 350);
+  m_battery_capacity = MyConfig.GetParamValueInt("xrz2o", "battcapacity", 52000);
+  m_UseBMScalculation = MyConfig.GetParamValueBool("xrz2o", "UseBMScalculation", false);
   StandardMetrics.ms_v_bat_range_ideal->SetValue(m_range_ideal, Kilometers);
-  if (m_battery_capacity == 52000) {
-    Bat_cell_capacity = 78.0 * 2 * (StandardMetrics.ms_v_bat_soh->AsFloat() / 100.0);
-  }
-  if (m_battery_capacity == 41000) {
-    Bat_cell_capacity = 65.6 * 2 * (StandardMetrics.ms_v_bat_soh->AsFloat() / 100.0);
-  }
-  if (m_battery_capacity == 22000) {
-    Bat_cell_capacity = 36.0 * 2 * (StandardMetrics.ms_v_bat_soh->AsFloat() / 100.0);
-  }
   ESP_LOGI(TAG, "Renault Zoe Ph2 (OBD) reload configuration: Range ideal: %d, Battery capacity: %d, Use BMS as energy counter: %s", m_range_ideal, m_battery_capacity, m_UseBMScalculation ? "yes" : "no");
 }
 
-void OvmsVehicleRenaultZoePh2OBD::ZoeWakeUp() {
-  ESP_LOGI(TAG,"Zoe woke up (CAN Bus activity detected)");
-      mt_bus_awake->SetValue(true);;
-      StandardMetrics.ms_v_env_charging12v->SetValue(true);
-      POLLSTATE_ON;
-      ESP_LOGI(TAG, "Pollstate switched to ON");
+void OvmsVehicleRenaultZoePh2OBD::ZoeWakeUp()
+{
+  ESP_LOGI(TAG, "Zoe woke up (CAN Bus activity detected)");
+  mt_bus_awake->SetValue(true);
+  StandardMetrics.ms_v_env_charging12v->SetValue(true);
+  POLLSTATE_ON;
+  ESP_LOGI(TAG, "Pollstate switched to ON");
 }
 
 /**
  * Handles incoming CAN-frames on bus 1
  */
-void OvmsVehicleRenaultZoePh2OBD::IncomingFrameCan1(CAN_frame_t* p_frame) {
-	uint8_t *data = p_frame->data.u8;
-	//ESP_LOGI(TAG, "PID:%x DATA: %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
-  //ESP_LOGD(TAG, "Status CAN Bus: %s", mt_bus_awake->AsBool() ? "true" : "false");
+void OvmsVehicleRenaultZoePh2OBD::IncomingFrameCan1(CAN_frame_t *p_frame)
+{
+  uint8_t *data = p_frame->data.u8;
+  // ESP_LOGI(TAG, "PID:%x DATA: %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
+  // ESP_LOGD(TAG, "Status CAN Bus: %s", mt_bus_awake->AsBool() ? "true" : "false");
 
-  // Poll reply gives 0x83 0xc0 that means zoe is sleeping and CAN gateway does not respond to anything
-   if (mt_bus_awake->AsBool() && data[0] == 0x83 && data[1] == 0xc0) {
-      ESP_LOGI(TAG,"Zoe has gone to sleep (CAN Gateway NAK response)");
-      mt_bus_awake->SetValue(false);
-		  StandardMetrics.ms_v_env_awake->SetValue(false);
-      StandardMetrics.ms_v_env_charging12v->SetValue(false);
-      StandardMetrics.ms_v_pos_speed->SetValue( 0 );
-      StandardMetrics.ms_v_bat_12v_current->SetValue( 0 );
-      StandardMetrics.ms_v_charge_12v_current->SetValue( 0 );
-      StandardMetrics.ms_v_bat_current->SetValue( 0 );
-      POLLSTATE_OFF;
-      ESP_LOGI(TAG, "Pollstate switched to OFF");
-      //Check if car is locked, if not send notify
-      if (!StandardMetrics.ms_v_env_locked->AsBool()) {
-        MyNotify.NotifyString("alert", "vehicle.lock", "Vehicle is not locked");
-      }
-    } else if (!mt_bus_awake->AsBool()) {
-      ZoeWakeUp();
+  if (mt_bus_awake->AsBool() && data[0] == 0x83 && data[1] == 0xc0)
+  {
+    POLLSTATE_OFF;
+    ESP_LOGI(TAG, "Zoe has gone to sleep (CAN Gateway NAK response)");
+    mt_bus_awake->SetValue(false);
+    StandardMetrics.ms_v_env_awake->SetValue(false);
+    StandardMetrics.ms_v_env_charging12v->SetValue(false);
+    StandardMetrics.ms_v_pos_speed->SetValue(0);
+    StandardMetrics.ms_v_bat_12v_current->SetValue(0);
+    StandardMetrics.ms_v_charge_12v_current->SetValue(0);
+    StandardMetrics.ms_v_bat_current->SetValue(0);
+
+    ESP_LOGI(TAG, "Pollstate switched to OFF");
+    // Check if car is locked, if not send notify
+    if (!StandardMetrics.ms_v_env_locked->AsBool())
+    {
+      MyNotify.NotifyString("alert", "vehicle.lock", "Vehicle is not locked");
     }
-  //There are some free frames on wakeup and start and stop charging.... I try to use them to see if Car is awake and charging, see /Reference/ZOE_Ph2_xxx text files
-  //if (!mt_bus_awake->AsBool() && (data[0] == 0x05 || data[0] == 0x06 || data[0] == 0x07)) { //listen for SingleFrames (0x0) with length of 5-7
-  //    ZoeWakeUp();
-  //}
+  }
+  else if (!mt_bus_awake->AsBool())
+  {
+    ZoeWakeUp();
+  }
+  // The TCU is requesting battery statistics data (mainly for rentail batteries) but the software never changed if you buied the battery. The ISO-TP requests from
+  // TCU is falling through the OBD Port (seperate CAN line to Gateway), we use them to detect car start up. The TCU must be installed and working for this OVMS integration.
 }
 
 /**
  * Handles incoming poll results
  */
-void OvmsVehicleRenaultZoePh2OBD::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) {
-	string& rxbuf = zoe_obd_rxbuf;
-  
-  //ESP_LOGV(TAG, "pid: %04x length: %d m_poll_ml_remain: %d mlframe: %d", pid, length, m_poll_ml_remain, m_poll_ml_frame);
+void OvmsVehicleRenaultZoePh2OBD::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t *data, uint8_t length)
+{
+  string &rxbuf = zoe_obd_rxbuf;
+
+  // ESP_LOGV(TAG, "pid: %04x length: %d m_poll_ml_remain: %d mlframe: %d", pid, length, m_poll_ml_remain, m_poll_ml_frame);
 
   // init / fill rx buffer:
-  if (job.mlframe == 0) {
+  if (job.mlframe == 0)
+  {
     rxbuf.clear();
     rxbuf.reserve(length + job.mlremain);
   }
-  rxbuf.append((char*)data, length);
-  
+  rxbuf.append((char *)data, length);
+
   if (job.mlremain)
     return;
-  
-	switch (job.moduleid_rec) {
-		// ****** INV *****
-		case 0x18daf1df:
-			IncomingINV(job.type, job.pid, rxbuf.data(), rxbuf.size());
-			break;
-    // ****** EVC *****
-		case 0x18daf1da:
-			IncomingEVC(job.type, job.pid, rxbuf.data(), rxbuf.size());
-			break;
-    // ****** BCM *****
-    case 0x765:
-      IncomingBCM(job.type, job.pid, rxbuf.data(), rxbuf.size());
-      break;
-    // ****** LBC *****
-    case 0x18daf1db:
-      IncomingLBC(job.type, job.pid, rxbuf.data(), rxbuf.size());
-      break;
-    // ****** HVAC *****
-    case 0x764:
-      IncomingHVAC(job.type, job.pid, rxbuf.data(), rxbuf.size());
-      break;
-    // ****** UCM *****
-    case 0x76D:
-      IncomingUCM(job.type, job.pid, rxbuf.data(), rxbuf.size());
-      break;
+
+  switch (job.moduleid_rec)
+  {
+  // ****** INV *****
+  case 0x18daf1df:
+    IncomingINV(job.type, job.pid, rxbuf.data(), rxbuf.size());
+    break;
+  // ****** EVC *****
+  case 0x18daf1da:
+    IncomingEVC(job.type, job.pid, rxbuf.data(), rxbuf.size());
+    break;
+  // ****** BCM *****
+  case 0x765:
+    IncomingBCM(job.type, job.pid, rxbuf.data(), rxbuf.size());
+    break;
+  // ****** LBC *****
+  case 0x18daf1db:
+    IncomingLBC(job.type, job.pid, rxbuf.data(), rxbuf.size());
+    break;
+  // ****** HVAC *****
+  case 0x764:
+    IncomingHVAC(job.type, job.pid, rxbuf.data(), rxbuf.size());
+    break;
+  // ****** UCM *****
+  case 0x76D:
+    IncomingUCM(job.type, job.pid, rxbuf.data(), rxbuf.size());
+    break;
     // ****** CLUSTER *****
-    //case 0x763:
+    // case 0x763:
     //  IncomingCLUSTER(job.type, job.pid, rxbuf.data(), rxbuf.size());
     //  break;
-	}
+  }
 }
 
-int OvmsVehicleRenaultZoePh2OBD::calcMinutesRemaining(float charge_voltage, float charge_current) {
+int OvmsVehicleRenaultZoePh2OBD::calcMinutesRemaining(float charge_voltage, float charge_current)
+{
   float bat_soc = StandardMetrics.ms_v_bat_soc->AsFloat(100);
 
-  float remaining_wh    = m_battery_capacity - (m_battery_capacity * bat_soc / 100.0);
+  float remaining_wh = m_battery_capacity - (m_battery_capacity * bat_soc / 100.0);
   float remaining_hours = remaining_wh / (charge_current * charge_voltage);
-  float remaining_mins  = remaining_hours * 60.0;
-  //ESP_LOGD(TAG, "SOC: %f, BattCap:%d, Current: %f, Voltage: %f, RemainWH: %f, RemainHour: %f, RemainMin: %f", bat_soc, m_battery_capacity, charge_current, charge_voltage, remaining_wh, remaining_hours, remaining_mins);
-  return MIN( 1440, (int)remaining_mins );
+  float remaining_mins = remaining_hours * 60.0;
+  // ESP_LOGD(TAG, "SOC: %f, BattCap:%d, Current: %f, Voltage: %f, RemainWH: %f, RemainHour: %f, RemainMin: %f", bat_soc, m_battery_capacity, charge_current, charge_voltage, remaining_wh, remaining_hours, remaining_mins);
+  return MIN(1440, (int)remaining_mins);
 }
 
-//Handle Charging values
-void OvmsVehicleRenaultZoePh2OBD::ChargeStatistics() {
-  float charge_current  = fabs(StandardMetrics.ms_v_bat_current->AsFloat(0, Amps));
-  float charge_voltage  = StandardMetrics.ms_v_bat_voltage->AsFloat(0, Volts);
-  float battery_power   = fabs(StandardMetrics.ms_v_bat_power->AsFloat(0, kW));
-  float charger_power   = StandardMetrics.ms_v_charge_power->AsFloat(0, kW);
-  float ac_current      = StandardMetrics.ms_v_charge_current->AsFloat(0, Amps);
-  string ac_phases      = mt_main_phases->AsString();
-  
-  if (CarIsCharging != CarLastCharging) {
-        if (CarIsCharging) {
-          StandardMetrics.ms_v_charge_kwh->SetValue(0);
-          StandardMetrics.ms_v_charge_inprogress->SetValue(CarIsCharging);
-          if (m_UseBMScalculation) {
-            mt_bat_chg_start->SetValue(StandardMetrics.ms_v_charge_kwh_grid_total->AsFloat());
-          }
-        } else {
-          StandardMetrics.ms_v_charge_inprogress->SetValue(CarIsCharging);
-        }
+// Handle Charging values
+void OvmsVehicleRenaultZoePh2OBD::ChargeStatistics()
+{
+  float charge_current = fabs(StandardMetrics.ms_v_bat_current->AsFloat(0, Amps));
+  float charge_voltage = StandardMetrics.ms_v_bat_voltage->AsFloat(0, Volts);
+  float battery_power = fabs(StandardMetrics.ms_v_bat_power->AsFloat(0, kW));
+  float charger_power = StandardMetrics.ms_v_charge_power->AsFloat(0, kW);
+  float ac_current = StandardMetrics.ms_v_charge_current->AsFloat(0, Amps);
+  string ac_phases = mt_main_phases->AsString();
+
+  if (CarIsCharging != CarLastCharging)
+  {
+    if (CarIsCharging)
+    {
+      StandardMetrics.ms_v_charge_kwh->SetValue(0);
+      StandardMetrics.ms_v_charge_inprogress->SetValue(CarIsCharging);
+      if (m_UseBMScalculation)
+      {
+        mt_bat_chg_start->SetValue(StandardMetrics.ms_v_charge_kwh_grid_total->AsFloat());
       }
+    }
+    else
+    {
+      StandardMetrics.ms_v_charge_inprogress->SetValue(CarIsCharging);
+    }
+  }
   CarLastCharging = CarIsCharging;
 
-  if (!StandardMetrics.ms_v_charge_pilot->AsBool() || !StandardMetrics.ms_v_charge_inprogress->AsBool() || (charge_current <= 0.0) ) {
+  if (!StandardMetrics.ms_v_charge_pilot->AsBool() || !StandardMetrics.ms_v_charge_inprogress->AsBool() || (charge_current <= 0.0))
+  {
     return;
   }
-  
-  if (charge_voltage > 0 && charge_current > 0) {
-    float power  = charge_voltage * charge_current / 1000.0;
+
+  if (charge_voltage > 0 && charge_current > 0)
+  {
+    float power = charge_voltage * charge_current / 1000.0;
     float energy = power / 3600.0 * 10.0;
     float c_efficiency;
 
-    if (m_UseBMScalculation) {
+    if (m_UseBMScalculation)
+    {
       StandardMetrics.ms_v_charge_kwh->SetValue(StandardMetrics.ms_v_charge_kwh_grid_total->AsFloat() - mt_bat_chg_start->AsFloat());
-    } else {
-      StandardMetrics.ms_v_charge_kwh->SetValue( StandardMetrics.ms_v_charge_kwh->AsFloat() + energy);
     }
-    
+    else
+    {
+      StandardMetrics.ms_v_charge_kwh->SetValue(StandardMetrics.ms_v_charge_kwh->AsFloat() + energy);
+    }
+
     int minsremaining = calcMinutesRemaining(charge_voltage, charge_current);
     StandardMetrics.ms_v_charge_duration_full->SetValue(minsremaining, Minutes);
 
-    if (StandardMetrics.ms_v_charge_type->AsString() == "type2") {
+    if (StandardMetrics.ms_v_charge_type->AsString() == "type2")
+    {
       c_efficiency = (battery_power / charger_power) * 100.0;
-      if (c_efficiency < 100.0) {
+      if (c_efficiency < 100.0)
+      {
         StandardMetrics.ms_v_charge_efficiency->SetValue(c_efficiency);
       }
       ESP_LOGI(TAG, "Charge time remaining: %d mins, AC Charge at %.2f kW with %.1f amps, %s at %.1f efficiency, %.2f powerfactor", minsremaining, charger_power, ac_current, ac_phases.c_str(), StandardMetrics.ms_v_charge_efficiency->AsFloat(100), ACInputPowerFactor);
-    } else if (StandardMetrics.ms_v_charge_type->AsString() == "ccs" || StandardMetrics.ms_v_charge_type->AsString() == "chademo") {
+    }
+    else if (StandardMetrics.ms_v_charge_type->AsString() == "ccs" || StandardMetrics.ms_v_charge_type->AsString() == "chademo")
+    {
       StandardMetrics.ms_v_charge_power->SetValue(battery_power);
       ESP_LOGI(TAG, "Charge time remaining: %d mins, DC Charge at %.2f kW", minsremaining, battery_power);
     }
   }
 }
 
-void OvmsVehicleRenaultZoePh2OBD::EnergyStatisticsOVMS() {
-  float voltage  = StandardMetrics.ms_v_bat_voltage->AsFloat(0, Volts);
-  float current  = StandardMetrics.ms_v_bat_current->AsFloat(0, Amps);
+void OvmsVehicleRenaultZoePh2OBD::EnergyStatisticsOVMS()
+{
+  float voltage = StandardMetrics.ms_v_bat_voltage->AsFloat(0, Volts);
+  float current = StandardMetrics.ms_v_bat_current->AsFloat(0, Amps);
 
   float power = voltage * current / 1000.0;
-  
-  if (power != 0.0 && StandardMetrics.ms_v_env_on->AsBool()) {
+
+  if (power != 0.0 && StandardMetrics.ms_v_env_on->AsBool())
+  {
     float energy = power / 3600.0 * 10.0;
     if (energy > 0.0f)
-      StandardMetrics.ms_v_bat_energy_used->SetValue( StandardMetrics.ms_v_bat_energy_used->AsFloat() + energy);
+      StandardMetrics.ms_v_bat_energy_used->SetValue(StandardMetrics.ms_v_bat_energy_used->AsFloat() + energy);
     else
-      StandardMetrics.ms_v_bat_energy_recd->SetValue( StandardMetrics.ms_v_bat_energy_recd->AsFloat() - energy);
+      StandardMetrics.ms_v_bat_energy_recd->SetValue(StandardMetrics.ms_v_bat_energy_recd->AsFloat() - energy);
   }
 }
 
-void OvmsVehicleRenaultZoePh2OBD::EnergyStatisticsBMS() {
+void OvmsVehicleRenaultZoePh2OBD::EnergyStatisticsBMS()
+{
   StandardMetrics.ms_v_bat_energy_used->SetValue(StandardMetrics.ms_v_bat_energy_used_total->AsFloat() - mt_bat_used_start->AsFloat());
   StandardMetrics.ms_v_bat_energy_recd->SetValue(StandardMetrics.ms_v_bat_energy_recd_total->AsFloat() - mt_bat_recd_start->AsFloat());
 }
 
-void OvmsVehicleRenaultZoePh2OBD::Ticker10(uint32_t ticker) {
-  if (StandardMetrics.ms_v_charge_pilot->AsBool() && !StandardMetrics.ms_v_env_on->AsBool()) {
+void OvmsVehicleRenaultZoePh2OBD::Ticker10(uint32_t ticker)
+{
+  if (StandardMetrics.ms_v_charge_pilot->AsBool() && !StandardMetrics.ms_v_env_on->AsBool())
+  {
     ChargeStatistics();
-  } else {
-    if (m_UseBMScalculation) {
+  }
+  else
+  {
+    if (m_UseBMScalculation)
+    {
       EnergyStatisticsBMS();
-    } else {
+    }
+    else
+    {
       EnergyStatisticsOVMS();
+    }
+    // Update usable capacity
+    if (m_battery_capacity == 52000)
+    {
+      Bat_cell_capacity_Ah = 78.0 * 2 * (StandardMetrics.ms_v_bat_soh->AsFloat() / 100.0);
+    }
+    if (m_battery_capacity == 41000)
+    {
+      Bat_cell_capacity_Ah = 65.6 * 2 * (StandardMetrics.ms_v_bat_soh->AsFloat() / 100.0);
+    }
+    if (m_battery_capacity == 22000)
+    {
+      Bat_cell_capacity_Ah = 36.0 * 2 * (StandardMetrics.ms_v_bat_soh->AsFloat() / 100.0);
     }
   }
 }
 
-void OvmsVehicleRenaultZoePh2OBD::Ticker1(uint32_t ticker) {
-  if (StandardMetrics.ms_v_env_on->AsBool() && !CarIsDriving) {
+void OvmsVehicleRenaultZoePh2OBD::Ticker1(uint32_t ticker)
+{
+  if (StandardMetrics.ms_v_env_on->AsBool() && !CarIsDriving)
+  {
     CarIsDriving = true;
-    //Start trip after power on
+    // Start trip after power on
     StandardMetrics.ms_v_pos_trip->SetValue(0);
     mt_pos_odometer_start->SetValue(StandardMetrics.ms_v_pos_odometer->AsFloat(0));
     StandardMetrics.ms_v_bat_energy_used->SetValue(0);
     StandardMetrics.ms_v_bat_energy_recd->SetValue(0);
-    if (m_UseBMScalculation) {
+    if (m_UseBMScalculation)
+    {
       mt_bat_used_start->SetValue(StandardMetrics.ms_v_bat_energy_used_total->AsFloat());
       mt_bat_recd_start->SetValue(StandardMetrics.ms_v_bat_energy_recd_total->AsFloat());
     }
   }
-  if (CarIsDriving && !CarIsDrivingInit) {
+  if (CarIsDriving && !CarIsDrivingInit)
+  {
     CarIsDrivingInit = true;
     ESP_LOGI(TAG, "Pollstate switched to DRIVING");
     POLLSTATE_DRIVING;
   }
-  if (!StandardMetrics.ms_v_env_on->AsBool() && CarIsDriving) {
+  if (!StandardMetrics.ms_v_env_on->AsBool() && CarIsDriving)
+  {
     CarIsDriving = false;
     CarIsDrivingInit = false;
     ESP_LOGI(TAG, "Pollstate switched to ON");
     POLLSTATE_ON;
   }
-  if (StandardMetrics.ms_v_charge_pilot->AsBool() && StandardMetrics.ms_v_charge_inprogress->AsBool() && !CarIsCharging) {
+  if (StandardMetrics.ms_v_charge_pilot->AsBool() && StandardMetrics.ms_v_charge_inprogress->AsBool() && !CarIsCharging)
+  {
     CarIsCharging = true;
     ESP_LOGI(TAG, "Pollstate switched to CHARGING");
     POLLSTATE_CHARGING;
-  } else if (!StandardMetrics.ms_v_charge_pilot->AsBool() && CarIsCharging) {
+  }
+  else if (!StandardMetrics.ms_v_charge_pilot->AsBool() && CarIsCharging)
+  {
     CarIsCharging = false;
     StandardMetrics.ms_v_charge_duration_full->SetValue(0);
     ESP_LOGI(TAG, "Pollstate switched to ON");
     POLLSTATE_ON;
-  } else if (StandardMetrics.ms_v_charge_pilot->AsBool() && CarIsCharging && StandardMetrics.ms_v_charge_substate->AsString() == "powerwait") {
+  }
+  else if (StandardMetrics.ms_v_charge_pilot->AsBool() && CarIsCharging && StandardMetrics.ms_v_charge_substate->AsString() == "powerwait")
+  {
     CarIsCharging = false;
     StandardMetrics.ms_v_charge_duration_full->SetValue(0);
     ESP_LOGI(TAG, "Pollstate switched to OFF, Wait for power...");
     POLLSTATE_OFF;
-  } else if (StandardMetrics.ms_v_charge_pilot->AsBool() && CarIsCharging && StandardMetrics.ms_v_charge_state->AsString() == "done") {
+    mt_bus_awake->SetValue(false);
+    StandardMetrics.ms_v_env_awake->SetValue(false);
+    StandardMetrics.ms_v_env_charging12v->SetValue(false);
+    StandardMetrics.ms_v_bat_12v_current->SetValue(0);
+    StandardMetrics.ms_v_charge_12v_current->SetValue(0);
+    StandardMetrics.ms_v_bat_current->SetValue(0);
+  }
+  else if (StandardMetrics.ms_v_charge_pilot->AsBool() && CarIsCharging && StandardMetrics.ms_v_charge_state->AsString() == "done")
+  {
     CarIsCharging = false;
     StandardMetrics.ms_v_charge_duration_full->SetValue(0);
     ESP_LOGI(TAG, "Pollstate switched to OFF, done charging...");
     POLLSTATE_OFF;
+    mt_bus_awake->SetValue(false);
+    StandardMetrics.ms_v_env_awake->SetValue(false);
+    StandardMetrics.ms_v_env_charging12v->SetValue(false);
+    StandardMetrics.ms_v_bat_12v_current->SetValue(0);
+    StandardMetrics.ms_v_charge_12v_current->SetValue(0);
+    StandardMetrics.ms_v_bat_current->SetValue(0);
   }
 
-  if (StandardMetrics.ms_v_env_on->AsBool()) {
+  if (StandardMetrics.ms_v_env_on->AsBool())
+  {
     StandardMetrics.ms_v_pos_trip->SetValue(StandardMetrics.ms_v_pos_odometer->AsFloat(0) - mt_pos_odometer_start->AsFloat(0));
   }
   StandardMetrics.ms_v_bat_range_est->SetValue((m_range_ideal * (StandardMetrics.ms_v_bat_soc->AsFloat(1) * 0.01)), Kilometers);
 
+  StandardMetrics.ms_v_charge_12v_power->SetValue(StandardMetrics.ms_v_bat_12v_voltage->AsFloat(0) * StandardMetrics.ms_v_bat_12v_current->AsFloat(0));
 }
 
-class OvmsVehicleRenaultZoePh2OBDInit {
-  public: OvmsVehicleRenaultZoePh2OBDInit();
-} MyOvmsVehicleRenaultZoePh2OBDInit  __attribute__ ((init_priority (9000)));
+class OvmsVehicleRenaultZoePh2OBDInit
+{
+public:
+  OvmsVehicleRenaultZoePh2OBDInit();
+} MyOvmsVehicleRenaultZoePh2OBDInit __attribute__((init_priority(9000)));
 
-
-OvmsVehicleRenaultZoePh2OBDInit::OvmsVehicleRenaultZoePh2OBDInit() 
+OvmsVehicleRenaultZoePh2OBDInit::OvmsVehicleRenaultZoePh2OBDInit()
 {
   ESP_LOGI(TAG, "Registering Vehicle: Renault Zoe Ph2 (OBD) (9000)");
-  MyVehicleFactory.RegisterVehicle<OvmsVehicleRenaultZoePh2OBD>("RZ2","Renault Zoe Ph2 (OBD)");
+  MyVehicleFactory.RegisterVehicle<OvmsVehicleRenaultZoePh2OBD>("RZ2", "Renault Zoe Ph2 (OBD)");
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.h
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2_obd/src/vehicle_renaultzoe_ph2_obd.h
@@ -41,98 +41,98 @@
 #endif
 
 // CAN buffer access macros: b=byte# 0..7 / n=nibble# 0..15
-#define CAN_BYTE(b)     data[b]
-#define CAN_UINT(b)     (((UINT)CAN_BYTE(b) << 8) | CAN_BYTE(b+1))
-#define CAN_UINT24(b)   (((uint32_t)CAN_BYTE(b) << 16) | ((UINT)CAN_BYTE(b+1) << 8) | CAN_BYTE(b+2))
-#define CAN_UINT32(b)   (((uint32_t)CAN_BYTE(b) << 24) | ((uint32_t)CAN_BYTE(b+1) << 16)  | ((UINT)CAN_BYTE(b+2) << 8) | CAN_BYTE(b+3))
-#define CAN_NIBL(b)     (data[b] & 0x0f)
-#define CAN_NIBH(b)     (data[b] >> 4)
-#define CAN_NIB(n)      (((n)&1) ? CAN_NIBL((n)>>1) : CAN_NIBH((n)>>1))
+#define CAN_BYTE(b) data[b]
+#define CAN_UINT(b) (((UINT)CAN_BYTE(b) << 8) | CAN_BYTE(b + 1))
+#define CAN_UINT24(b) (((uint32_t)CAN_BYTE(b) << 16) | ((UINT)CAN_BYTE(b + 1) << 8) | CAN_BYTE(b + 2))
+#define CAN_UINT32(b) (((uint32_t)CAN_BYTE(b) << 24) | ((uint32_t)CAN_BYTE(b + 1) << 16) | ((UINT)CAN_BYTE(b + 2) << 8) | CAN_BYTE(b + 3))
+#define CAN_NIBL(b) (data[b] & 0x0f)
+#define CAN_NIBH(b) (data[b] >> 4)
+#define CAN_NIB(n) (((n) & 1) ? CAN_NIBL((n) >> 1) : CAN_NIBH((n) >> 1))
 
-#define POLLSTATE_OFF					PollSetState(0);
-#define POLLSTATE_ON					PollSetState(1);
-#define POLLSTATE_DRIVING			PollSetState(2);
-#define POLLSTATE_CHARGING		PollSetState(3);
+#define POLLSTATE_OFF PollSetState(0);
+#define POLLSTATE_ON PollSetState(1);
+#define POLLSTATE_DRIVING PollSetState(2);
+#define POLLSTATE_CHARGING PollSetState(3);
 
 using namespace std;
 
 #define TAG (OvmsVehicleRenaultZoePh2OBD::s_tag)
 
-class OvmsVehicleRenaultZoePh2OBD : public OvmsVehicle {
-  public:
-    static const char *s_tag;
+class OvmsVehicleRenaultZoePh2OBD : public OvmsVehicle
+{
+public:
+  static const char *s_tag;
 
-  public:
-    OvmsVehicleRenaultZoePh2OBD();
-    ~OvmsVehicleRenaultZoePh2OBD();
+public:
+  OvmsVehicleRenaultZoePh2OBD();
+  ~OvmsVehicleRenaultZoePh2OBD();
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
-    static void WebCfgCommon(PageEntry_t& p, PageContext_t& c);
+  static void WebCfgCommon(PageEntry_t &p, PageContext_t &c);
 #endif
-    void ConfigChanged(OvmsConfigParam* param) override;
-    void ZoeWakeUp();
-    void IncomingFrameCan1(CAN_frame_t* p_frame) override;
-    void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
+  void ConfigChanged(OvmsConfigParam *param) override;
+  void ZoeWakeUp();
+  void IncomingFrameCan1(CAN_frame_t *p_frame) override;
+  void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t *data, uint8_t length) override;
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
-    void WebInit();
-    void WebDeInit();
+  void WebInit();
+  void WebDeInit();
 #endif
-    bool CarIsCharging = false;
-    bool CarPluggedIn = false;
-    bool CarLastCharging = false;
-    bool CarIsDriving = false;
-    bool CarIsDrivingInit = false;
-    float ACInputPowerFactor = 0.0;
-    float Bat_cell_capacity = 0.0;
+  bool CarIsCharging = false;
+  bool CarPluggedIn = false;
+  bool CarLastCharging = false;
+  bool CarIsDriving = false;
+  bool CarIsDrivingInit = false;
+  float ACInputPowerFactor = 0.0;
+  float Bat_cell_capacity_Ah = 0.0;
 
-	protected:
-    int m_range_ideal;
-    int m_battery_capacity;
-    bool m_UseCarTrip = false;
-    bool m_UseBMScalculation = false;
-    char zoe_vin[18] = "";
-		void IncomingINV(uint16_t type, uint16_t pid, const char* data, uint16_t len);
-		void IncomingEVC(uint16_t type, uint16_t pid, const char* data, uint16_t len);
-		void IncomingBCM(uint16_t type, uint16_t pid, const char* data, uint16_t len);
-		void IncomingLBC(uint16_t type, uint16_t pid, const char* data, uint16_t len);
-    void IncomingHVAC(uint16_t type, uint16_t pid, const char* data, uint16_t len);
-    void IncomingUCM(uint16_t type, uint16_t pid, const char* data, uint16_t len);
-    //void IncomingCLUSTER(uint16_t type, uint16_t pid, const char* data, uint16_t len);
-    int calcMinutesRemaining(float charge_voltage, float charge_current);
-    void ChargeStatistics();
-    void EnergyStatisticsOVMS();
-    void EnergyStatisticsBMS();
-    void Ticker10(uint32_t ticker) override;//Handle charge, energy statistics
-    void Ticker1(uint32_t ticker) override; //Handle trip counter
-    
-    		
-    // Renault ZOE specific metrics
-    OvmsMetricBool   *mt_bus_awake;               //CAN bus awake status
-    OvmsMetricFloat  *mt_pos_odometer_start;      //ODOmeter at trip start
-    OvmsMetricFloat  *mt_bat_used_start;          //Used battery kWh at trip start
-    OvmsMetricFloat  *mt_bat_recd_start;          //Recd battery kWh at trip start
-    OvmsMetricFloat  *mt_bat_chg_start;           //Charge battery kWh at charge start
-    OvmsMetricFloat  *mt_bat_available_energy;    //Available energy in battery
-    OvmsMetricFloat  *mt_bat_aux_power_consumer;  //Power usage by consumer
-    OvmsMetricFloat  *mt_bat_aux_power_ptc;       //Power usage by PTCs
-    OvmsMetricFloat  *mt_bat_max_charge_power;    //Battery max allowed charge, recd power
-    OvmsMetricFloat  *mt_bat_cycles;              //Battery full charge cycles
-    OvmsMetricFloat  *mt_main_power_available;    //Mains power available
-    OvmsMetricString *mt_main_phases;             //Mains phases used
-    OvmsMetricFloat  *mt_main_phases_num;         //Mains phases used
-    OvmsMetricString *mt_inv_status;              //Inverter status string
-    OvmsMetricFloat  *mt_inv_hv_voltage;          //Inverter battery voltage sense, used for motor power calc
-    OvmsMetricFloat  *mt_inv_hv_current;          //Inverter battery current sense, used for motor power calc
-    OvmsMetricFloat  *mt_mot_temp_stator1;        //Temp of motor stator 1
-    OvmsMetricFloat  *mt_mot_temp_stator2;        //Temp of motor stator 2
-    OvmsMetricFloat  *mt_hvac_compressor_speed;   //Compressor speed
-    OvmsMetricFloat  *mt_hvac_compressor_pressure;//Compressor high-side pressure in BAR
-    OvmsMetricFloat  *mt_hvac_compressor_power;   //Compressor power usage
-    OvmsMetricString *mt_hvac_compressor_mode;    //Compressor mode
-    OvmsMetricFloat  *mt_v_env_pressure;          //Ambient air pressure
-    
-        
-  protected:
-    string zoe_obd_rxbuf;
+protected:
+  string zoe_obd_rxbuf;
+  int m_range_ideal;
+  int m_battery_capacity;
+  bool m_UseCarTrip = false;
+  bool m_UseBMScalculation = false;
+  char zoe_vin[18] = "";
+  void IncomingINV(uint16_t type, uint16_t pid, const char *data, uint16_t len);
+  void IncomingEVC(uint16_t type, uint16_t pid, const char *data, uint16_t len);
+  void IncomingBCM(uint16_t type, uint16_t pid, const char *data, uint16_t len);
+  void IncomingLBC(uint16_t type, uint16_t pid, const char *data, uint16_t len);
+  void IncomingHVAC(uint16_t type, uint16_t pid, const char *data, uint16_t len);
+  void IncomingUCM(uint16_t type, uint16_t pid, const char *data, uint16_t len);
+  // void IncomingCLUSTER(uint16_t type, uint16_t pid, const char* data, uint16_t len);
+  int calcMinutesRemaining(float charge_voltage, float charge_current);
+  void ChargeStatistics();
+  void EnergyStatisticsOVMS();
+  void EnergyStatisticsBMS();
+  void Ticker10(uint32_t ticker) override; // Handle charge, energy statistics
+  void Ticker1(uint32_t ticker) override;  // Handle trip counter
+
+  // Renault ZOE specific metrics
+  OvmsMetricBool *mt_bus_awake;                 // CAN bus awake status
+  OvmsMetricFloat *mt_pos_odometer_start;       // ODOmeter at trip start
+  OvmsMetricFloat *mt_bat_used_start;           // Used battery kWh at trip start
+  OvmsMetricFloat *mt_bat_recd_start;           // Recd battery kWh at trip start
+  OvmsMetricFloat *mt_bat_chg_start;            // Charge battery kWh at charge start
+  OvmsMetricFloat *mt_bat_available_energy;     // Available energy in battery
+  OvmsMetricFloat *mt_bat_max_charge_power;     // Battery max allowed charge, recd power
+  OvmsMetricFloat *mt_bat_cycles;               // Battery full charge cycles
+  OvmsMetricFloat *mt_main_power_available;     // Mains power available
+  OvmsMetricString *mt_main_phases;             // Mains phases used
+  OvmsMetricFloat *mt_main_phases_num;          // Mains phases used
+  OvmsMetricString *mt_inv_status;              // Inverter status string
+  OvmsMetricFloat *mt_inv_hv_voltage;           // Inverter battery voltage sense, used for motor power calc
+  OvmsMetricFloat *mt_inv_hv_current;           // Inverter battery current sense, used for motor power calc
+  OvmsMetricFloat *mt_mot_temp_stator1;         // Temp of motor stator 1
+  OvmsMetricFloat *mt_mot_temp_stator2;         // Temp of motor stator 2
+  OvmsMetricFloat *mt_hvac_compressor_speed;    // Compressor speed
+  OvmsMetricFloat *mt_hvac_compressor_pressure; // Compressor high-side pressure in BAR
+  OvmsMetricFloat *mt_hvac_compressor_power;    // Compressor power usage
+  OvmsMetricString *mt_hvac_compressor_mode;    // Compressor mode
+  OvmsMetricFloat *mt_v_env_pressure;           // Ambient air pressure
+
+public:
+  // Renault ZOE commands
+  vehicle_command_t CommandClimateControl(bool enable);
+  vehicle_command_t CommandHomelink(int button, int durationms = 1000);
 };
 
-#endif //#ifndef __VEHICLE_RENAULTZOE_PH2_OBD_H__
+#endif // #ifndef __VEHICLE_RENAULTZOE_PH2_OBD_H__


### PR DESCRIPTION
code:
- reformat code for better readability
- remove tabstop and replace it with whitespace

fix:
- correct 12v current and bus state after charge stopped while plugged in
- SoH / CaC handling while runtime instead of one-shot after config
- cell voltage readings (factor was wrong, voltage was too high)

update:
- update readme for TCU removal information, V-CAN tapping and feature list
- significantly improve "bms status" output reading
- code comments

removal:
- remove unneccessary aux power gauges

add:
- added battery health text
- added usable battery capacity (kWh) depends on SoC, SoH
- added 12V charger power value
- added CAN2 interface for V-CAN connection
- added commands for ClimateControl and HomeLink button 1 (because App not showing AC button)
- added pre-heat capability through CAN2