### PR TITLE
Add the option to avoid powering off Can busses on powerdown

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/can.cpp
+++ b/vehicle/OVMS.V3/components/can/src/can.cpp
@@ -129,7 +129,7 @@ void can_start(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, co
     writer->puts("Error: invalid can bus number");
     return;
     }
-  res = MyPollers.RegisterCanBus(busno, smode, cspeed, dbcfile, false, sbus, verbosity, writer);
+  res = MyPollers.RegisterCanBus(busno, smode, cspeed, dbcfile, OvmsPollers::BusPoweroff::System, sbus, verbosity, writer);
 #else
   canbus* sbus = (canbus*)MyPcpApp.FindDeviceByName(bus);
   if (sbus == NULL)

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -697,10 +697,12 @@ class OvmsPoller : public InternalRamAllocated {
 
 #define VEHICLE_MAXBUSSES 4
 class OvmsPollers : public InternalRamAllocated {
+  public:
+    enum class BusPoweroff {None, System, Vehicle};
   private:
     typedef  struct {
       canbus* can;
-      bool from_vehicle;
+      BusPoweroff auto_poweroff;
     } bus_info_t;
     bus_info_t        m_canbusses[VEHICLE_MAXBUSSES];
     OvmsRecMutex      m_poller_mutex;
@@ -974,9 +976,9 @@ class OvmsPollers : public InternalRamAllocated {
       }
     uint8_t GetBusNo(canbus* bus);
     canbus* GetBus(uint8_t busno);
-    canbus* RegisterCanBus(int busno, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile, bool from_vehicle);
+    canbus* RegisterCanBus(int busno, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile, BusPoweroff autoPower);
 
-    esp_err_t RegisterCanBus(int busno, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile, bool from_vehicle, canbus*& bus,int verbosity, OvmsWriter* writer );
+    esp_err_t RegisterCanBus(int busno, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile, BusPoweroff autoPower, canbus*& bus,int verbosity, OvmsWriter* writer );
 
     void PowerDownCanBus(int busno);
     bool HasPollTask()

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -455,6 +455,8 @@ OvmsVehicle::OvmsVehicle()
   xTaskCreatePinnedToCore(OvmsVehicleTask, "OVMS Vehicle Poll",
       CONFIG_OVMS_VEHICLE_RXTASK_STACK, (void*)this, 10, &m_vtask, CORE(1));
   MyCan.RegisterListener(m_vqueue);
+  for (int idx = 0; idx < VEHICLE_MAXBUSSES; ++idx)
+    m_autopoweroff[idx] = false;
 #endif
   }
 
@@ -552,10 +554,13 @@ void OvmsVehicle::ShuttingDown()
   entry.MsgID = 0;
   xQueueSendToFront(m_vqueue, &entry, 0);
 
-  if (m_can1) m_can1->SetPowerMode(Off);
-  if (m_can2) m_can2->SetPowerMode(Off);
-  if (m_can3) m_can3->SetPowerMode(Off);
-  if (m_can4) m_can4->SetPowerMode(Off);
+  if (MyConfig.GetParamValueBool("vehicle", "can.autooff", true))
+    {
+    if (m_can1 && m_autopoweroff[0]) m_can1->SetPowerMode(Off);
+    if (m_can2 && m_autopoweroff[1]) m_can2->SetPowerMode(Off);
+    if (m_can3 && m_autopoweroff[2]) m_can3->SetPowerMode(Off);
+    if (m_can4 && m_autopoweroff[3]) m_can4->SetPowerMode(Off);
+    }
 
 #endif
   MyEvents.DeregisterEvent(TAG);
@@ -661,17 +666,20 @@ void OvmsVehicle::Status(int verbosity, OvmsWriter* writer)
   writer->printf("Vehicle module '%s' (code %s) loaded and running\n", VehicleShortName(), VehicleType());
   }
 
-void OvmsVehicle::RegisterCanBus(int bus, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile)
+void OvmsVehicle::RegisterCanBus(int bus, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile, bool autoPoweroff)
   {
   canbus *can;
 #ifdef CONFIG_OVMS_COMP_POLLER
-  can = MyPollers.RegisterCanBus(bus, mode, speed, dbcfile, true);
+  OvmsPollers::BusPoweroff unload = autoPoweroff ? OvmsPollers::BusPoweroff::Vehicle : OvmsPollers::BusPoweroff::None;
+  can = MyPollers.RegisterCanBus(bus, mode, speed, dbcfile, unload);
 #else
   {
     std::string busname = string_format("can%d", bus);
     can = (canbus*)MyPcpApp.FindDeviceByName(busname.c_str());
     can->SetPowerMode(On);
     can->Start(mode,speed,dbcfile);
+    if (bus <= VEHICLE_MAXBUSSES)
+      m_autopoweroff[bus-1] = autoPoweroff;
   }
 #endif
   switch (bus)

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -465,7 +465,7 @@ class OvmsVehicle : public InternalRamAllocated
     virtual void Status(int verbosity, OvmsWriter* writer);
 
   protected:
-    void RegisterCanBus(int bus, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile = NULL);
+    void RegisterCanBus(int bus, CAN_mode_t mode, CAN_speed_t speed, dbcfile* dbcfile = NULL, bool autoPoweroff = true);
     bool PinCheck(const char* pin);
 
   public:
@@ -576,6 +576,8 @@ class OvmsVehicle : public InternalRamAllocated
     void VehicleTask();
     QueueHandle_t m_vqueue;
     TaskHandle_t  m_vtask;
+
+    bool m_autopoweroff[VEHICLE_MAXBUSSES];
 #endif
     void SendIncomingFrame(const CAN_frame_t *frame);
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -194,8 +194,9 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   m_AZE0_charger = false;
   m_climate_really_off = false;
 
-  RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
-  RegisterCanBus(2,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS);
+  // register but don't auto-power-off the busses.
+  RegisterCanBus(1,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS, nullptr, false);
+  RegisterCanBus(2,CAN_MODE_ACTIVE,CAN_SPEED_500KBPS, nullptr, false);
   PollSetState(POLLSTATE_OFF);
   PollSetResponseSeparationTime(0);
   PollSetPidList(m_can1,obdii_polls);


### PR DESCRIPTION
Includes option to suppress power-down of Can busses for the Leave vehicle module