### PR TITLE
Simcom 7670 support and updated Simcom powering

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/gsmmux.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/gsmmux.cpp
@@ -155,7 +155,8 @@ void GsmMuxChannel::ProcessFrame(uint8_t* frame, size_t length, size_t iframepos
 	[[fallthrough]];
 #endif
     case ChanOpen:
-      if (frame[1] == (GSM_UIH + GSM_PF))
+      // GSM_UIH alone set for CGNSSINFO response
+      if (frame[1] == (GSM_UIH + GSM_PF) || frame[1] == GSM_UIH )  
         {
         for (size_t k=iframepos;k<length;k++)
           m_buffer.Push(frame[k]);

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/gsmnmea.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/gsmnmea.cpp
@@ -121,11 +121,11 @@ void GsmNMEA::IncomingLine(const std::string line)
   std::istringstream sentence(line);
   std::string token;
 
-  if (line.find("+CGNSSINFO:",0) == 0)   // CGNSSINFO record
+  if ( line.find("+CGNSSINFO:",0) == 0 )   // CGNSSINFO record
     {
     // check for +CGNSSINFO output record
-    // no fix yet: +CGNSSINFO ,,,,,,,,
-    // GPS fix:    +CGNSSINFO 3,15,,01,01,52.3973694,N,7.1607476,E,040125,091435.00,121.7,2.072,161.56,4.11,2.21,3.46,05
+    // no fix yet: +CGNSSINFO: ,,,,,,,,
+    // GPS fix:    +CGNSSINFO: 3,15,,01,01,52.3973694,N,7.1607476,E,040125,091435.00,121.7,2.072,161.56,4.11,2.21,3.46,05
     // Info
     // 3,         : 3|2  3D fix|2D fix
     // 15,,01,01  : number of used sats of 4 GPS sytems (documentation of 76XX states only 3 fields!)
@@ -255,7 +255,7 @@ void GsmNMEA::IncomingLine(const std::string line)
     if (speedok)
       *StdMetrics.ms_v_pos_gpsspeed = speed;
 
-    ESP_LOGV(TAG, "CGNSSINFO: %s %s nsats %d lat %f lon %f ", date, timestr, satcnt, lat, lon);
+    ESP_LOGV(TAG, "CGNSSINFO: %s %s nsats %d lat %f lon %f hdop %f vdop %f pdop %f", date, timestr, satcnt, lat, lon, hdop, vdop, pdop);
     
     } // END "+CGNSSINFO" handler
   

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/gsmnmea.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/gsmnmea.cpp
@@ -120,9 +120,8 @@ void GsmNMEA::IncomingLine(const std::string line)
   {
   std::istringstream sentence(line);
   std::string token;
-  std::string header;
 
-  if (std::getline(sentence, header, ' ') && header == "+CGNSSINFO:" )   // CGNSSINFO record
+  if (line.find("+CGNSSINFO:",0) == 0)   // CGNSSINFO record
     {
     // check for +CGNSSINFO output record
     // no fix yet: +CGNSSINFO ,,,,,,,,
@@ -144,6 +143,7 @@ void GsmNMEA::IncomingLine(const std::string line)
     // 3.46,      : VDOP 
     // 05 : not mentioned in the documentation. Checksum?
     ESP_LOGV(TAG, "Incoming location data: %s", line.c_str());
+    if (!std::getline(sentence, token, ' ')) return;  // skip the CGNSSINFO header
     if (!std::getline(sentence, token, ',')) return;
     float lat=0, lon=0, alt=0, hdop=0, vdop=0, pdop=0;
     char  ns='N', ew='E';

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -600,13 +600,15 @@ void modem::State1Enter(modem_state1_t newstate)
   ESP_LOGI(TAG, "State: Enter %s state",ModemState1Name(newstate));
 
   // See if the driver want's to override our default behaviour
-  if (m_driver->State1Enter(newstate)) return;
+  if (m_driver->State1Enter(newstate)) {
+    m_powermode = newstate == PoweredOn ? On : Off;
+    return;
+  }
 
   switch (m_state1)
     {
     case CheckPowerOff:
       ClearNetMetrics();
-      PowerOff();
       m_state1_timeout_ticks = 15;
       m_state1_timeout_goto = PoweredOff;
       break;
@@ -632,6 +634,7 @@ void modem::State1Enter(modem_state1_t newstate)
     case PoweredOn:
       ClearNetMetrics();
       MyEvents.SignalEvent("system.modem.poweredon", NULL);
+      m_powermode = On;
       m_state1_timeout_ticks = 30;
       m_state1_timeout_goto = PoweringOn;
       break;
@@ -689,8 +692,8 @@ void modem::State1Enter(modem_state1_t newstate)
       ClearNetMetrics();
       StopPPP();
       StopNMEA();
+      PowerOff();
       MyEvents.SignalEvent("system.modem.stop",NULL);
-      PowerCycle();
       m_state1_timeout_ticks = 20;
       m_state1_timeout_goto = CheckPowerOff;
       break;
@@ -705,6 +708,7 @@ void modem::State1Enter(modem_state1_t newstate)
         m_driver = NULL;
         m_model.clear();
         }
+      m_powermode = Off;
       break;
 
     case PowerOffOn:
@@ -837,15 +841,17 @@ modem::modem_state1_t modem::State1Ticker1()
   switch (m_state1)
     {
     case None:
-      return CheckPowerOff;
+      PowerCycle();
+      return PoweringOff;
       break;
 
     case CheckPowerOff:
-      if (m_state1_ticker > 10) tx("AT\r\n");
+      m_buffer.EmptyAll(); // Drain it
+      if (m_state1_ticker%3 == 0) tx("AT\r\n");
       break;
 
     case PoweringOn:
-      tx("AT\r\n");
+      if (m_state1_ticker%3 == 0) tx("AT\r\n");
       break;
 
     case Identify:
@@ -1029,7 +1035,7 @@ void modem::StandardLineHandler(int channel, OvmsBuffer* buf, std::string line)
     line = m_line_buffer;
     }
 
-  if (line.compare(0, 2, "$G") == 0)
+  if (line.compare(0, 2, "$G") == 0 || line.compare(0, 12, "+CGNSSINFO: ") == 0 )
     {
     // GPS NMEA URC:
     if (m_nmea) m_nmea->IncomingLine(line);

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
@@ -266,7 +266,8 @@ class modemdriver : public InternalRamAllocated
     virtual modem::modem_state1_t State1Ticker1(modem::modem_state1_t curstate);
 
   protected:
-    unsigned int m_powercyclefactor;
+    unsigned int m_pwridx;
+    time_t m_t_pwrcycle;
     modem* m_modem;
     int m_statuspoller_step;
   };

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular_modem_driver.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular_modem_driver.cpp
@@ -34,8 +34,8 @@ static const char *TAG = "cellular-modem-auto";
 #include <string.h>
 
 #include "ovms_cellular.h"
-#include "ovms_peripherals.h"
 #include "ovms_config.h"
+#include "simcom_powering.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // The virtual modem driver.
@@ -60,7 +60,8 @@ autoInit::autoInit()
 modemdriver::modemdriver()
   {
   m_modem = MyPeripherals->m_cellular_modem;
-  m_powercyclefactor = 0;
+  m_pwridx = 0;
+  m_t_pwrcycle = 0;
   m_statuspoller_step = 0;
   }
 
@@ -89,36 +90,41 @@ void modemdriver::Restart()
 
 void modemdriver::PowerOff()
   {
+  int T_off = TimePwrOff;
+  ESP_LOGI(TAG, "Power Off - timing: %d ms",T_off);
   PowerSleep(false);
-#ifdef CONFIG_OVMS_COMP_MAX7317
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-#endif // #ifdef CONFIG_OVMS_COMP_MAX7317
+  uart_wait_tx_done(m_modem->m_uartnum, portMAX_DELAY);
+  uart_flush(m_modem->m_uartnum); // Flush the ring buffer, to try to address MUX start issues
+
+  SimcomPowerOff(T_off);
   }
 
 void modemdriver::PowerCycle()
   {
-  unsigned int psd = 2000 * (++m_powercyclefactor);
-  m_powercyclefactor = m_powercyclefactor % 3;
-  ESP_LOGI(TAG, "Power Cycle %dms", psd);
+  // Check time since last Powercycle 
+  // State timeout usually occurs after 30s -> Powercycle triggered
+  // Frequent PowerCycles -> try different timing
+  int dt = (m_t_pwrcycle == 0) ? 0 : (time(NULL) - m_t_pwrcycle);
+  if (dt > 10 && dt < 60  ) m_pwridx = (m_pwridx+1) % (NPwrTime+1);  // toggle between different time settings
+  m_t_pwrcycle = time(NULL);
 
+  ESP_LOGI(TAG, "Power Cycle");
   uart_wait_tx_done(m_modem->m_uartnum, portMAX_DELAY);
-  uart_flush(m_modem->m_uartnum); // Flush the ring buffer, to try to address MUX start issues
-#ifdef CONFIG_OVMS_COMP_MAX7317
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 1); // Modem EN/PWR line high
-  vTaskDelay(psd / portTICK_PERIOD_MS);
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-#endif // #ifdef CONFIG_OVMS_COMP_MAX7317
+  uart_flush(m_modem->m_uartnum);       // Flush the ring buffer, to try to address MUX start issues
+
+  SimcomPowerCycle(m_pwridx);
   }
 
 void modemdriver::PowerSleep(bool onoff)
   {
-  #ifdef CONFIG_OVMS_COMP_MAX7317
     if (onoff)
-      MyPeripherals->m_max7317->Output(MODEM_EGPIO_DTR, 1);
+    {
+      setDTRLevel(1);
+    }
     else
-      MyPeripherals->m_max7317->Output(MODEM_EGPIO_DTR, 0);
-  #endif // #ifdef CONFIG_OVMS_COMP_MAX7317
+    {
+      setDTRLevel(0);
+    }
   }
 
 int modemdriver::GetMuxChannels()    { return 4; }

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular_modem_driver.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular_modem_driver.cpp
@@ -105,7 +105,7 @@ void modemdriver::PowerCycle()
   // State timeout usually occurs after 30s -> Powercycle triggered
   // Frequent PowerCycles -> try different timing
   int dt = (m_t_pwrcycle == 0) ? 0 : (time(NULL) - m_t_pwrcycle);
-  if (dt > 10 && dt < 60  ) m_pwridx = (m_pwridx+1) % (NPwrTime+1);  // toggle between different time settings
+  if (dt > 10 && dt < 60  ) m_pwridx = (m_pwridx+1) % NPwrTime;  // toggle between different time settings
   m_t_pwrcycle = time(NULL);
 
   ESP_LOGI(TAG, "Power Cycle");

--- a/vehicle/OVMS.V3/components/simcom/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/simcom/CMakeLists.txt
@@ -2,7 +2,7 @@ set(srcs)
 set(include_dirs)
 
 if (CONFIG_OVMS_COMP_CELLULAR_SIMCOM)
-  list(APPEND srcs "src/simcom_5360.cpp" "src/simcom_7000.cpp" "src/simcom_7600.cpp")
+  list(APPEND srcs "src/simcom_5360.cpp" "src/simcom_7000.cpp" "src/simcom_7600.cpp" "src/simcom_7670.cpp" "simcom_powering.cpp")
   list(APPEND include_dirs "src")
 endif ()
 

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7000.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7000.cpp
@@ -32,7 +32,7 @@
 static const char *TAG = "SIM7000";
 
 #include <string.h>
-#include "ovms_peripherals.h"
+#include "simcom_powering.h"
 #include "simcom_7000.h"
 
 const char model[] = "SIM7000";
@@ -67,20 +67,13 @@ const char* simcom7000::GetName()
   return name;
   }
 
+
 void simcom7000::PowerCycle()
   {
-  unsigned int psd = 2000 * (++m_powercyclefactor);
-  m_powercyclefactor = m_powercyclefactor % 3;
-  ESP_LOGI(TAG, "Power Cycle (SIM7000) %dms",psd);
-
+  ESP_LOGV(TAG, "Power Cycle");
   uart_wait_tx_done(m_modem->m_uartnum, portMAX_DELAY);
-  uart_flush(m_modem->m_uartnum); // Flush the ring buffer, to try to address MUX start issues
-#ifdef CONFIG_OVMS_COMP_MAX7317
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 1); // Modem EN/PWR line high
-  vTaskDelay(psd / portTICK_PERIOD_MS);
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-#endif // #ifdef CONFIG_OVMS_COMP_MAX7317
+  uart_flush(m_modem->m_uartnum);       // Flush the ring buffer, to try to address MUX start issues
+  SimcomPowerCycle(-1,1050, 1250);
   }
 
 bool simcom7000::State1Leave(modem::modem_state1_t oldstate)

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7600.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7600.cpp
@@ -32,7 +32,7 @@
 static const char *TAG = "SIM7600";
 
 #include <string.h>
-#include "ovms_peripherals.h"
+#include "simcom_powering.h"
 #include "simcom_7600.h"
 
 const char model[] = "SIM7600";
@@ -143,35 +143,22 @@ void simcom7600::StatusPoller()
     }
   }
 
+
 void simcom7600::PowerOff()
   {
-  unsigned int psd = 3000;    // min 2500ms
-  ESP_LOGI(TAG, "Power Off (SIM7600) %dms",psd);
-
+  ESP_LOGV(TAG, "Power Off");
   modemdriver::PowerSleep(false);
   uart_wait_tx_done(m_modem->m_uartnum, portMAX_DELAY);
   uart_flush(m_modem->m_uartnum); // Flush the ring buffer, to try to address MUX start issues
-#ifdef CONFIG_OVMS_COMP_MAX7317
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 1); // Modem EN/PWR line high
-  vTaskDelay(psd / portTICK_PERIOD_MS);
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-#endif // #ifdef CONFIG_OVMS_COMP_MAX7317
+  SimcomPowerOff(3000);
   }
 
 void simcom7600::PowerCycle()
   {
-  unsigned int psd = 500;     // min 100ms  typical 500ms
-  ESP_LOGI(TAG, "Power Cycle (SIM7600) %dms, wait 10s for uart",psd);
-
+  ESP_LOGV(TAG, "Power Cycle");
   uart_wait_tx_done(m_modem->m_uartnum, portMAX_DELAY);
-  uart_flush(m_modem->m_uartnum); // Flush the ring buffer, to try to address MUX start issues
-#ifdef CONFIG_OVMS_COMP_MAX7317
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 1); // Modem EN/PWR line high
-  vTaskDelay(psd / portTICK_PERIOD_MS);
-  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, 0); // Modem EN/PWR line low
-#endif // #ifdef CONFIG_OVMS_COMP_MAX7317
+  uart_flush(m_modem->m_uartnum);       // Flush the ring buffer, to try to address MUX start issues
+  SimcomPowerCycle(-1, 500, 3000);
   }
 
 bool simcom7600::State1Leave(modem::modem_state1_t oldstate)

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7670.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7670.cpp
@@ -1,0 +1,187 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th March 2017
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2017  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#include "ovms_log.h"
+static const char *TAG = "SIM7670";
+
+#include <string.h>
+#include "simcom_7670.h"
+#include "ovms_cellular.h"
+#include "ovms_config.h"
+#include "ovms_notify.h"
+#include "ovms_events.h"
+#include "simcom_powering.h"
+
+const char model[] = "A7670";
+const char name[] = "Experimental support for SIMCOM A7670E";
+
+simcom7670* MySimcom7670 = NULL;
+
+class simcom7670Init
+  {
+  public: 
+    simcom7670Init();
+} MySimcom7670Init  __attribute__ ((init_priority (4660)));
+
+
+simcom7670Init::simcom7670Init()
+  {
+  ESP_LOGI(TAG, "Registering Simcom A7670E modem driver (4660)");
+  MyCellularModemFactory.RegisterCellularModemDriver<simcom7670>(model,name);
+  }
+
+simcom7670::simcom7670()
+  {
+    m_timer = NULL;
+    m_interval = SIMCOM7670_GNSS_INTERVAL;
+    MySimcom7670 = this;
+  }
+
+simcom7670::~simcom7670()
+  {
+    MySimcom7670 = NULL;
+  }
+
+void simcom7670::StartupNMEA()
+  {
+    // GPS config for simcom 7670 - will use AT+CGNSSINFO to get location
+  if (m_modem->m_mux != NULL)
+    {
+    m_modem->muxtx(GetMuxChannelCMD(), "AT+CGNSSPWR=1\r\n");      //power GPS module on
+    vTaskDelay(5000 / portTICK_PERIOD_MS);
+    m_modem->muxtx(GetMuxChannelCMD(), "AT+CGNSSMODE=3\r\n");     // select used satellite networks 3: GPS, GLONASS, BEIDOU
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    MyEvents.RegisterEvent(TAG, "gnss.modem.request", std::bind(&simcom7670::SendGNSSRequest, this, _1, _2));
+    }
+  else
+    { ESP_LOGE(TAG, "Attempt to transmit on non running mux"); }
+  }
+
+void simcom7670::ShutdownNMEA()
+  {
+  // Switch off GPS:
+  if (m_modem->m_mux != NULL)
+    {
+    m_modem->muxtx(GetMuxChannelCMD(), "AT+CGNSSPWR=0\r\n");  // power gps module off
+    MyEvents.DeregisterEvent(TAG);
+    }
+  else
+    { ESP_LOGE(TAG, "Attempt to transmit on non running mux"); }
+  }
+
+
+void simcom7670::SendGNSSRequest(std::string event, void* data)
+  {
+    if (MySimcom7670 != NULL && MySimcom7670->m_modem->m_nmea) 
+      MySimcom7670->m_modem->muxtx(MySimcom7670->m_modem->m_mux_channel_POLL,"AT+CGNSSINFO\r\n");
+  }
+
+void simcom7670::PowerOff()
+  {
+  ESP_LOGV(TAG, "Power Off");
+  modemdriver::PowerSleep(false);
+  uart_wait_tx_done(m_modem->m_uartnum, portMAX_DELAY);
+  uart_flush(m_modem->m_uartnum); // Flush the ring buffer, to try to address MUX start issues
+  SimcomPowerOff();
+  }
+
+void simcom7670::PowerCycle()
+  {
+  ESP_LOGV(TAG, "Power Cycle");
+  uart_wait_tx_done(m_modem->m_uartnum, portMAX_DELAY);
+  uart_flush(m_modem->m_uartnum);       // Flush the ring buffer, to try to address MUX start issues
+  SimcomPowerCycle(-1, 70);
+  }
+
+void simcom7670::StatusPoller()
+  {
+  if (m_modem->m_mux != NULL)
+    {
+    // The ESP32 UART queue has a capacity of 128 bytes, NMEA and PPP data may be
+    // coming in concurrently, and we cannot use flow control.
+    // Reduce the queue stress by distributing the status poll:
+    switch (++m_statuspoller_step)
+      {
+      case 1:
+        m_modem->muxtx(GetMuxChannelPOLL(), "AT+CREG?;+CGREG?;+CEREG?;+CCLK?;+CSQ\r\n");
+        // → ~ 80 bytes, e.g.
+        //  +CREG: 1,5  +CGREG: 1,5  +CEREG: 1,5  +CCLK: "22/09/09,12:54:41+08"  +CSQ: 13,99  
+        break;
+      case 2:
+        m_modem->muxtx(GetMuxChannelPOLL(), "AT+CPSI?\r\n");
+        // → ~ 85 bytes, e.g.
+        //  +CPSI: LTE,Online,262-02,0xB0F5,13179412,448,EUTRAN-BAND1,100,4,4,-122,-1184,-874,9  
+        break;
+      case 3:
+        m_modem->muxtx(GetMuxChannelPOLL(), "AT+CGNSSINFO\r\n");
+        // request GNSS location
+        break;
+      case 4:
+        m_modem->muxtx(GetMuxChannelPOLL(), "AT+COPS?\r\n");
+        // → ~ 35 bytes, e.g.
+        //  +COPS: 0,0,"vodafone.de Hologram",7  
+
+        // done, fallthrough:
+        FALLTHROUGH;
+      default:
+        m_statuspoller_step = 0;
+        break;
+      }
+    }
+  }
+
+// State1Ticker needed for the Simcom7670 for a successful PPP connection.
+// Standard AT command (CGDATA=PPP) in modem State1Ticker fails
+modem::modem_state1_t simcom7670::State1Ticker1(modem::modem_state1_t state)
+  {
+    if (state == modem::NetStart && m_modem->GetPowerMode() != Sleep) 
+    {
+      if (m_modem->m_state1_ticker == 1)  
+        {
+        m_modem->m_state1_userdata = 1;
+        if (m_modem->m_mux != NULL)
+          {
+          std::string apncmd("AT+CGDCONT=1,\"IP\",\"");
+          apncmd.append(MyConfig.GetParamValue("modem", "apn"));
+          apncmd.append("\"\r\n");
+          m_modem->muxtx(m_modem->m_mux_channel_DATA,apncmd.c_str());
+          // CGDATA=PPP does not work -> old school PPP dial up 
+          apncmd="ATD*99#\r\n"; 
+          ESP_LOGD(TAG,"Netstart %s",apncmd.c_str());
+          m_modem->muxtx(m_modem->m_mux_channel_DATA,apncmd.c_str());
+          // Dirty hack - increment modem state1_ticker to avoid that a similar action 
+          // is performed in the generic modemdriver State1Ticker
+          ++m_modem->m_state1_ticker; 
+          }
+        }
+    }
+  return state;
+  }

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7670.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7670.h
@@ -1,0 +1,57 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th March 2017
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2017  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;    (C) 2025       Christian Zeitnitz
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#ifndef __SIMCOM_7670_H__
+#define __SIMCOM_7670_H__
+
+#include "ovms_cellular.h"
+
+// time between GPS location requests (seconds)
+#define   SIMCOM7670_GNSS_INTERVAL  10
+
+class simcom7670 : public modemdriver
+  {
+  public:
+    simcom7670();
+    ~simcom7670();
+    void PowerCycle();
+    void PowerOff();
+    void StartupNMEA();
+    void ShutdownNMEA();
+    void StatusPoller();
+    modem::modem_state1_t State1Ticker1(modem::modem_state1_t state);
+    void SendGNSSRequest(std::string event, void* data);
+
+  private:
+    TimerHandle_t m_timer;
+    int           m_interval;
+  };
+#endif //#ifndef __SIMCOM_7670_H__

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_powering.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_powering.cpp
@@ -1,0 +1,62 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th March 2017
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2017  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;    (C) 2025       Christian Zeitnitz
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#include "simcom_powering.h"
+
+void SimcomPowerOff(int T_off)
+  {
+  ESP_LOGI("Simcom", "Power Off - %d ms", T_off);
+  setPWRLevel(PwrKeyHigh);
+  setPWRLevel(PwrKeyLow);
+  vTaskDelay(T_off / portTICK_PERIOD_MS);          // Toff > 2500ms
+  setPWRLevel(PwrKeyHigh);
+  vTaskDelay(5000 / portTICK_PERIOD_MS);          // Wait for UART to be offline (modem sends DETACH message)
+  }
+
+void SimcomPowerCycle(int iPwr, int T_on, int T_off)
+  {
+  T_on = (iPwr >= 0) ? TimePwrOn[iPwr] : T_on;
+  ESP_LOGI("Simcom", "Power Cycle - T_off %d ms - T_on %d ms", T_off, T_on);
+  setPWRLevel(PwrKeyHigh);              // set POWERKEY of modem to high
+  // Power OFf
+  setPWRLevel(PwrKeyLow);               // set POWERKEY of modem to low
+  vTaskDelay(T_off / portTICK_PERIOD_MS);   // PWR off -> t > 2500ms
+  setPWRLevel(PwrKeyHigh);              // set POWERKEY of modem to high
+  
+  //Wait until powered off (1.9s) and delay to power on again (Tonoff > 2s) 
+  vTaskDelay(TPwrOffOn / portTICK_PERIOD_MS); // > 3.9s
+
+  // Power on again
+  setPWRLevel(PwrKeyLow);               // set POWERKEY of modem to low
+  vTaskDelay(T_on / portTICK_PERIOD_MS);  // PWR on -> t > 180ms  ( > 1000 for 7000)
+  setPWRLevel(PwrKeyHigh);              // set POWERKEY of modem to high
+  }
+

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_powering.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_powering.h
@@ -71,18 +71,20 @@ const int TimePwrOn[]  = {     200,       1000 };   // array of T_on (ms) settin
 
 // time (ms) from PWRKEY Off released to PWRKEY On asserted
 #define TPwrOffOn   5000
-// 
-// Powering of Simcom modems via PWRKEY and DTR pin 
+//
+// Powering of Simcom modems via PWRKEY and DTR pin
 //   Signal level might be inverted (driven by NPN transistor)
-// 
-#ifdef CONFIG_SIMCOM_INVERTED_PWRKEY
+//
+//#ifdef CONFIG_SIMCOM_INVERTED_PWRKEY
+
 // inverted PWR signal
   #define PwrKeyLow  1
   #define PwrKeyHigh 0
-#else
-  #define PwrKeyLow  0
-  #define PwrKeyHigh 1
-#endif
+
+//#else
+//  #define PwrKeyLow  0
+//  #define PwrKeyHigh 1
+//#endif
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
   #define setPWRLevel(level)  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, level)

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_powering.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_powering.h
@@ -1,0 +1,106 @@
+/*
+;    Project:       Open Vehicle Monitor System
+;    Date:          14th March 2017
+;
+;    Changes:
+;    1.0  Initial release
+;
+;    (C) 2011       Michael Stegen / Stegen Electronics
+;    (C) 2011-2017  Mark Webb-Johnson
+;    (C) 2011        Sonny Chen @ EPRO/DX
+;    (C) 2025       Christian Zeitnitz
+;
+; Permission is hereby granted, free of charge, to any person obtaining a copy
+; of this software and associated documentation files (the "Software"), to deal
+; in the Software without restriction, including without limitation the rights
+; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+; copies of the Software, and to permit persons to whom the Software is
+; furnished to do so, subject to the following conditions:
+;
+; The above copyright notice and this permission notice shall be included in
+; all copies or substantial portions of the Software.
+;
+; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+; THE SOFTWARE.
+*/
+
+#ifndef __SIMCOM_POWERING_H__
+#define __SIMCOM_POWERING_H__
+
+#include "ovms_peripherals.h"
+
+//
+// Timing of PWRKEY pin for Simcom modems
+//
+// procedure to power off via the PWRKEY pin
+//          T_off         
+// High ---      ------- Wait for uart to be offline
+// LOW     ------        
+//
+// procedure to power cycle via the PWRKEY pin
+//           T_off  4-5s   T_on
+// High ---       --------    -----
+// LOW     -------        ----
+//
+// If initial state (On or Off) is unknown -> timing has to ensure, that the
+// modem is in ON state after the power cycle
+// - second pulse has to be short enough to avoid another power off
+//
+// Minimal time (ms) for different Simcom Models
+//
+// Model  T_on     T_off
+// ------+-------+-------
+// 5360    180       500
+// 7000   1000      1200
+// 7600    100      2500
+// 7670     50      2500 
+//
+// In case of frequent power cycles, the T_on time is changed (see array below) 
+//
+// Model                  5360/7600/7670  7000
+const int TimePwrOn[]  = {     200,       1000 };   // array of T_on (ms) settings
+#define NPwrTime    sizeof(TimePwrOn)/sizeof(TimePwrOn[0])  
+
+// T_off can be the same for all models
+#define TimePwrOff  2500
+
+// time (ms) from PWRKEY Off released to PWRKEY On asserted
+#define TPwrOffOn   5000
+// 
+// Powering of Simcom modems via PWRKEY and DTR pin 
+//   Signal level might be inverted (driven by NPN transistor)
+// 
+#ifdef CONFIG_SIMCOM_INVERTED_PWRKEY
+// inverted PWR signal
+  #define PwrKeyLow  1
+  #define PwrKeyHigh 0
+#else
+  #define PwrKeyLow  0
+  #define PwrKeyHigh 1
+#endif
+
+#ifdef CONFIG_OVMS_COMP_MAX7317
+  #define setPWRLevel(level)  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, level)
+#elif defined(MODEM_GPIO_PWR)
+  #define setPWRLevel(level)  gpio_set_level((gpio_num_t)MODEM_GPIO_PWR, level)
+#else
+  #define setPWRLevel(level)  {}
+#endif
+
+#ifdef CONFIG_OVMS_COMP_MAX7317
+  #define setDTRLevel(level)  MyPeripherals->m_max7317->Output(MODEM_EGPIO_DTR, level)
+#elif defined(MODEM_GPIO_DTR)
+  #define setDTRLevel(level)  gpio_set_level((gpio_num_t)MODEM_GPIO_DTR, level)
+#else
+  #define setDTRLevel(level)  {}
+#endif
+
+void SimcomPowerOff(int T_off=TimePwrOff);
+void SimcomPowerCycle(int iPwr=-1, int T_on=200, int T_off=TimePwrOff);
+
+  #endif // __SIMCOM_POWERING_H__

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_powering.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_powering.h
@@ -38,9 +38,9 @@
 // Timing of PWRKEY pin for Simcom modems
 //
 // procedure to power off via the PWRKEY pin
-//          T_off         
+//          T_off
 // High ---      ------- Wait for uart to be offline
-// LOW     ------        
+// LOW     ------
 //
 // procedure to power cycle via the PWRKEY pin
 //           T_off  4-5s   T_on
@@ -58,13 +58,13 @@
 // 5360    180       500
 // 7000   1000      1200
 // 7600    100      2500
-// 7670     50      2500 
+// 7670     50      2500
 //
-// In case of frequent power cycles, the T_on time is changed (see array below) 
+// In case of frequent power cycles, the T_on time is changed (see array below)
 //
 // Model                  5360/7600/7670  7000
 const int TimePwrOn[]  = {     200,       1000 };   // array of T_on (ms) settings
-#define NPwrTime    sizeof(TimePwrOn)/sizeof(TimePwrOn[0])  
+#define NPwrTime    sizeof(TimePwrOn)/sizeof(TimePwrOn[0])
 
 // T_off can be the same for all models
 #define TimePwrOff  2500
@@ -73,18 +73,11 @@ const int TimePwrOn[]  = {     200,       1000 };   // array of T_on (ms) settin
 #define TPwrOffOn   5000
 //
 // Powering of Simcom modems via PWRKEY and DTR pin
-//   Signal level might be inverted (driven by NPN transistor)
 //
-//#ifdef CONFIG_SIMCOM_INVERTED_PWRKEY
 
-// inverted PWR signal
+// PWRKEY signal is inverted by NPN transistor
   #define PwrKeyLow  1
   #define PwrKeyHigh 0
-
-//#else
-//  #define PwrKeyLow  0
-//  #define PwrKeyHigh 1
-//#endif
 
 #ifdef CONFIG_OVMS_COMP_MAX7317
   #define setPWRLevel(level)  MyPeripherals->m_max7317->Output(MODEM_EGPIO_PWR, level)


### PR DESCRIPTION
Add support for Simcom 7670 modem and GNSS.
Streamline the powering of the Simcom modems during powering on/off and power cycling.
