### PR TITLE
 DBC - Implement extended multiplexing

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -26,6 +26,8 @@ Open Vehicle Monitor System v3 - Change log
     can <bus> explain [errorflags]    -- Decode error flags into human readable text 
 - DBC Files
   Add unit support
+  Add extended signals/multiplexing support
+  Add support for enum values.
 - OVMS Server v3: Ability to define less frequent MQTT communication to save data charges and power
   Events:
     Excludes clock.* events from being published at the start of every minute.

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.h
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.h
@@ -248,6 +248,26 @@ class dbcValueTableTable
     dbcValueTableTableEntry_t m_entrymap;
   };
 
+
+class dbcMetric
+  {
+  public:
+    virtual ~dbcMetric() {};
+    virtual void SetValue(dbcNumber value, metric_unit_t metric) = 0;
+    virtual void SetValue(const std::string &value) = 0;
+    virtual metric_unit_t DefaultUnit() const = 0;
+  };
+class dbcOvmsMetric : public dbcMetric
+  {
+  private:
+    OvmsMetric *m_metric;
+  public:
+    dbcOvmsMetric(OvmsMetric *metric);
+    void SetValue(dbcNumber value, metric_unit_t unit) override;
+    void SetValue(const std::string &value) override;
+    metric_unit_t DefaultUnit() const override;
+  };
+
 typedef std::list<std::string> dbcReceiverList_t;
 class dbcSignal
   {
@@ -309,7 +329,8 @@ class dbcSignal
 
   public:
     void AssignMetric(OvmsMetric* metric);
-    OvmsMetric* GetMetric() const;
+    void AttachDbcMetric(dbcMetric* metric);
+    dbcMetric* GetMetric() const;
 
   public:
     void WriteFile(dbcOutputCallback callback, void* param) const;
@@ -336,7 +357,7 @@ class dbcSignal
     std::string m_unit;
     metric_unit_t m_metric_unit;
 
-    OvmsMetric* m_metric;
+    dbcMetric* m_metric;
   };
 
 typedef std::list<dbcSignal*> dbcSignalList_t;

--- a/vehicle/OVMS.V3/components/dbc/src/dbc_app.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc_app.cpp
@@ -572,6 +572,71 @@ void dbc_signal_set_mux(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int
     }
   }
 
+void dbc_signal_set_mux_ext(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv)
+  {
+  if (MyDBC.m_selected == NULL)
+    {
+    writer->puts("Error: No DBC selected");
+    return;
+    }
+
+  uint32_t msgid = dbcMessageIdFromString(argv[0]);
+  dbcMessage* msg = MyDBC.m_selected->m_messages.FindMessage(msgid);
+  if (msg == NULL)
+    {
+    writer->printf("Error: Could not find message %s\n",argv[0]);
+    return;
+    }
+
+  dbcSignal* signal = msg->FindSignal(argv[1]);
+  if (signal == NULL)
+    {
+    writer->printf("Error: Could not find signal %s on message %s\n",argv[1],argv[0]);
+    return;
+    }
+
+  if (argc > 3)
+    {
+    dbcSignal* source = msg->FindSignal(argv[2]);
+    if (!source)
+      {
+      writer->printf("Error: Could not find signal source %s on message %s\n",argv[2],argv[0]);
+      return;
+      }
+    source->SetMultiplexSource();
+
+    bool first = true;
+    std::istringstream iss(argv[3]);
+    std::string item;
+    while (std::getline(iss, item, ',')) {
+      dbcSwitchRange_t range;
+      switch( sscanf(item.c_str(), "%" PRIu32 "-%" PRIu32, &range.min_val, &range.max_val) )
+        {
+        case 0: continue;
+        case 1:
+           range.max_val = range.min_val;
+           FALLTHROUGH;
+        case 2:
+          {
+          if (first)
+            {
+            first = false;
+            signal->SetMultiplexed(range.min_val); // first one.
+            signal->SetMultiplexSource(source);
+            }
+          signal->AddMultiplexRange(range);
+          }
+        }
+    }
+    writer->printf("DBC: Set mux %s for signal %s on message %s\n",argv[2],argv[1],argv[0]);
+    }
+  else
+    {
+    signal->ClearMultiplexed();
+    writer->printf("DBC: Cleared mux for signal %s on message %s\n",argv[1],argv[0]);
+    }
+  }
+
 dbc::dbc()
   {
   ESP_LOGI(TAG, "Initialising DBC (4520)");
@@ -594,6 +659,8 @@ dbc::dbc()
   cmd_set->RegisterCommand("timing", "Set bit timing for selected DBC file", dbc_set_timing, "<baud> <btr1> <btr2>", 3, 3);
   cmd_set->RegisterCommand("messagemux", "Set message mux for selected DBC file", dbc_message_set_mux, "<id> [<signal>]", 1, 2);
   cmd_set->RegisterCommand("signalmux", "Set signal mux for selected DBC file", dbc_signal_set_mux, "<id> <name> [<value>]", 2, 3);
+  cmd_set->RegisterCommand("signalmuxext", "Set extended signal mux link for selected DBC file",
+      dbc_signal_set_mux_ext, "<id> <name> [<messagesource> <value>-<value>{,<value_n>-<value_n>}]", 2, 4);
 
   OvmsCommand* cmd_add = cmd_dbc->RegisterCommand("add","DBC Add framework");
   cmd_add->RegisterCommand("node", "Add node for selected DBC file", dbc_node_add, "<node>", 1, 1);

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -146,7 +146,7 @@ void OvmsPoller::IncomingPollTxCallback(const OvmsPoller::poll_job_t &job, bool 
   m_polls.IncomingTxReply(job, success);
   }
 
-bool OvmsPoller::Ready()
+bool OvmsPoller::Ready() const
   {
   return m_parent->Ready();
   }
@@ -270,7 +270,7 @@ void OvmsPoller::ResetPollEntry(bool force)
     }
   }
 
-bool OvmsPoller::HasPollList()
+bool OvmsPoller::HasPollList() const
   {
   OvmsRecMutexLock lock(&m_poll_mutex);
   return m_polls.HasPollList();
@@ -282,7 +282,7 @@ void OvmsPoller::ClearPollList()
   return m_polls.Clear();
   }
 
-bool OvmsPoller::CanPoll()
+bool OvmsPoller::CanPoll() const
   {
   // Check Throttle
   return (!m_poll_sequence_max || m_poll_sequence_cnt < m_poll_sequence_max);
@@ -969,7 +969,7 @@ void OvmsPollers::ShuttingDownVehicle()
     }
   }
 
-uint8_t OvmsPollers::GetBusNo(canbus* bus)
+uint8_t OvmsPollers::GetBusNo(canbus* bus) const
   {
   for (int i = 0; i < VEHICLE_MAXBUSSES; ++i)
     {
@@ -978,7 +978,7 @@ uint8_t OvmsPollers::GetBusNo(canbus* bus)
     }
   return 0;
   }
-canbus* OvmsPollers::GetBus(uint8_t busno)
+canbus* OvmsPollers::GetBus(uint8_t busno) const
   {
   if (busno <1 || busno > VEHICLE_MAXBUSSES)
     return nullptr;
@@ -2592,7 +2592,7 @@ OvmsPoller::OvmsNextPollResult OvmsPoller::PollSeriesList::NextPollEntry(poll_pi
     }
   }
 
-bool OvmsPoller::PollSeriesList::HasPollList()
+bool OvmsPoller::PollSeriesList::HasPollList() const
   {
   for (auto it = m_first; it != nullptr; it = it->next)
     {
@@ -2602,7 +2602,7 @@ bool OvmsPoller::PollSeriesList::HasPollList()
   return false;
   }
 
-bool OvmsPoller::PollSeriesList::HasRepeat()
+bool OvmsPoller::PollSeriesList::HasRepeat() const
   {
   for (auto it = m_first; it != nullptr; it = it->next)
     {
@@ -2619,7 +2619,7 @@ void OvmsPoller::PollSeriesEntry::IncomingTxReply(const OvmsPoller::poll_job_t& 
   // ignore
   }
 
-bool OvmsPoller::PollSeriesEntry::Ready()
+bool OvmsPoller::PollSeriesEntry::Ready() const
   {
   return true;
   }
@@ -2715,14 +2715,14 @@ void OvmsPoller::StandardPollSeries::Removing()
   m_poller = nullptr;
   }
 
-bool OvmsPoller::StandardPollSeries::HasPollList()
+bool OvmsPoller::StandardPollSeries::HasPollList() const
   {
   return (m_defaultbus != 0)
       && (m_poll_plist != NULL)
       && (m_poll_plist->txmoduleid != 0);
   }
 
-bool OvmsPoller::StandardPollSeries::HasRepeat()
+bool OvmsPoller::StandardPollSeries::HasRepeat() const
   {
   return false;
   }
@@ -2749,7 +2749,7 @@ void OvmsPoller::StandardVehiclePollSeries::IncomingError(const OvmsPoller::poll
  }
 
 // Return true if this series is ok to run.
-bool OvmsPoller::StandardVehiclePollSeries::Ready()
+bool OvmsPoller::StandardVehiclePollSeries::Ready() const
   {
   return (!m_signal) || m_signal->Ready();
   }
@@ -2825,7 +2825,7 @@ void OvmsPoller::StandardPacketPollSeries::IncomingError(const OvmsPoller::poll_
   }
 
 // Return true if this series has entries to retry/redo.
-bool OvmsPoller::StandardPacketPollSeries::HasRepeat()
+bool OvmsPoller::StandardPacketPollSeries::HasRepeat() const
   {
   return (m_repeat_count < m_repeat_max) && HasPollList();
   }
@@ -3009,12 +3009,12 @@ void OvmsPoller::OnceOffPollBase::IncomingError(const OvmsPoller::poll_job_t& jo
   Done(false);
   }
 
-bool OvmsPoller::OnceOffPollBase::HasPollList()
+bool OvmsPoller::OnceOffPollBase::HasPollList() const
   {
   return m_poll.txmoduleid != 0;
   }
 
-bool OvmsPoller::OnceOffPollBase::HasRepeat()
+bool OvmsPoller::OnceOffPollBase::HasRepeat() const
   {
   return false; // Don't retry in same tick.
   }

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.cpp
@@ -46,6 +46,7 @@ static const char *TAG = "vehicle-poll";
 #include "vehicle_poller.h"
 #include "can.h"
 #include "ovms_boot.h"
+#include "dbc.h"
 
 using namespace std::placeholders;
 
@@ -76,6 +77,9 @@ OvmsPoller::OvmsPoller(canbus* can, uint8_t can_number, OvmsPollers *parent,
   m_poll.mlremain = 0;
   m_poll.mloffset = 0;
   m_poll.mlframe = 0;
+  m_poll.format = CAN_frame_std;
+  m_poll.raw_data = nullptr;
+  m_poll.raw_data_len = 0;
   m_poll_wait = 0;
   m_poll_sequence_max = 1;
   m_poll_sequence_cnt = 0;
@@ -86,29 +90,44 @@ OvmsPoller::OvmsPoller(canbus* can, uint8_t can_number, OvmsPollers *parent,
   m_poll_between_success = 0;
   }
 
-void OvmsPoller::Incoming(CAN_frame_t &frame, bool success)
+/** Handle incoming frame.
+ * @return true if the frame was handled by the poller.
+ */
+bool OvmsPoller::Incoming(CAN_frame_t &frame, bool success)
   {
 
   // No multiframe request is active.
   if (m_poll.type == VEHICLE_POLL_TYPE_NONE)
-    return;
+    return false;
 
   // Pass frame to poller protocol handlers:
   if (frame.origin == m_poll_vwtp.bus && frame.MsgID == m_poll_vwtp.rxid)
     {
-    PollerVWTPReceive(&frame, frame.MsgID);
+    // Keep raw Data for DBC
+    m_poll.format = frame.FIR.B.FF;
+    m_poll.raw_data = &frame.data.u8[0];
+    m_poll.raw_data_len = 8;
+
+    auto ret = PollerVWTPReceive(&frame, frame.MsgID);
+    m_poll.raw_data = nullptr;
+    m_poll.raw_data_len = 0;
+    return ret;
     }
-  else if (frame.origin == m_poll.bus)
+  else if (frame.origin != m_poll.bus)
+    {
+    return false;
+    }
+  else
     {
     if (m_poll.entry.txmoduleid == 0)
       {
       IFTRACE(TXRX) ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Incoming - dropped (no poll entry)", m_poll.bus_no);
-      return;
+      return false;
       }
     if (!m_poll_wait)
       {
       IFTRACE(TXRX) ESP_LOGV(TAG, "[%" PRIu8 "]Poller: Incoming - timed out", m_poll.bus_no);
-      return;
+      return false;
       }
     uint32_t msgid;
     if (m_poll.protocol == ISOTP_EXTADR)
@@ -118,9 +137,17 @@ void OvmsPoller::Incoming(CAN_frame_t &frame, bool success)
     IFTRACE(TXRX) ESP_LOGV(TAG, "[%" PRIu8 "]Poller: FrameRx(bus=%s, msg=%" PRIx32 " )", m_poll.bus_no, frame.origin == m_poll.bus ? "Self" : "Other", msgid );
     if (msgid >= m_poll.moduleid_low && msgid <= m_poll.moduleid_high)
       {
-      PollerISOTPReceive(&frame, msgid);
+      // Keep raw Data for DBC
+      m_poll.format = frame.FIR.B.FF;
+      m_poll.raw_data = &frame.data.u8[0];
+      m_poll.raw_data_len = 8;
+      auto ret = PollerISOTPReceive(&frame, msgid);
+      m_poll.raw_data = nullptr;
+      m_poll.raw_data_len = 0;
+      return ret;
       }
     }
+  return false;
   }
 
 OvmsPoller::~OvmsPoller()
@@ -1433,11 +1460,23 @@ void OvmsPollers::PollerTask()
       {
       case OvmsPoller::OvmsPollEntryType::FrameRx:
         {
+        bool processed = false;
+        canbus* bus = entry.entry_FrameRxTx.frame.origin;
         auto poller = GetPoller(entry.entry_FrameRxTx.frame.origin);
         IFTRACE(Poller) ESP_LOGV(TAG, "Pollers: FrameRx(bus=%d)", GetBusNo(entry.entry_FrameRxTx.frame.origin));
         if (poller)
-          poller->Incoming(entry.entry_FrameRxTx.frame, entry.entry_FrameRxTx.success);
+          processed = poller->Incoming(entry.entry_FrameRxTx.frame, entry.entry_FrameRxTx.success);
         PollerFrameRx(entry.entry_FrameRxTx.frame);
+
+        if (!processed) // Not processed by poller.
+          {
+          dbcfile* dbc = bus->GetDBC();
+          if (dbc != nullptr)
+            {
+            CAN_frame_t &frame = entry.entry_FrameRxTx.frame;
+            dbc->DecodeSignal(frame.FIR.B.FF, frame.MsgID, frame.data.u8, 8);
+            }
+          }
         }
         break;
       case OvmsPoller::OvmsPollEntryType::FrameTx:
@@ -2627,7 +2666,7 @@ bool OvmsPoller::PollSeriesEntry::Ready() const
 
 // Standard Poll Series class
 OvmsPoller::StandardPollSeries::StandardPollSeries(OvmsPoller *poller, uint16_t stateoffset  )
-  : m_poller(poller), m_state_offset(stateoffset),  m_defaultbus(0), m_poll_plist(nullptr), m_poll_plcur(nullptr) 
+  : m_poller(poller), m_state_offset(stateoffset),  m_defaultbus(0), m_poll_plist(nullptr), m_poll_plcur(nullptr)
   {
   }
 void OvmsPoller::StandardPollSeries::SetParentPoller(OvmsPoller *poller)
@@ -2763,12 +2802,14 @@ void OvmsPoller::StandardVehiclePollSeries::IncomingTxReply(const OvmsPoller::po
 
 // StandardPacketPollSeries
 
-OvmsPoller::StandardPacketPollSeries::StandardPacketPollSeries( OvmsPoller *poller, int repeat_max, poll_success_func success, poll_fail_func fail)
+OvmsPoller::StandardPacketPollSeries::StandardPacketPollSeries( OvmsPoller *poller, int repeat_max, poll_success_func success, poll_fail_func fail, bool pack_raw_data)
   : StandardPollSeries(poller),
     m_repeat_max(repeat_max),
     m_repeat_count(0),
     m_success(success),
-    m_fail(fail)
+    m_fail(fail),
+    m_format(CAN_frame_std),
+    m_pack_raw_data(pack_raw_data)
   {
   }
 
@@ -2794,14 +2835,21 @@ void OvmsPoller::StandardPacketPollSeries::IncomingPacket(const OvmsPoller::poll
   {
   if (job.mlframe == 0)
     {
+    m_format = job.format;
     m_data.clear();
-    m_data.reserve(length+job.mlremain);
+    auto len = length+job.mlremain;
+    if (m_pack_raw_data) // Default to a bit more.
+      len = (1+ (len >> 3)) << 3;
+    m_data.reserve(len);
     }
-  m_data.append((char*)data, length);
+  if (m_pack_raw_data)
+    m_data.append((char*)job.raw_data, job.raw_data_len);
+  else
+    m_data.append((char*)data, length);
   if (job.mlremain == 0)
     {
     if (m_success)
-      m_success(job.type, job.moduleid_sent, job.moduleid_rec, job.pid, m_data);
+      m_success(job.type, job.moduleid_sent, job.moduleid_rec, job.pid, job.format, m_data);
     m_data.clear();
     }
   }
@@ -2814,7 +2862,7 @@ void OvmsPoller::StandardPacketPollSeries::IncomingError(const OvmsPoller::poll_
     IFTRACE(Poller) ESP_LOGD(TAG, "Packet failed with zero error %.03" PRIx32 " TYPE:%x PID: %03x", job.moduleid_rec, job.type, job.pid);
     m_data.clear();
     if (m_success)
-      m_success(job.type, job.moduleid_sent, job.moduleid_rec, job.pid, m_data);
+      m_success(job.type, job.moduleid_sent, job.moduleid_rec, job.pid, job.format, m_data);
     }
   else
     {
@@ -2834,7 +2882,7 @@ bool OvmsPoller::StandardPacketPollSeries::HasRepeat() const
 
 OvmsPoller::OnceOffPollBase::OnceOffPollBase( const poll_pid_t &pollentry, std::string *rxbuf, int *rxerr, uint8_t retry_fail)
    : m_sent(status_t::Init), m_poll(pollentry), m_poll_rxbuf(rxbuf), m_poll_rxerr(rxerr),
-    m_retry_fail(retry_fail)
+    m_retry_fail(retry_fail), m_format(CAN_frame_std)
   {
   }
 void OvmsPoller::OnceOffPollBase::SetParentPoller(OvmsPoller *poller)
@@ -2845,7 +2893,7 @@ OvmsPoller::OnceOffPollBase::OnceOffPollBase(std::string *rxbuf, int *rxerr, uin
    : m_sent(status_t::Init),
     m_poll({ 0, 0, 0, 0, { 1, 1, 1, 1 }, 0, 0 }),
     m_poll_rxbuf(rxbuf), m_poll_rxerr(rxerr),
-    m_retry_fail(retry_fail)
+    m_retry_fail(retry_fail), m_format(CAN_frame_std)
   {
   }
 
@@ -2964,6 +3012,7 @@ void OvmsPoller::OnceOffPollBase::IncomingPacket(const OvmsPoller::poll_job_t& j
     {
     if (job.mlframe == 0 )
       {
+      m_format = job.format;
       m_poll_rxbuf->clear();
       m_poll_rxbuf->reserve(length+job.mlremain);
       }
@@ -3083,7 +3132,7 @@ void OvmsPoller::OnceOffPoll::Done(bool success)
   if (success)
     {
     if (m_success)
-      m_success(m_poll.type, m_poll.txmoduleid, m_poll.rxmoduleid, m_poll.pid, m_data );
+      m_success(m_poll.type, m_poll.txmoduleid, m_poll.rxmoduleid, m_poll.pid, m_format, m_data );
     }
   else
     {

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -640,7 +640,7 @@ void OvmsVehicle::OvmsVehicleSignal::IncomingPollTxCallback(const OvmsPoller::po
     m_parent->IncomingPollTxCallback(job, success);
   }
 
-bool OvmsVehicle::OvmsVehicleSignal::Ready()
+bool OvmsVehicle::OvmsVehicleSignal::Ready() const
   {
   return m_parent->m_ready;
   }

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -547,7 +547,7 @@ class OvmsVehicle : public InternalRamAllocated
       void IncomingPollError(const OvmsPoller::poll_job_t &job, uint16_t code) override;
       void IncomingPollTxCallback(const OvmsPoller::poll_job_t &job, bool success) override;
 
-      bool Ready() override;
+      bool Ready() const override;
     };
 #endif
 

--- a/vehicle/OVMS.V3/components/vehicle_dbc/src/vehicle_dbc.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_dbc/src/vehicle_dbc.cpp
@@ -82,9 +82,6 @@ void OvmsVehicleDBC::IncomingFrameCan3(CAN_frame_t* p_frame)
 
 void OvmsVehicleDBC::IncomingFrame(canbus* bus, CAN_frame_t* frame)
   {
-  dbcfile* dbc = bus->GetDBC();
-  if (dbc==NULL) return;
-  dbc->DecodeSignal(frame->FIR.B.FF, frame->MsgID, frame->data.u8, 8);
   }
 
 OvmsVehiclePureDBC::OvmsVehiclePureDBC()

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_can_poll.cpp
@@ -141,14 +141,14 @@ void OvmsHyundaiIoniqEv::IncomingPollReply(const OvmsPoller::poll_job_t &job, ui
       return;
     }
 
-    Incoming_Full(job.type, job.moduleid_sent, job.moduleid_rec, job.pid, rxbuf);
+    Incoming_Full(job.type, job.moduleid_sent, job.moduleid_rec, job.pid, job.format, rxbuf);
     obd_frame = 0xffff; // Received all - drop until we have a new frame 0
     rxbuf.clear();
   }
   XDISARM;
 }
 
-void OvmsHyundaiIoniqEv::Incoming_Full(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, const std::string &data)
+void OvmsHyundaiIoniqEv::Incoming_Full(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, CAN_frame_format_t format, const std::string &data)
 {
   ESP_LOGD(TAGP, "IoniqISOTP: IPR %03" PRIx32 " TYPE:%x PID: %03x Message Size: %d",
       module_rec, type, pid, data.size());
@@ -981,7 +981,7 @@ bool OvmsHyundaiIoniqEv::PollRequestVIN()
   }
   auto poll_entry = std::shared_ptr<OvmsPoller::OnceOffPoll>(
       new OvmsPoller::OnceOffPoll(
-        std::bind(&OvmsHyundaiIoniqEv::Incoming_Full, this, _1, _2, _3, _4, _5),
+        std::bind(&OvmsHyundaiIoniqEv::Incoming_Full, this, _1, _2, _3, _4, _5, _6),
         std::bind(&OvmsHyundaiIoniqEv::Incoming_Fail, this, _1, _2, _3, _4, _5),
         0x7e2, 0x7ea,
         VEHICLE_POLL_TYPE_OBDIIVEHICLE,  2,

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.cpp
@@ -480,7 +480,7 @@ void OvmsHyundaiIoniqEv::ECUStatusChange(bool run)
     // Add an extra set of polling.
     auto poll_series = std::shared_ptr<OvmsPoller::StandardPacketPollSeries>(
         new OvmsPoller::StandardPacketPollSeries(nullptr, 3/*repeats*/,
-              std::bind(&OvmsHyundaiIoniqEv::Incoming_Full, this, _1, _2, _3, _4, _5),
+              std::bind(&OvmsHyundaiIoniqEv::Incoming_Full, this, _1, _2, _3, _4, _5, _6),
               nullptr));
     poll_series->PollSetPidList(1, vehicle_ioniq_driving_polls);
 

--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/vehicle_hyundai_ioniq5.h
@@ -174,7 +174,7 @@ protected:
   void NotifiedVehicleAux12vStateChanged(OvmsBatteryState new_state, const OvmsBatteryMon &monitor) override;
   void BatteryStateStillCharging();
 
-  void Incoming_Full(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, const std::string &data);
+  void Incoming_Full(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, CAN_frame_format_t format, const std::string &data);
   void Incoming_Fail(uint16_t type, uint32_t module_sent, uint32_t module_rec, uint16_t pid, int errorcode);
 
   void IncomingVMCU_Full(uint16_t type, uint16_t pid, const std::string &data);


### PR DESCRIPTION
     - moves DBC handling to poller object.
     - Supports extended multiplex attributes (allows for more complex states)
     - Supports Unit specifiers for metrics
     - Supports list  specifiers to assign state string metric values from an integer.
     - Abstracts setting metric for future support of more complex metrics.  The big example I want to tackle is so the battery cells (v, temp) are stored in a way that would allow for the averages etc to be recorded.
   
