### PR TITLE
Battery monitor fixes

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -69,7 +69,7 @@ Open Vehicle Monitor System v3 - Change log
   New commands:
     vehicle aux [status]
     vehicle aux monitor [status]
-    vehicle aux monitor enable
+    vehicle aux monitor enable [[low-threshold] [charging-threshold]]
     vehicle aux monitor disable
   Duktape Support:
     OvmsVehicle.AuxMon.Enable

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -2852,10 +2852,10 @@ OvmsBatteryState OvmsBatteryMon::calc_state(int32_t &diff_last) const
   int32_t diff = (average_short - average_long);
   diff_last = diff;
 
-  if (average_short < m_low_threshold)
+  if (average_long < m_low_threshold)
     return OvmsBatteryState::Low;
 
-  if (average_short > m_charge_threshold)
+  if (average_long > m_charge_threshold)
     {
     if (diff < chdip_threshold)
       return OvmsBatteryState::ChargingDip;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -86,7 +86,7 @@ OvmsVehicleFactory::OvmsVehicleFactory()
   cmd_aux->RegisterCommand("status", "Aux Battery Status", vehicle_aux);
   OvmsCommand *cmd_aux_mon = cmd_aux->RegisterCommand("monitor", "Aux Battery Monitor", vehicle_aux_monitor);
   cmd_aux_mon->RegisterCommand("status", "Aux Battery Status", vehicle_aux_monitor);
-  cmd_aux_mon->RegisterCommand("enable", "Enable Aux Monitor", vehicle_aux_monitor_enable);
+  cmd_aux_mon->RegisterCommand("enable", "Enable Aux Monitor", vehicle_aux_monitor_enable, "[<low-threshold> [<charging-threshold>]]", 0, 2);
   cmd_aux_mon->RegisterCommand("disable", "Disable Aux Monitor", vehicle_aux_monitor_disable);
 
 


### PR DESCRIPTION
Use the 'long' average for 'Low' and 'Charging' related states.

Register the parameters for setting low / charging thresholds for the battery monitor. (Was already implemented in the command)

`vehicle aux monitor enable 11.1 14.5`
