### PR TITLE
Add ability to report short-lived low 12v conditions

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,14 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Add ability to report short-lived low 12v conditions
+  New metric:
+    v.b.12v.voltage.min  -- Minimum 12 volt value observed by OVMS hardware
+                         -- Can be tracked over time using Server v3; value is reset when transmitted
+                         -- On other systems, metric records lowest value since boot
+  New config:
+    [vehicle] 12v.low_warning_awake  -- Log a warning if 12v dips below this while the vehicle is awake
+                                     -- default 11.5
 - Nissan Leaf:
     ZE1 inital release
     Fix: Poll state not set to off when charging stopped by OVMS

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -318,6 +318,12 @@ void OvmsServerV3::TransmitMetric(OvmsMetric* metric)
   mg_mqtt_publish(m_mgconn, topic.c_str(), m_msgid++,
     MG_MQTT_QOS(0) | MG_MQTT_RETAIN, val.c_str(), val.length());
   ESP_LOGD(TAG,"Tx metric %s=%s",topic.c_str(),val.c_str());
+
+  if (metric_name.compare(MS_V_BAT_12V_VOLTAGE_MIN) == 0)
+    {
+	// We've just published min voltage, so start again
+	metric->Clear();
+    }
   }
 
 int OvmsServerV3::TransmitNotificationInfo(OvmsNotifyEntry* entry)

--- a/vehicle/OVMS.V3/main/metrics_standard.cpp
+++ b/vehicle/OVMS.V3/main/metrics_standard.cpp
@@ -106,6 +106,7 @@ MetricsStandard::MetricsStandard()
   ms_v_bat_12v_current = new OvmsMetricFloat(MS_V_BAT_12V_CURRENT, SM_STALE_HIGH, Amps);
   ms_v_bat_12v_voltage_ref = new OvmsMetricFloat(MS_V_BAT_12V_VOLTAGE_REF, SM_STALE_HIGH, Volts, true);
   ms_v_bat_12v_voltage_alert = new OvmsMetricBool(MS_V_BAT_12V_VOLTAGE_ALERT, SM_STALE_MID);
+  ms_v_bat_12v_voltage_min = new OvmsMetricFloat(MS_V_BAT_12V_VOLTAGE_MIN, SM_STALE_HIGH, Volts, true);
 
   ms_v_bat_pack_level_min = new OvmsMetricFloat(MS_V_BAT_PACK_LEVEL_MIN, SM_STALE_HIGH, Percentage);
   ms_v_bat_pack_level_max = new OvmsMetricFloat(MS_V_BAT_PACK_LEVEL_MAX, SM_STALE_HIGH, Percentage);

--- a/vehicle/OVMS.V3/main/metrics_standard.h
+++ b/vehicle/OVMS.V3/main/metrics_standard.h
@@ -104,6 +104,7 @@
 #define MS_V_BAT_12V_CURRENT        "v.b.12v.current"
 #define MS_V_BAT_12V_VOLTAGE_REF    "v.b.12v.voltage.ref"
 #define MS_V_BAT_12V_VOLTAGE_ALERT  "v.b.12v.voltage.alert"
+#define MS_V_BAT_12V_VOLTAGE_MIN    "v.b.12v.voltage.min"
 #define MS_V_BAT_TEMP               "v.b.temp"
 
 #define MS_V_BAT_PACK_LEVEL_MIN     "v.b.p.level.min"
@@ -353,6 +354,7 @@ class MetricsStandard
     OvmsMetricFloat*  ms_v_bat_12v_current;               // Auxiliary 12V battery momentary current [A]
     OvmsMetricFloat*  ms_v_bat_12v_voltage_ref;           // Auxiliary 12V battery reference voltage [V]
     OvmsMetricBool*   ms_v_bat_12v_voltage_alert;         // True = auxiliary battery under voltage alert
+    OvmsMetricFloat*  ms_v_bat_12v_voltage_min;           // Auxiliary 12V battery minimum value since last report [V]
 
     OvmsMetricFloat*  ms_v_bat_pack_level_min;            // Cell level - weakest cell in pack [%]
     OvmsMetricFloat*  ms_v_bat_pack_level_max;            // Cell level - strongest cell in pack [%]

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -2319,8 +2319,9 @@ bool OvmsMetricFloat::SetValue(const dbcNumber& value, metric_unit_t units)
 
 void OvmsMetricFloat::Clear()
   {
-  SetValue(0);
   OvmsMetric::Clear();
+  // OvmsMetric::Clear() sets value to "", so make it a float again.
+  m_value = 0.0;
   }
 
 OvmsMetricString::OvmsMetricString(const char* name, uint16_t autostale, metric_unit_t units, bool persist)


### PR DESCRIPTION
I found it very useful to be able to track the minimum 12 volt level as well as the average. The minimum is what's needed to diagnose communication DTCs where the root cause is insufficient voltage. This PR adds a metric v.b.12v.voltage.min and two ways of using it.

For all cars it can generate warning entries in the log when the car is awake and voltage is below the new config parameter 12v.low_warning_awake (default 11.5, although personally I prefer 12.0).

For those with Server v3, the metric is available to be periodically reported. To make this useful, the value is reset every time it's reported so you can track the minimum over time. It would be possible to add it to Server v2 as well, but I didn't go there as I suspect the protocol means clients need to be aware of the additional field.

I tried to make this fit the style of the surrounding code. Happy to make any changes desired, for example if it's felt there should be a Web GUI field for 12v.low_warning_awake.