### PR TITLE
Duktape add objects & commands for scripting polling lists

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -140,6 +140,14 @@ Open Vehicle Monitor System v3 - Change log
     OvmsPoller.Times.Stop
     OvmsPoller.Times.Reset
     OvmsPoller.Times.GetStatus
+    OvmsPoller.RegisterBus(bus, mode, speed, [,dbcfile])
+    OvmsPoller.PowerDown(bus)
+    OvmsPoller.Poll.Add(..)
+    OvmsPoller.Poll.Remove(..)
+    OvmsPoller.Poll.GetState([busno])
+    OvmsPoller.Poll.SetState([busno,] state)
+    OvmsPoller.Poll.Request(..)
+    OvmsPoller.Poll.SetTrace(enable)
 - Duktape support for Metric Age / Stale
   New Duktape methods
     OvmsMetrics.IsStale

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.h
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.h
@@ -391,7 +391,7 @@ class dbcMessage
     dbcSignal* FindSignal(std::string name);
     void Count(int* signals, int* bits, int* covered) const;
 
-    void DecodeSignal(const uint8_t* msg, uint8_t size, OvmsWriter* writer = nullptr) const;
+    void DecodeSignal(const uint8_t* msg, uint8_t size, bool assignMetrics = true, OvmsWriter* writer = nullptr) const;
 
   public:
     void AddComment(const std::string& comment);
@@ -483,7 +483,7 @@ class dbcfile
     void UnlockFile();
     bool IsLocked() const;
 
-    void DecodeSignal(CAN_frame_format_t format, uint32_t msg_id, const uint8_t* msg, uint8_t size, OvmsWriter* writer = nullptr) const;
+    void DecodeSignal(CAN_frame_format_t format, uint32_t msg_id, const uint8_t* msg, uint8_t size, bool assignMetrics = true, OvmsWriter* writer = nullptr) const;
   public:
     std::string m_name;
     std::string m_path;

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_http.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_http.cpp
@@ -109,7 +109,7 @@ class DuktapeHTTPRequest : public DuktapeObject
     void MongooseCallback(struct mg_connection *nc, int ev, void *ev_data);
 
   public:
-    duk_ret_t CallMethod(duk_context *ctx, const char* method, void* data=NULL);
+    duk_ret_t CallMethod(duk_context *ctx, const char* method, DuktapeCallbackParameter* params=nullptr) override;
 
   protected:
     extram::string m_url;
@@ -397,11 +397,11 @@ void DuktapeHTTPRequest::MongooseCallback(struct mg_connection *nc, int ev, void
     }
   }
 
-duk_ret_t DuktapeHTTPRequest::CallMethod(duk_context *ctx, const char* method, void* data /*=NULL*/)
+duk_ret_t DuktapeHTTPRequest::CallMethod(duk_context *ctx, const char* method, DuktapeCallbackParameter* params/*=nullptr*/)
   {
   if (!ctx)
     {
-    RequestCallback(method, data);
+    RequestCallback(method, params);
     return 0;
     }
   OvmsRecMutexLock lock(&m_mutex);

--- a/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_vfs.cpp
+++ b/vehicle/OVMS.V3/components/ovms_script/srcduk/ovms_duk_vfs.cpp
@@ -80,7 +80,7 @@ class DuktapeVFSLoad : public DuktapeObject
     static duk_ret_t Create(duk_context *ctx);
 
   public:
-    duk_ret_t CallMethod(duk_context *ctx, const char* method, void* data=NULL);
+    duk_ret_t CallMethod(duk_context *ctx, const char* method, DuktapeCallbackParameter* params=NULL) override;
 
   protected:
     static void LoadTask(void *param);
@@ -220,11 +220,11 @@ void DuktapeVFSLoad::Load()
     }
   }
 
-duk_ret_t DuktapeVFSLoad::CallMethod(duk_context *ctx, const char* method, void* data /*=NULL*/)
+duk_ret_t DuktapeVFSLoad::CallMethod(duk_context *ctx, const char* method, DuktapeCallbackParameter* params /*=NULL*/)
   {
   if (!ctx)
     {
-    RequestCallback(method, data);
+    RequestCallback(method, params);
     return 0;
     }
   OvmsRecMutexLock lock(&m_mutex);
@@ -341,7 +341,7 @@ class DuktapeVFSSave : public DuktapeObject
     static duk_ret_t Create(duk_context *ctx);
 
   public:
-    duk_ret_t CallMethod(duk_context *ctx, const char* method, void* data=NULL);
+    duk_ret_t CallMethod(duk_context *ctx, const char* method, DuktapeCallbackParameter* params = nullptr);
 
   protected:
     static void SaveTask(void *param);
@@ -520,11 +520,11 @@ void DuktapeVFSSave::Save()
     }
   }
 
-duk_ret_t DuktapeVFSSave::CallMethod(duk_context *ctx, const char* method, void* data /*=NULL*/)
+duk_ret_t DuktapeVFSSave::CallMethod(duk_context *ctx, const char* method, DuktapeCallbackParameter* params /*=NULL*/)
   {
   if (!ctx)
     {
-    RequestCallback(method, data);
+    RequestCallback(method, params);
     return 0;
     }
   OvmsRecMutexLock lock(&m_mutex);

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -252,6 +252,8 @@ class OvmsPoller : public InternalRamAllocated {
       std::shared_ptr<PollSeriesEntry> series;
 
       bool is_blocking;
+      OvmsPoller::OvmsNextPollResult last_status;
+      uint32_t last_status_monotonic;
 
       struct poll_series_st *prev, *next;
       } poll_series_t;
@@ -324,6 +326,9 @@ class OvmsPoller : public InternalRamAllocated {
          */
         bool HasRepeat() const;
 
+        /** CLI Status.
+         */
+        void Status(int verbosity, OvmsWriter* writer);
       };
 
     /** Standard series.
@@ -710,6 +715,8 @@ class OvmsPoller : public InternalRamAllocated {
     static const char *PollerCommand(OvmsPollCommand src, bool brief=false);
     static const char *PollerSource(poller_source_t src);
     static const char *PollResultCodeName(int code);
+
+   void PollerStatus(int verbosity, OvmsWriter* writer);
   friend class OvmsPollers;
 };
 

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller.h
@@ -208,6 +208,9 @@ class OvmsPoller : public InternalRamAllocated {
         /// Set the parent poller
         virtual void SetParentPoller(OvmsPoller *poller) = 0;
 
+        /// Destructed by pointer.
+        virtual ~PollSeriesEntry() { }
+
         /** Move list to start.
           * @arg  mode Specify Resetting for Poll-Start or for Retry
           */
@@ -437,7 +440,7 @@ class OvmsPoller : public InternalRamAllocated {
         poll_pid_t m_poll; // Poll Entry
         std::string *m_poll_rxbuf;    // … response buffer
         int         *m_poll_rxerr;    // … response error code (NRC) / TX failure code
-        uint8_t     m_retry_fail;
+        int16_t     m_retry_fail;
         CAN_frame_format_t m_format;
 
         // Called when the one-off is finished (for semaphore etc).
@@ -445,7 +448,7 @@ class OvmsPoller : public InternalRamAllocated {
         virtual void Done(bool success);
 
         void SetPollPid( uint32_t txid, uint32_t rxid, const std::string &request, uint8_t protocol=ISOTP_STD, uint8_t pollbus = 0, uint16_t polltime = 1);
-        void SetPollPid( uint32_t txid, uint32_t rxid, uint8_t polltype, uint16_t pid,  uint8_t protocol=ISOTP_STD, uint8_t pollbus = 0, uint16_t polltime = 1);
+        void SetPollPid( uint32_t txid, uint32_t rxid, uint8_t polltype, uint16_t pid,  uint8_t protocol, const std::string &request, uint8_t pollbus = 0, uint16_t polltime = 1);
       public:
         OnceOffPollBase(const poll_pid_t &pollentry, std::string *rxbuf, int *rxerr, uint8_t retry_fail = 0);
         OnceOffPollBase(std::string *rxbuf, int *rxerr, uint8_t retry_fail = 0);
@@ -502,6 +505,7 @@ class OvmsPoller : public InternalRamAllocated {
         poll_fail_func m_fail;
         std::string m_data;
         int m_error;
+        bool m_result_sent;
 
         void Done(bool success) override;
       public:
@@ -509,6 +513,8 @@ class OvmsPoller : public InternalRamAllocated {
             uint32_t txid, uint32_t rxid, const std::string &request, uint8_t protocol=ISOTP_STD, uint8_t pollbus = 0, uint8_t retry_fail = 0);
         OnceOffPoll(poll_success_func success, poll_fail_func fail,
             uint32_t txid, uint32_t rxid, uint8_t polltype, uint16_t pid,  uint8_t protocol=ISOTP_STD, uint8_t pollbus = 0, uint8_t retry_fail = 0);
+        OnceOffPoll(poll_success_func success, poll_fail_func fail,
+            uint32_t txid, uint32_t rxid, uint8_t polltype, uint16_t pid,  uint8_t protocol, const std::string &request, uint8_t pollbus = 0, uint8_t retry_fail = 0);
 
         // Called when run is finished to determine what happens next.
         SeriesStatus FinishRun() override;
@@ -806,6 +812,9 @@ class OvmsPollers : public InternalRamAllocated {
     static duk_ret_t DukOvmsPollerPollSetState(duk_context *ctx);
     // OvmsPoller.Poll.SetTrace
     static duk_ret_t DukOvmsPollerPollSetTrace(duk_context *ctx);
+
+    // OvmsPoller.Poll.Request
+    static duk_ret_t DukOvmsPollerPollRequest(duk_context *ctx);
 
   public:
     static void Duk_GetRequestFromObject( duk_context *ctx, duk_idx_t obj_idx,

--- a/vehicle/OVMS.V3/components/poller/src/vehicle_poller_isotp.cpp
+++ b/vehicle/OVMS.V3/components/poller/src/vehicle_poller_isotp.cpp
@@ -227,18 +227,27 @@ bool OvmsPoller::PollerISOTPReceive(CAN_frame_t* frame, uint32_t msgid)
       tp_len = fr_data[0] & 0x0f;
       tp_data = &fr_data[1];
       tp_datalen = tp_len;
+
+      m_poll.raw_data = tp_data;
+      m_poll.raw_data_len = tp_datalen;
       break;
     case ISOTP_FT_FIRST:
       tp_frameindex = 0;
       tp_len = (fr_data[0] & 0x0f) << 8 | fr_data[1];
       tp_data = &fr_data[2];
       tp_datalen = (tp_len > fr_maxlen-2) ? fr_maxlen-2 : tp_len;
+
+      m_poll.raw_data = tp_data;
+      m_poll.raw_data_len = tp_datalen;
       break;
     case ISOTP_FT_CONSECUTIVE:
       tp_frameindex = fr_data[0] & 0x0f;
       tp_len = m_poll.mlremain;
       tp_data = &fr_data[1];
       tp_datalen = (tp_len > fr_maxlen-1) ? fr_maxlen-1 : tp_len;
+
+      m_poll.raw_data = tp_data;
+      m_poll.raw_data_len = tp_datalen;
       break;
     case ISOTP_FT_FLOWCTRL:
       tp_fc_command  = fr_data[0] & 0x0f;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -2525,6 +2525,18 @@ void OvmsVehicle::PollSetState(uint8_t state, canbus* bus)
   }
 
 #ifdef CONFIG_OVMS_COMP_POLLER
+int OvmsVehicle::PollSingleRequest(canbus*  bus, uint32_t txid, uint32_t rxid,
+                  uint8_t polltype, uint16_t pid, const std::string &payload, std::string& response,
+                  int timeout_ms, uint8_t protocol)
+  {
+  if (!m_ready)
+    return POLLSINGLE_TXFAILURE;
+  auto poller = MyPollers.GetPoller(bus, true);
+  if (!poller)
+    return POLLSINGLE_TXFAILURE;
+  return poller->PollSingleRequest(txid, rxid, polltype, pid, payload, response, timeout_ms, protocol);
+  }
+
 int OvmsVehicle::PollSingleRequest(canbus* bus, uint32_t txid, uint32_t rxid,
                 std::string request, std::string& response,
                 int timeout_ms, uint8_t protocol)

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -272,6 +272,9 @@ class OvmsVehicle : public InternalRamAllocated
       }
     OvmsPoller::VehicleSignal *GetPollerSignal();
 
+    int PollSingleRequest(canbus*  bus, uint32_t txid, uint32_t rxid,
+                      uint8_t polltype, uint16_t pid, const std::string &payload, std::string& response,
+                      int timeout_ms=3000, uint8_t protocol=ISOTP_STD);
     int PollSingleRequest(canbus* bus, uint32_t txid, uint32_t rxid,
                       std::string request, std::string& response,
                       int timeout_ms=3000, uint8_t protocol=ISOTP_STD);

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_duktape.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_duktape.cpp
@@ -380,16 +380,18 @@ duk_ret_t OvmsVehicleFactory::DukOvmsVehicleStopCooldown(duk_context *ctx)
 
 
 /**
- * DukOvmsVehicleObdRequest: OBD/UDS PollSingleRequest wrapper (synchronous)
+ * DukOvmsVehicleObdRequest: OBD/UDS PollSingleRequest wrapper (synchronous).
  * 
  * Javascript API:
  *    var obdResult = OvmsVehicle.ObdRequest({
  *      txid: <int>,
  *      rxid: <int>,
- *      request: <string>|<Uint8Array>,   // hex encoded string or binary byte array
- *      [bus: <string>,]                  // default: "can1"
- *      [timeout: <int>,]                 // in ms, default: 3000
- *      [protocol: <int>,]                // default: 0 = ISOTP_STD, see vehicle.h
+ *      [bus: <string>,]    // default: "can1"
+ *      [timeout: <int>,]   // in ms, default: 3000
+ *      [protocol: <int>,]  // default: 0 = ISOTP_STD, see vehicle_common.h
+ *      [pid: <int>,]       // PID (otherwise embedded in request with type)
+ *      [type: <int>,]      // Package type (defaults to READDATA type 0x22 if pid specified)
+ *      [request: <string>|<Uint8Array>,]  // hex encoded string or binary byte array
  *    });
  * 
  *    obdResult = {
@@ -402,17 +404,9 @@ duk_ret_t OvmsVehicleFactory::DukOvmsVehicleStopCooldown(duk_context *ctx)
 duk_ret_t OvmsVehicleFactory::DukOvmsVehicleObdRequest(duk_context *ctx)
   {
   DukContext dc(ctx);
-
   int error = 0;
   std::string errordesc;
-  std::string bus = "can1";
-  uint32_t txid = 0, rxid = 0;
-  std::string request, response;
-  int timeout = 3000;
-#ifdef CONFIG_OVMS_COMP_POLLER
-  uint8_t protocol = ISOTP_STD;
-#endif
-
+  std::string response;
   if (!MyVehicleFactory.m_currentvehicle)
     {
     error = -1000;
@@ -423,65 +417,32 @@ duk_ret_t OvmsVehicleFactory::DukOvmsVehicleObdRequest(duk_context *ctx)
     error = -1001;
     errordesc = "No request object given";
     }
+#ifndef CONFIG_OVMS_COMP_POLLER
   else
     {
-    // Read arguments:
-    if (duk_get_prop_string(ctx, 0, "bus"))
-      bus = duk_to_string(ctx, -1);
-    duk_pop(ctx);
-    if (duk_get_prop_string(ctx, 0, "timeout"))
-      timeout = duk_to_int(ctx, -1);
-    duk_pop(ctx);
-#ifdef CONFIG_OVMS_COMP_POLLER
-    if (duk_get_prop_string(ctx, 0, "protocol"))
-      protocol = duk_to_int(ctx, -1);
-#endif
-    duk_pop(ctx);
-    if (duk_get_prop_string(ctx, 0, "txid"))
-      txid = duk_to_int(ctx, -1);
-    else
-      error = -1002;
-    duk_pop(ctx);
-    if (duk_get_prop_string(ctx, 0, "rxid"))
-      rxid = duk_to_int(ctx, -1);
-    else
-      error = -1002;
-    duk_pop(ctx);
-    if (duk_get_prop_string(ctx, 0, "request"))
-      {
-      if (duk_is_buffer_data(ctx, -1))
-        {
-        size_t size;
-        void *data = duk_get_buffer_data(ctx, -1, &size);
-        request.resize(size, '\0');
-        memcpy(&request[0], data, size);
-        }
-      else
-        {
-        request = hexdecode(duk_to_string(ctx, -1));
-        }
-      }
-    duk_pop(ctx);
+    error = -1;
+    errordesc = "Polling not implemented";
+    }
+#else
+  else
+    {
+    uint32_t txid, rxid;
+    uint8_t protocol;
+    std::string request;
+    int timeout;
+    uint16_t pid;
+    uint16_t type;
+    canbus* device;
 
-    // Validate arguments:
-    canbus* device = (canbus*)MyPcpApp.FindDeviceByName(bus.c_str());
-    if (error != 0)
-      {
-      errordesc = "Missing mandatory argument";
-      }
-    else if (device == NULL || (txid <= 0 || (txid != 0x7df && rxid <= 0) ||
-        request.size() == 0) || timeout <= 0)
-      {
-      error = -1003;
-      errordesc = "Invalid argument";
-      }
+    // Retrieve parameters
+    OvmsPollers::Duk_GetRequestFromObject(ctx, 0, "can1", true, device,
+        txid, rxid, protocol, type, pid, request, timeout, error, errordesc);
 
     // Execute request:
     if (error == 0)
       {
-#ifdef CONFIG_OVMS_COMP_POLLER
       error = MyVehicleFactory.m_currentvehicle->PollSingleRequest(
-        device, txid, rxid, request, response, timeout, protocol);
+        device, txid, rxid, type, pid, request, response, timeout, protocol);
 
       if (error == POLLSINGLE_TXFAILURE)
         errordesc = "Transmission failure (CAN bus error)";
@@ -497,12 +458,9 @@ duk_ret_t OvmsVehicleFactory::DukOvmsVehicleObdRequest(duk_context *ctx)
           errordesc += errname;
           }
         }
-#else
-      error = -1;
-      errordesc = "Polling not implemented";
-#endif
       }
     }
+#endif
 
   // Push result object:
   duk_idx_t obj_idx = dc.PushObject();


### PR DESCRIPTION
This series of commits adds various objects and commands for dealing with the bus and polled lists from a Duktape script.

It adds: 
* basic Bus management (Register/PowerDown) 
* Adding(/Removing) a poll list to the system poller.
  * The list is represented by a series of 'send' / 'decode' functions
  * The decode functionality leverages the already existing DBC decoding. Either by
    * Transferring a version of the packet consistent with DBC multi-packet decoding to an existing loaded dbc file
    * Create an internal dbc decoding structure that decodes against the payload-only version of the multi-packet ISOTP.  The fact that the DBC decoding is used internally is not important (only in that it avoids duplication).
 * Various actions to control the poll state.
 * Support for once-off polls with a Duktape call-back. 