### PR TITLE
NL: 2012 - Fix missing max_gids from config and battery capacity derrived from it

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1446,6 +1446,13 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
             if (MyConfig.GetParamValueBool("xnl", "soc.newcar", false))
               {
               StandardMetrics.ms_v_bat_soc->SetValue(soc_new_car);
+
+              // 2012 Leaf has no instrument soc, battery capacity and max gids will be set from config, because it is not available on CAN
+              if (MyConfig.GetParamValueInt("xnl", "modelyear", DEFAULT_MODEL_YEAR) == 2012) 
+                {
+                m_max_gids->SetValue(max_gids);
+                m_battery_energy_capacity->SetValue(max_gids * GEN_1_WH_PER_GID, WattHours);
+                }
               }
             }
             break;


### PR DESCRIPTION
The old Leaf from 2012 has no "User SOC" (aka instrument/dashboard SOC) nor max_gid value from BMS at least for now, so socnewcar in config settings must be used to set the real max gid value, to get a calculated SoC from this. 
But max_gids custom metric and battery capacity will never be set, because CAN message for battery detecting is missing. So if socnewcar is choosen the max_gids metric and battery capacity will be set from config. 

This enables ranges calculation otherwise all three values stay at zero.