### PR TITLE
Update vehicle.cpp

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -360,6 +360,7 @@ OvmsVehicle::OvmsVehicle()
 #ifdef CONFIG_OVMS_COMP_POLLER
   m_poll_state = 0;
   m_pollsignal = nullptr;
+  m_poll_bus_default = nullptr;
 
   // Poll parameters.
   PollSetThrottling(1);


### PR DESCRIPTION
Added missing m_poll_bus_default initialization.
MG models are no longer crashing on boot.