### PR TITLE
Nissan LEAF: improve v.p.speed accuracy and precision

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
@@ -78,6 +78,7 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   bool ze1;
   std::string modelyear;
   std::string cabintempoffset;
+  std::string speeddivisor;
   std::string maxgids;
   std::string newcarah;
   std::string cfg_ev_request_port;
@@ -86,13 +87,14 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     // process form submission:
     modelyear           = c.getvar("modelyear");
     cabintempoffset     = c.getvar("cabintempoffset");
+    speeddivisor        = c.getvar("speeddivisor");
     cfg_ev_request_port = c.getvar("cfg_ev_request_port");
     maxgids             = c.getvar("maxgids");
     newcarah            = c.getvar("newcarah");
     socnewcar           = (c.getvar("socnewcar") == "yes");
     sohnewcar           = (c.getvar("sohnewcar") == "yes");
     canwrite            = (c.getvar("canwrite") == "yes");
-    ze1                = (c.getvar("ze1") == "yes");
+    ze1                 = (c.getvar("ze1") == "yes");
 
     // check:
     if (!modelyear.empty()) {
@@ -105,6 +107,10 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
       error += "<li data-input=\"cabintempoffset\">Cabin Temperature Offset can not be empty</li>";
     }
 
+    if (speeddivisor.empty()) {
+      error += "<li data-input=\"speeddivisor\">Speed Divisor cannot be empty</li>";
+    }
+
     if (cfg_ev_request_port.empty()) {
       error += "<li data-input=\"cfg_ev_request_port\">EV SYSTEM ACTIVATION REQUEST Pin field cannot be empty</li>";
     }
@@ -113,6 +119,7 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
       // store:
       MyConfig.SetParamValue("xnl", "modelyear", modelyear);
       MyConfig.SetParamValue("xnl", "cabintempoffset", cabintempoffset);
+      MyConfig.SetParamValue("xnl", "speeddivisor", speeddivisor);
       MyConfig.SetParamValue("xnl", "cfg_ev_request_port", cfg_ev_request_port);
       MyConfig.SetParamValue("xnl", "maxGids",   maxgids);
       MyConfig.SetParamValue("xnl", "newCarAh",  newcarah);
@@ -137,13 +144,14 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     // read configuration:
     modelyear           = MyConfig.GetParamValue("xnl", "modelyear", STR(DEFAULT_MODEL_YEAR));
     cabintempoffset     = MyConfig.GetParamValue("xnl", "cabintempoffset", STR(DEFAULT_CABINTEMP_OFFSET));
+    speeddivisor        = MyConfig.GetParamValue("xnl", "speeddivisor", STR(DEFAULT_SPEED_DIVISOR));
     cfg_ev_request_port = MyConfig.GetParamValue("xnl", "cfg_ev_request_port", STR(DEFAULT_PIN_EV));
     maxgids             = MyConfig.GetParamValue("xnl", "maxGids", STR(GEN_1_NEW_CAR_GIDS));
     newcarah            = MyConfig.GetParamValue("xnl", "newCarAh", STR(GEN_1_NEW_CAR_AH));
     socnewcar           = MyConfig.GetParamValueBool("xnl", "soc.newcar", false);
     sohnewcar           = MyConfig.GetParamValueBool("xnl", "soh.newcar", false);
     canwrite            = MyConfig.GetParamValueBool("xnl", "canwrite", false);
-    ze1                = MyConfig.GetParamValueBool("xnl", "ze1", false);
+    ze1                 = MyConfig.GetParamValueBool("xnl", "ze1", false);
 
     c.head(200);
   }
@@ -175,6 +183,10 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input("number", "Cabin Temperature Offset", "cabintempoffset", cabintempoffset.c_str(), "Default: " STR(DEFAULT_CABINTEMP_OFFSET),
       "<p>This allows an offset adjustment to the cabin temperature sensor readings in Celcius.</p>",
       "step=\"0.1\"", "");
+  c.input("number", "Speed Divisor", "speeddivisor", speeddivisor.c_str(), "Default: " STR(DEFAULT_SPEED_DIVISOR),
+      "<p>This allows the speed readings to be adjusted (which also affects the trip odometer), e.g. if wheel diameter has changed. This can be estimated by comparing trip odometer to GPS track distance.</p>"
+      "<p>The resulting speed will be much lower than the speedometer speed, as the speedometer display is deliberately set ~10% higher.</p>",
+      "min=\"1\" step=\"1\"", "");
   c.fieldset_end();
 
   c.fieldset_start("Remote Control");

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1079,7 +1079,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       // allowing us to use it for deriving accurate trip odometer distances
 
       // verified by comparing derived trip odometer value with two ~20km GPS tracks
-      StandardMetrics.ms_v_pos_speed->SetValue(car_speed16 / 98);
+      StandardMetrics.ms_v_pos_speed->SetValue((float) car_speed16 / 98);
     }
       break;
     case 0x380:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1069,9 +1069,17 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       uint16_t car_speed16 = d[4];
       car_speed16 = car_speed16 << 8;
       car_speed16 = car_speed16 | d[5];
-      // this ratio determined by comparing with the dashboard speedometer
-      // it is approximately correct and converts to km/h on my car with km/h speedo
-      StandardMetrics.ms_v_pos_speed->SetValue(car_speed16 / 92);
+      // old ratio was 1/92, previously approximated by comparison with dashboard speedo.
+      // however, this figure appears to be ~4-4.5% lower than the speedometer speed, AND the
+      // speedometer speed is itself 10% higher than the actual speed reported by OBD-II standard
+      // PIDs and GPS speed (probably due to regulations allowing speedo speed to be up to 10%
+      // higher but not any lower than actual speed)
+
+      // dividing this value by 98 makes it approximately match OBD-II and GPS reported speeds,
+      // allowing us to use it for deriving accurate trip odometer distances
+
+      // verified by comparing derived trip odometer value with two ~20km GPS tracks
+      StandardMetrics.ms_v_pos_speed->SetValue(car_speed16 / 98);
     }
       break;
     case 0x380:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -325,6 +325,7 @@ void OvmsVehicleNissanLeaf::ConfigChanged(OvmsConfigParam* param)
   cfg_allowed_rangedrop     = MyConfig.GetParamValueInt("xnl", "rangedrop", DEFAULT_RANGEDROP);
   cfg_allowed_socdrop       = MyConfig.GetParamValueInt("xnl", "socdrop", DEFAULT_SOCDROP);
   cfg_enable_autocharge     = MyConfig.GetParamValueBool("xnl", "autocharge", DEFAULT_AUTOCHARGE_ENABLED);
+  cfg_speed_divisor         = MyConfig.GetParamValueFloat("xnl", "speeddivisor", DEFAULT_SPEED_DIVISOR);
 
 
   //TODO nl_enable_write = MyConfig.GetParamValueBool("xnl", "canwrite", false);
@@ -1079,7 +1080,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       // allowing us to use it for deriving accurate trip odometer distances
 
       // verified by comparing derived trip odometer value with two ~20km GPS tracks
-      StandardMetrics.ms_v_pos_speed->SetValue((float) car_speed16 / 98);
+      StandardMetrics.ms_v_pos_speed->SetValue((float) car_speed16 / cfg_speed_divisor);
     }
       break;
     case 0x380:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -51,6 +51,7 @@
 #define DEFAULT_RANGEDROP 0
 #define DEFAULT_SOCDROP 0
 #define DEFAULT_AUTOCHARGE_ENABLED true
+#define DEFAULT_SPEED_DIVISOR 98.0
 #define GEN_1_NEW_CAR_GIDS 281
 #define GEN_1_NEW_CAR_AH 66
 #define GEN_1_KM_PER_KWH 7.1
@@ -234,6 +235,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     bool   cfg_ze1;                                     // Enable/disable ZE1 specific features
     bool   cfg_soh_newcar;                              // True if SOH is calculated from new car max ah, false if from BMS
     string cfg_limit_range_calc;                        // What range calc to use for charge to range feature
+    float  cfg_speed_divisor;                           // Divisor used for dividing raw speed value received from can1 0x284 msg
 
     int     m_MITM = 0;
     float   m_cum_energy_used_wh;				    // Cumulated energy (in wh) used within 1 second ticker interval


### PR DESCRIPTION
two changes:
- update divisor for calculating actual km/h speed value from can1 0x284 message
- cast uint16_t raw speed value to float before dividing (to avoid dropping the decimal part of the speed value)

---

the new divisor for calculating km/h speed value was validated by eyeballing the standard OBD-II PID for vehicle speed from Car Scanner and comparing it with a custom OVMS dashboard with `v.p.gpsspeed` and `v.p.speed` on a straight, flat road with cruise control on.

it *is* significantly lower (by approx 10%) compared to the speedometer speed, but this is likely due to Nissan (and many others) deliberately overstating speedo speed to comply with [UNECE Regulation No.39](https://unece.org/sites/default/files/2024-04/GRSG-127-12e.pdf) (see point 5.4 on page 8).

the vehicle itself is aware of the true speed as well (as evidenced by the OBD-II PID readings), so i believe it may be more reasonable to have `v.p.speed` reflect true speed instead of speedometer speed

this will also allow us to derive an accurate trip odometer value based on speed (like what's being done for the MG EVs) that matches the vehicle odometer