### PR TITLE
Nissan LEAF: derive v.pos.trip from speed

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -176,6 +176,8 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     void PollReply_BMS_Shunt(const uint8_t *reply_data, uint16_t reply_len);
     void PollReply_BMS_Temp(const uint8_t *reply_data, uint16_t reply_len);
     void PollReply_BMS_SOH(const uint8_t *reply_data, uint16_t reply_len);
+    void ResetTripCounters();
+    void UpdateTripCounters();
 
     TimerHandle_t m_remoteCommandTimer;
     TimerHandle_t m_ccDisableTimer;
@@ -237,14 +239,17 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     string cfg_limit_range_calc;                        // What range calc to use for charge to range feature
     float  cfg_speed_divisor;                           // Divisor used for dividing raw speed value received from can1 0x284 msg
 
-    int     m_MITM = 0;
-    float   m_cum_energy_used_wh;				    // Cumulated energy (in wh) used within 1 second ticker interval
-    float   m_cum_energy_recd_wh; 					// Cumulated energy (in wh) recovered  within 1 second ticker interval
-    float   m_cum_energy_charge_wh;					// Cumulated energy (in wh) charged within 10 second ticker interval
-    float   m_cum_energy_gen_wh;					  // Cumulated energy (in wh) exported within 10 second ticker interval
-    bool    m_ZE0_charger;					        // True if 2011-2012 ZE0 LEAF with 0x380 message (Gen 1)
-	  bool    m_AZE0_charger;							    // True if 2013+ AZE0 LEAF with 0x390 message (Gen 2)
-    bool    m_climate_really_off;           // Needed for AZE0 to shown correct hvac status while charging
+    int         m_MITM = 0;
+    double      m_trip_odo;                             // trip distance estimated from speed
+    uint32_t    m_trip_last_upd_time;                  // timestamp as of last trip counter update
+    float       m_trip_last_upd_speed;                 // speed as of last trip counter update
+    float       m_cum_energy_used_wh;                   // Cumulated energy (in wh) used within 1 second ticker interval
+    float       m_cum_energy_recd_wh;                   // Cumulated energy (in wh) recovered  within 1 second ticker interval
+    float       m_cum_energy_charge_wh;                 // Cumulated energy (in wh) charged within 10 second ticker interval
+    float       m_cum_energy_gen_wh;                    // Cumulated energy (in wh) exported within 10 second ticker interval
+    bool        m_ZE0_charger;                          // True if 2011-2012 ZE0 LEAF with 0x380 message (Gen 1)
+    bool        m_AZE0_charger;                         // True if 2013+ AZE0 LEAF with 0x390 message (Gen 2)
+    bool        m_climate_really_off;                   // Needed for AZE0 to shown correct hvac status while charging
 
     OvmsPoller::poll_pid_t* obdii_polls;
 


### PR DESCRIPTION
probably best used with #1144 for accurate trip odometer values

this is basically the same as what's being done for the MG EVs, and appears to be reasonably accurate (+/- 1%) when comparing to GPS tracks (recorded on a phone, dual-band GNSS, 1Hz, ~45km across 3 tracks). of course, this depends on having accurate speed measurements, hence #1144 