### PR TITLE
fix(ovms_cellular): update `m.net.good.sq` in `UpdateNetMetrics()`

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -1723,17 +1723,8 @@ void modem::SetSignalQuality(int newsq)
     {
     m_sq = newsq;
     ESP_LOGD(TAG, "Signal Quality is: %d (%d dBm)", m_sq, UnitConvert(sq, dbm, m_sq));
-    float current_dbm = UnitConvert(sq, dbm, m_sq);
     StdMetrics.ms_m_net_mdm_sq->SetValue(m_sq, sq);
-    if (StdMetrics.ms_m_net_type->AsString() == "modem")
-      {
-      StdMetrics.ms_m_net_sq->SetValue(m_sq, sq);
-      if (m_good_signal && current_dbm < m_bad_dbm)
-        m_good_signal = false;
-      if (!m_good_signal && current_dbm > m_good_dbm)
-        m_good_signal = true;
-      StdMetrics.ms_m_net_good_sq->SetValue(m_good_signal);
-      }
+    UpdateNetMetrics();
     }
   }
 
@@ -1763,6 +1754,12 @@ void modem::UpdateNetMetrics()
     {
     StdMetrics.ms_m_net_provider->SetValue(m_provider);
     StdMetrics.ms_m_net_sq->SetValue(m_sq, sq);
+    float current_dbm = UnitConvert(sq, dbm, m_sq);
+    if (m_good_signal && current_dbm < m_bad_dbm)
+      m_good_signal = false;
+    if (!m_good_signal && current_dbm > m_good_dbm)
+      m_good_signal = true;
+    StdMetrics.ms_m_net_good_sq->SetValue(m_good_signal);
     }
   }
 


### PR DESCRIPTION
this fixes a bug where:
- `m.net.type` starts off as "none", before modem IP link is up
- modem manages to register, and we get an AT+CSQ response w/ the signal strength
- `modem::SetSignalQuality()` is called, but `m.net.sq`/`m.net.good.sq` is not updated because `m.net.type` is not "modem" (yet)
- modem IP link comes up, `m.net.type` gets set to "modem", `modem::UpdateNetMetrics()` gets called
- but `m.net.good.sq` is not updated if signal strength doesn't change (caused by `m_sq != newsq` check in `modem::SetSignalQuality()`)
- until signal strength or network type changes to "wifi", `m.net.good.sq` will remain undefined

in this scenario, if the signal strength stays the same for an extended period of time, then `m.net.good.sq` will remain undefined, causing Server v3 to not connect until the signal strength changes.

Server v2 is not affected because it does not have `m.net.good.sq` as a prerequisite for connecting