### PR TITLE
fix(ovms_server_v3): don't check for m.net.good.sq as a prerequisite for connecting to MQTT broker

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -902,8 +902,7 @@ void OvmsServerV3::NetmanStop(std::string event, void* data)
 void OvmsServerV3::Ticker1(std::string event, void* data)
   {
   m_connection_available = StdMetrics.ms_m_net_connected->AsBool() &&
-                              StdMetrics.ms_m_net_ip->AsBool() &&
-                              StdMetrics.ms_m_net_good_sq->AsBool();
+                              StdMetrics.ms_m_net_ip->AsBool();
   if (!m_connection_available && m_mgconn)
     {
     Disconnect();


### PR DESCRIPTION
prevents users from accidentally locking themselves out, if they can only connect via MQTT

(e.g. no Server v2/WiFi/etc access, and they cannot access the module physically)

fixes #1150 (maybe?), but I'm not sure if there's any other reason we might want to keep this check