### PR TITLE
Set CAN transceiver active/listen-only mode according to CAN bus mode

### DIFF
--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.h
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.h
@@ -116,7 +116,8 @@ class esp32can : public canbus
   public:
     void SetPowerMode(PowerMode powermode);
     bool GetErrorFlagsDesc(std::string &buffer, uint32_t error_flags) override;
-
+    void SetTransceiverMode(bool isactive);
+ 
   public:
     static void shell_setaccfilter(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
 

--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.h
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.h
@@ -116,7 +116,7 @@ class esp32can : public canbus
   public:
     void SetPowerMode(PowerMode powermode);
     bool GetErrorFlagsDesc(std::string &buffer, uint32_t error_flags) override;
-    void SetTransceiverMode(bool isactive);
+    void SetTransceiverMode(CAN_mode_t mode);
  
   public:
     static void shell_setaccfilter(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -105,6 +105,7 @@ if (m_spibus->m_initialized == false) {
   m_canctrl_mode = CANCTRL_MODE_CONFIG; // MCP2515 mode after reset
   m_powermode = Off; // Stop an event being raised
   SetPowerMode(Off);
+  SetTransceiverMode(false);
 
   // Register mcp2515 specific commands:
   OvmsCommand* cmd_can = MyCommandApp.RegisterCommand("can", "CAN framework");
@@ -120,6 +121,7 @@ if (m_spibus->m_initialized == false) {
 
 mcp2515::~mcp2515()
   {
+  SetTransceiverMode(false);
   gpio_isr_handler_remove((gpio_num_t)m_intpin);
   spi_bus_remove_device(m_spi);
   }
@@ -186,8 +188,7 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
   // Rx Buffer 0 control (receive all and enable buffer 1 rollover)
   WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01101101);
 
-  // BFPCTRL RXnBF PIN CONTROL AND STATUS
-  WriteRegAndVerify(REG_BFPCTRL, 0b00001100);
+  SetTransceiverMode(mode == CAN_MODE_ACTIVE);
 
   // Bus speed
   uint8_t cnf1 = 0;
@@ -311,8 +312,7 @@ esp_err_t mcp2515::Stop()
   m_spibus->spi_cmd(m_spi, buf, 0, 1, CMD_RESET);
   vTaskDelay(50 / portTICK_PERIOD_MS);
 
-  // BFPCTRL RXnBF PIN CONTROL AND STATUS
-  WriteRegAndVerify(REG_BFPCTRL, 0b00111100);
+  SetTransceiverMode(false);
 
   // Set SLEEP mode
   ChangeMode(CANCTRL_MODE_SLEEP);
@@ -816,6 +816,19 @@ void mcp2515::SetPowerMode(PowerMode powermode)
     }
   }
 
+void mcp2515::SetTransceiverMode(bool isactive)
+  {
+  if ( isactive ) 
+  {
+    // BFPCTRL RXnBF PIN CONTROL AND STATUS - enable TX driver of SN65 - rd/wr mode
+    WriteRegAndVerify(REG_BFPCTRL, 0b00001100);
+  } 
+  else
+  {
+    // BFPCTRL RXnBF PIN CONTROL AND STATUS - disable TX driver of SN65 - listen only mode
+    WriteRegAndVerify(REG_BFPCTRL, 0b00111100);
+  }
+  }
 
 /**
  * GetErrorFlagsDesc: decode error flags into human readable text

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -105,7 +105,7 @@ if (m_spibus->m_initialized == false) {
   m_canctrl_mode = CANCTRL_MODE_CONFIG; // MCP2515 mode after reset
   m_powermode = Off; // Stop an event being raised
   SetPowerMode(Off);
-  SetTransceiverMode(false);
+  SetTransceiverMode(CAN_MODE_LISTEN);
 
   // Register mcp2515 specific commands:
   OvmsCommand* cmd_can = MyCommandApp.RegisterCommand("can", "CAN framework");
@@ -121,7 +121,7 @@ if (m_spibus->m_initialized == false) {
 
 mcp2515::~mcp2515()
   {
-  SetTransceiverMode(false);
+  SetTransceiverMode(CAN_MODE_LISTEN);
   gpio_isr_handler_remove((gpio_num_t)m_intpin);
   spi_bus_remove_device(m_spi);
   }
@@ -188,7 +188,7 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
   // Rx Buffer 0 control (receive all and enable buffer 1 rollover)
   WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01101101);
 
-  SetTransceiverMode(mode == CAN_MODE_ACTIVE);
+  SetTransceiverMode(mode);
 
   // Bus speed
   uint8_t cnf1 = 0;
@@ -312,7 +312,7 @@ esp_err_t mcp2515::Stop()
   m_spibus->spi_cmd(m_spi, buf, 0, 1, CMD_RESET);
   vTaskDelay(50 / portTICK_PERIOD_MS);
 
-  SetTransceiverMode(false);
+  SetTransceiverMode(CAN_MODE_LISTEN);
 
   // Set SLEEP mode
   ChangeMode(CANCTRL_MODE_SLEEP);
@@ -816,18 +816,18 @@ void mcp2515::SetPowerMode(PowerMode powermode)
     }
   }
 
-void mcp2515::SetTransceiverMode(bool isactive)
+void mcp2515::SetTransceiverMode(CAN_mode_t mode)
   {
-  if ( isactive ) 
-  {
-    // BFPCTRL RXnBF PIN CONTROL AND STATUS - enable TX driver of SN65 - rd/wr mode
-    WriteRegAndVerify(REG_BFPCTRL, 0b00001100);
-  } 
+  if ( mode == CAN_MODE_ACTIVE ) 
+    {
+      // BFPCTRL RXnBF PIN CONTROL AND STATUS - enable TX driver of SN65 - rd/wr mode
+      WriteRegAndVerify(REG_BFPCTRL, 0b00001100);
+    } 
   else
-  {
-    // BFPCTRL RXnBF PIN CONTROL AND STATUS - disable TX driver of SN65 - listen only mode
-    WriteRegAndVerify(REG_BFPCTRL, 0b00111100);
-  }
+    {
+      // BFPCTRL RXnBF PIN CONTROL AND STATUS - disable TX driver of SN65 - listen only mode
+      WriteRegAndVerify(REG_BFPCTRL, 0b00111100);
+    }
   }
 
 /**

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
@@ -94,7 +94,7 @@ class mcp2515 : public canbus
   public:
     void SetPowerMode(PowerMode powermode);
     bool GetErrorFlagsDesc(std::string &buffer, uint32_t error_flags) override;
-    void SetTransceiverMode(bool isactive);
+    void SetTransceiverMode(CAN_mode_t mode);
 
   public:
     static void shell_setaccfilter(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
@@ -94,6 +94,7 @@ class mcp2515 : public canbus
   public:
     void SetPowerMode(PowerMode powermode);
     bool GetErrorFlagsDesc(std::string &buffer, uint32_t error_flags) override;
+    void SetTransceiverMode(bool isactive);
 
   public:
     static void shell_setaccfilter(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);


### PR DESCRIPTION
Enable/disable the CAN transceiver TX driver dependent on the CAN bus mode (CAN_MODE_ACTIVE, CAN_MODE_LISTEN) set by the Registration of the bus.
The RS-pin of the SN65HVD233 is set to the corresponding level low (ACTIVE) or high (LISTEN-Only). 

The code has been tested for ESP32CAN as well as MCP2515 based CAN buses.

In the vehicle specific code, the registration of the CAN bus should set the mode correctly, dependent on the write enable configuration:
````
CAN_mode_t mode = m_enable_write ? CAN_MODE_ACTIVE : CAN_MODE_LISTEN;
RegisterCanBus(can-no, mode, CAN_SPEED_500KBPS);
```` 
This code should be executed again, if the write access is changed in the configuration. 

