### PR TITLE
GPS parking off re-activate by default for 5 minutes

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,7 +1,10 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
-
+- Cellular: GPS auto pause on parking re-activate option added (update position).
+  New config:
+    [modem] gps.reactivate    -- park time in minutes for auto re-activate for (default 5 minutes) GPS lock (gps.reactlock), 0 = disabled (default)
+    [modem] gps.reactlock     -- by default, GPS lock for 5 minutes until automatic shutdown during parking time
 
 2024-03-23 MB   3.3.005  OTA release
 - Cellular: GPS auto pause on parking option added (power saving).

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
@@ -178,6 +178,9 @@ class modem : public pcp, public InternalRamAllocated
     gps_usermode_t         m_gps_usermode;          // manual GPS control status
     int                    m_gps_parkpause;         // = config modem gps.parkpause (seconds, 0=off)
     int                    m_gps_stopticker;        // Park pause countdown
+    int                    m_gps_startticker;       // Re-activation countdown
+    int                    m_gps_reactivate;        // = config modem gps.parkreactivate (minutes, 0=off)
+    int                    m_gps_reactlock;         // = config modem gps.reactlock (minutes, default 5)
     OvmsMutex              m_gps_mutex;             // lock for start/stop NMEA
 
     OvmsMutex              m_cmd_mutex;             // lock for the CMD channel

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -880,7 +880,7 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
  */
 void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
 {
-  std::string apn, apn_user, apn_pass, network_dns, pincode, error, gps_parkpause;
+  std::string apn, apn_user, apn_pass, network_dns, pincode, error, gps_parkpause, gps_parkreactivate, gps_parkreactlock;
   bool enable_gps, enable_gpstime, enable_net, enable_sms, wrongpincode;
   float cfg_sq_good, cfg_sq_bad;
 
@@ -896,6 +896,8 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
     enable_gps = (c.getvar("enable_gps") == "yes");
     enable_gpstime = (c.getvar("enable_gpstime") == "yes");
     gps_parkpause = c.getvar("gps_parkpause");
+    gps_parkreactivate = c.getvar("gps_parkreactivate");
+    gps_parkreactlock = c.getvar("gps_parkreactlock");
     cfg_sq_good = atof(c.getvar("cfg_sq_good").c_str());
     cfg_sq_bad = atof(c.getvar("cfg_sq_bad").c_str());
 
@@ -920,7 +922,8 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
       MyConfig.SetParamValueBool("modem", "enable.gps", enable_gps);
       MyConfig.SetParamValueBool("modem", "enable.gpstime", enable_gpstime);
       MyConfig.SetParamValue("modem", "gps.parkpause", gps_parkpause);
-
+      MyConfig.SetParamValue("modem", "gps.parkreactivate", gps_parkreactivate);
+      MyConfig.SetParamValue("modem", "gps.parkreactlock", gps_parkreactlock);
       MyConfig.SetParamValueFloat("network", "modem.sq.good", cfg_sq_good);
       MyConfig.SetParamValueFloat("network", "modem.sq.bad", cfg_sq_bad);
     }
@@ -953,7 +956,9 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   enable_sms = MyConfig.GetParamValueBool("modem", "enable.sms", true);
   enable_gps = MyConfig.GetParamValueBool("modem", "enable.gps", false);
   enable_gpstime = MyConfig.GetParamValueBool("modem", "enable.gpstime", false);
-  gps_parkpause = MyConfig.GetParamValue("modem", "gps.parkpause");
+  gps_parkpause = MyConfig.GetParamValue("modem", "gps.parkpause","0");
+  gps_parkreactivate = MyConfig.GetParamValue("modem", "gps.parkreactivate","0");
+  gps_parkreactlock = MyConfig.GetParamValue("modem", "gps.parkreactlock","5");
   cfg_sq_good = MyConfig.GetParamValueFloat("network", "modem.sq.good", -93);
   cfg_sq_bad = MyConfig.GetParamValueFloat("network", "modem.sq.bad", -95);
 
@@ -1007,6 +1012,12 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
     " <a target=\"_blank\" href=\"https://docs.openvehicles.com/en/latest/userguide/warnings.html#average-power-usage\">user manual</a>"
     " for details.</p>",
     "min=\"0\" step=\"5\"", "Seconds");
+  c.input("number", "GPS park re-activate", "gps_parkreactivate", gps_parkreactivate.c_str(), "Default: 0 = disabled",
+    "<p>Auto re-activate GPS after parking for longer than this time / 0 = no auto re-activation</p>",
+    "min=\"0\" step=\"5\"", "Minutes");
+  c.input("number", "GPS lock time", "gps_parkreactlock", gps_parkreactlock.c_str(), "Default: 5",
+    "<p>by default, GPS lock for 5 minutes until automatic shutdown during parking time</p>",
+    "min=\"5\" step=\"1\"", "Minutes");
   c.fieldset_end();
 
   c.fieldset_start("Cellular client options");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -268,8 +268,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   if (MyConfig.GetParamValue("xsq", "tpms.front.pressure","0") == "0") {
     MyConfig.SetParamValueInt("xsq", "tpms.front.pressure",  225); // kPa
     MyConfig.SetParamValueInt("xsq", "tpms.rear.pressure",  255); // kPa
-    MyConfig.SetParamValueInt("xsq", "tpms.value.warn",  30); // kPa
-    MyConfig.SetParamValueInt("xsq", "tpms.value.alert", 50); // kPa
+    MyConfig.SetParamValueInt("xsq", "tpms.value.warn",  50); // kPa
+    MyConfig.SetParamValueInt("xsq", "tpms.value.alert", 75); // kPa
   }
 
   if (MyConfig.GetParamValue("xsq", "tpms.alert.enable","0") == "0") {
@@ -845,6 +845,13 @@ void OvmsVehicleSmartEQ::GPSOnOff() {
   #ifdef CONFIG_OVMS_COMP_CELLULAR
     static const int PARK_TIMEOUT_SECS = 600;  // 10 minutes
     static const int INITIAL_DELAY = 10;
+    int gps_parkpause = MyConfig.GetParamValueInt("modem", "gps.parkpause", 0); // Check if GPS parking off is enabled in Cellular config
+    if (gps_parkpause > 0) {
+        ESP_LOGI(TAG, "smart EQ GPS on/off disabled, GPS parking off by Cellular config is enabled");
+        MyConfig.SetParamValueBool("xsq", "gps.onoff", false);
+        m_gps_onoff = false;
+        return;
+    }
     m_gps_ticker++;
 
     // Power saving: Turn off GPS

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -55,6 +55,9 @@
 #define CAN_NIBH(b)     (data[b] >> 4)
 #define CAN_NIB(n)      (((n)&1) ? CAN_NIBL((n)>>1) : CAN_NIBH((n)>>1))
 
+// VW e-Up specific MSG protocol commands:
+#define CMD_SetChargeAlerts         204 // (suffsoc)
+
 using namespace std;
 
 typedef std::vector<OvmsPoller::poll_pid_t, ExtRamAllocator<OvmsPoller::poll_pid_t>> poll_vector_t;
@@ -105,6 +108,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void NotifyTotalCounters();
     void NotifyMaintenance();
     void Notify12Vcharge();
+    void NotifySOClimit();
     void DoorLockState();
     void WifiRestart();
     void ModemRestart();
@@ -121,6 +125,8 @@ public:
     vehicle_command_t CommandDeactivateValet(const char* pin) override;
     vehicle_command_t CommandCan(uint32_t txid,uint32_t rxid,bool reset=false,bool wakeup=false);
     vehicle_command_t CommandWakeup2();
+    vehicle_command_t ProcessMsgCommand(std::string &result, int command, const char* args);
+    vehicle_command_t MsgCommandCA(std::string &result, int command, const char* args);
     virtual vehicle_command_t CommandTripStart(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandTripReset(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandMaintenance(int verbosity, OvmsWriter* writer);
@@ -132,6 +138,7 @@ public:
     virtual vehicle_command_t CommandTPMSset(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandDDT4all(int number, OvmsWriter* writer);
     virtual vehicle_command_t CommandDDT4List(int verbosity, OvmsWriter* writer);
+    virtual vehicle_command_t CommandSOClimit(int verbosity, OvmsWriter* writer);
 
 public:
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
@@ -316,6 +323,7 @@ public:
     bool m_warning_unlocked;                //!< unlocked warning
     bool m_modem_check;                     //!< modem check enabled
     bool m_modem_restart;                   //!< modem restart enabled
+    bool m_notifySOClimit;                  //!< notify SOClimit reached one time
     int m_ddt4all_ticker;                   //!< DDT4ALL active ticker 
     int m_ddt4all_exec;                     //!< DDT4ALL ticker for next execution
     int m_led_state;


### PR DESCRIPTION
An option has been added to re-activate GPS for position update at intervals when GPS pause while parked is active, allowing the theft and towing alert to issue a warning.

For smart EQ, if the GPS off function is enabled in Cellular, the smart EQ GPS on/off function will be deactivated.