### PR TITLE
Improve NIU MQi GT EVO consumption and charge time calc

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_niu_gtevo/src/vehicle_niu_gtevo.h
+++ b/vehicle/OVMS.V3/components/vehicle_niu_gtevo/src/vehicle_niu_gtevo.h
@@ -171,7 +171,9 @@ private:
   // Define helper vars for 25km rolling consumption calculation
   std::deque<std::pair<float, float>> consumptionHistory; // distance, consumption queue as data source for rolling consumption calc
   float totalConsumption = 0.0;                           // total aggregated battery consumption
-  float totalDistance = 0.0;                              // total distance driven withng rolling cons. calc needed if less than 200km
+  float totalDistance = 0.0;                              // total distance driven within rolling cons
+  const int m_final_charge_phase_minutes = 60;            // Estimated minutes for the TAPER to 100% CV phase.
+  const int m_final_charge_phase_soc = 85.0f;             // SOC where taper phase (CV) begins, it is not exactly every time on 85
 };
 
 #endif // #ifndef __VEHICLE_NIU_GTEVO__


### PR DESCRIPTION
I've improved the estimated range calculation, making it much more accurate! The scooter enters power-saving mode when the SoC (State of Charge) drops below 15%, so I’ve excluded this from the range calculation.

I’ve also optimized the remaining charge time, and while it’s getting closer to being accurate, it’s still not perfect. Additionally, I’ve added a notification for when the battery is removed, similar to the original app, for anti-theft protection.