### PR TITLE
VW e-up!: Fixed battery management abs SoC value

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -890,7 +890,7 @@ void OvmsVehicleVWeUp::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint
 
     case VWUP_BAT_MGMT_SOC_ABS:
       if (PollReply.FromUint8("VWUP_BAT_MGMT_SOC_ABS", value)) {
-        BatMgmtSoCAbs->SetValue(value / 2.5f);
+        BatMgmtSoCAbs->SetValue(value / 2.55f);
         VALUE_LOG(TAG, "VWUP_BAT_MGMT_SOC_ABS=%f => %f", value, BatMgmtSoCAbs->AsFloat());
       }
       break;


### PR DESCRIPTION
Fixed value calculation of BMS absolute SoC according to https://www.goingelectric.de/wiki/VW-e-up-OBD2-SG8C/