### PR TITLE
VW e-up!: Restored old abs SoC calculation

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_obd.cpp
@@ -890,7 +890,7 @@ void OvmsVehicleVWeUp::IncomingPollReply(const OvmsPoller::poll_job_t &job, uint
 
     case VWUP_BAT_MGMT_SOC_ABS:
       if (PollReply.FromUint8("VWUP_BAT_MGMT_SOC_ABS", value)) {
-        BatMgmtSoCAbs->SetValue(value / 2.55f);
+        BatMgmtSoCAbs->SetValue(value / 2.5f);
         VALUE_LOG(TAG, "VWUP_BAT_MGMT_SOC_ABS=%f => %f", value, BatMgmtSoCAbs->AsFloat());
       }
       break;


### PR DESCRIPTION
As verified again with ODIS, the previous calculation was correct, not the recently changed one.