### PR TITLE
esp32wifi switch APclient to Client mode

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,11 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- esp32wifi:
+  The OVMS will switch from Wifi APClient to Wifi Client mode after the timeout reached and a client is not connected. "APClient" will be restored upon reboot/network restart.
+  new config:
+    [network] ap2client.timeout   -- Wifi Mode APClient to client timeout in minutes (default 30 minutes), settings at Wifi
+    [network] ap2client.enable    -- Wifi Mode APClient to client enable/disable (default enable), settings at Wifi
 - Vehicle framework: signal generator operation state changes
   New events:
     vehicle.gen.start         -- Power delivery started

--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
@@ -69,6 +69,8 @@ class esp32wifi : public pcp, public InternalRamAllocated
     void SetPowerMode(PowerMode powermode);
     void PowerUp();
     void PowerDown();
+    void AP2ClientCheck();
+    void AP2ClientSwitch();
 
   public:
     void StartClientMode(std::string ssid, std::string password, uint8_t* bssid=NULL);
@@ -133,10 +135,13 @@ class esp32wifi : public pcp, public InternalRamAllocated
     bool m_sta_connected;
     uint32_t m_sta_reconnect;
     wifi_ap_record_t m_sta_ap_info;
-    int m_sta_rssi;                               // smoothed RSSI [dBm/10]
+    int m_sta_rssi;                              // smoothed RSSI [dBm/10]
     float m_good_dbm;
     float m_bad_dbm;
     bool m_good_signal;
+    int m_ap2client_timeout;                     //!< Wifi Mode APClient to client timeout in minutes
+    bool m_ap2client_enabled;                    //!< Wifi Mode APClient to client enable/disable
+    bool m_ap2client_active;                     //!< Wifi Mode APClient enabled and timeout not reached
   };
 
 #endif //#ifndef __ESP32WIFI_H__

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -180,8 +180,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     "<p>Enable = send a notification with Trip values when Trip values are reseted</p>");
   c.input_checkbox("Enable OBD kWh/100km value", "bcvalue", bcvalue,
     "<p>Enable = show OBD kWh/100km value</p>");
-  c.input_slider("WLTP km", "full_km", 3, "km",
-    atof(full_km.c_str()) > 0, atof(full_km.c_str()), 126, 100, 180, 1,
+  c.input_slider("WLTP km", "full_km", 3, "km",-1, atof(full_km.c_str()), 126, 100, 180, 1,
   "<p>set default max Range (126km WLTP, 155km NFEZ) at full charged HV for calculate ideal Range</p>");
   c.fieldset_end();
 
@@ -205,9 +204,8 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input_checkbox("Enable Wakeup on Restart", "wakeup", wakeup,
     "<p>Enable = Wakeup the Car on Restart of the OVMS</p>");
   c.input_checkbox("Enable extended statistics", "extstats", extstats,
-      "<p>Enable = Show extended statistics incl. maintenance and trip data. Not recomment for iOS Open Vehicle App!</p>");
-  c.input_slider("Restart Network Time", "rebootnw", 3, "min",
-    atof(rebootnw.c_str()) > 0, atof(rebootnw.c_str()), 15, 0, 60, 1,
+      "<p>Enable = Show extended statistics incl. maintenance and trip data. Not recomment for iOS Open Vehicle App!</p>");      
+  c.input_slider("Restart Network Time", "rebootnw", 3, "min",-1, atof(rebootnw.c_str()), 15, 0, 60, 1,
     "<p>Default 0 = off. Restart Network automatic when no v2Server connection.</p>");
   c.input_select_start("Modem Network type", "net_type");
   c.input_select_option("Auto", "auto", net_type == "auto");
@@ -311,8 +309,7 @@ void OvmsVehicleSmartEQ::WebCfgClimate(PageEntry_t& p, PageContext_t& c) {
   c.fieldset_start("Climate/Heater start timer");
   c.input_checkbox("Enable Climate/Heater at time", "climate_on", climate_on,
     "<p>Enable = start Climate/Heater at time</p>");
-  c.input_slider("Enable two time activation Climate/Heater", "climate_1to3", 3, "min",
-    atof(climate_1to3.c_str()) > -1, atof(climate_1to3.c_str()), 5, 5, 15, 5,
+  c.input_slider("Enable two time activation Climate/Heater", "climate_1to3", 3, "min",-1, atof(climate_1to3.c_str()), 5, 5, 15, 5,
     "<p>Enable = this option start Climate/Heater for 5-15 minutes</p>");
   c.input_text("time", "climate_time", climate_time.c_str(), "515","<p>Time: 5:15 = 515 or 15:30 = 1530</p>");
 
@@ -425,17 +422,13 @@ void OvmsVehicleSmartEQ::WebCfgTPMS(PageEntry_t& p, PageContext_t& c) {
     "<p>Set External Temperatures to TPMS Temperatures to Display Tire Pressures in iOS App Open Vehicle</p>");
   c.input_checkbox("Enable TPMS Alert", "enable", enable,
     "<p>enable TPMS Tire Pressures low/high alert</p>");
-  c.input_slider("Front Tire Pressure", "front_pressure", 3, "kPa",
-    atof(front_pressure.c_str()) > 0, atof(front_pressure.c_str()), 220, 170, 350, 5,
+  c.input_slider("Front Tire Pressure", "front_pressure", 3, "kPa",-1, atof(front_pressure.c_str()), 220, 170, 350, 5,
     "<p>set Front Tire Pressure value</p>");
-  c.input_slider("Rear Tire Pressure", "rear_pressure", 3, "kPa",
-    atof(rear_pressure.c_str()) > 0, atof(rear_pressure.c_str()), 250, 170, 350, 5,
+  c.input_slider("Rear Tire Pressure", "rear_pressure", 3, "kPa",-1, atof(rear_pressure.c_str()), 250, 170, 350, 5,
     "<p>set Rear Tire Pressure value</p>");
-  c.input_slider("Pressure Warning", "pressure_warning", 3, "kPa",
-    atof(pressure_warning.c_str()) > 0, atof(pressure_warning.c_str()), 25, 10, 60, 5,
+  c.input_slider("Pressure Warning", "pressure_warning", 3, "kPa",-1, atof(pressure_warning.c_str()), 25, 10, 60, 5,
     "<p>set under/over Pressure Warning value</p>");
-  c.input_slider("Pressure Alert", "pressure_alert", 3, "kPa",
-    atof(pressure_alert.c_str()) > 0, atof(pressure_alert.c_str()), 45, 30, 120, 5,
+  c.input_slider("Pressure Alert", "pressure_alert", 3, "kPa",-1, atof(pressure_alert.c_str()), 45, 30, 120, 5,
     "<p>set under/over Pressure Alert value</p>");
   c.input_select_start("Front Left Sensor", "TPMS_FL");
   c.input_select_option("Front_Left",  "0", TPMS_FL == "0");
@@ -538,23 +531,19 @@ void OvmsVehicleSmartEQ::WebCfgBattery(PageEntry_t& p, PageContext_t& c)
 
   c.fieldset_start("Charge control");
 
-  c.input_slider("Sufficient range", "suffrange", 3, "km",
-    atof(suffrange.c_str()) > 0, atof(suffrange.c_str()), 75, 0, 150, 1,
+  c.input_slider("Sufficient range", "suffrange", 3, "km",-1, atof(suffrange.c_str()), 75, 0, 150, 1,
     "<p>Default 0=off. Notify/stop charge when reaching this level.</p>");
 
-  c.input_slider("Sufficient SOC", "suffsoc", 3, "%",
-    atof(suffsoc.c_str()) > 0, atof(suffsoc.c_str()), 80, 0, 100, 1,
+  c.input_slider("Sufficient SOC", "suffsoc", 3, "%",-1, atof(suffsoc.c_str()), 80, 0, 100, 1,
     "<p>Default 0=off. Notify/stop charge when reaching this level.</p>");
 
   c.fieldset_end();
   
   c.fieldset_start("BMS Cell Monitoring");
-  c.input_slider("Update interval driving", "cell_interval_drv", 3, "s",
-    atof(cell_interval_drv.c_str()) > 0, atof(cell_interval_drv.c_str()),
+  c.input_slider("Update interval driving", "cell_interval_drv", 3, "s",-1, atof(cell_interval_drv.c_str()),
     60, 0, 300, 1,
     "<p>Default 60 seconds, 0=off.</p>");
-  c.input_slider("Update interval charging", "cell_interval_chg", 3, "s",
-    atof(cell_interval_chg.c_str()) > 0, atof(cell_interval_chg.c_str()),
+  c.input_slider("Update interval charging", "cell_interval_chg", 3, "s",-1, atof(cell_interval_chg.c_str()),
     60, 0, 300, 1,
     "<p>Default 60 seconds, 0=off.</p>");
   

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -48,10 +48,14 @@ static const char *TAG = "v-smarteq";
 #include "ovms_peripherals.h"
 #include "vehicle_smarteq.h"
 #include "ovms_time.h"
+#include "buffered_shell.h"
+#include "ovms_boot.h" 
 #ifdef CONFIG_OVMS_COMP_PLUGINS
   #include "ovms_plugins.h"
 #endif
-#include "buffered_shell.h"
+#ifdef CONFIG_OVMS_COMP_SERVER_V2
+#include "ovms_server_v2.h"
+#endif
 
 OvmsVehicleSmartEQ* OvmsVehicleSmartEQ::GetInstance(OvmsWriter* writer)
 {
@@ -145,7 +149,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   m_led_state = 4;
   m_cfg_cell_interval_drv = 0;
   m_cfg_cell_interval_chg = 0;
-
+    
   for (int i = 0; i < 4; i++) {
     m_tpms_pressure[i] = 0.0f;
     m_tpms_index[i] = i;
@@ -187,6 +191,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_climate_de                 = MyMetrics.InitInt("xsq.climate.de", SM_STALE_MID, 6, Other);
   mt_climate_1to3               = MyMetrics.InitInt("xsq.climate.1to3", SM_STALE_MID, 0, Other);
   mt_climate_data               = MyMetrics.InitString("xsq.climate.data", SM_STALE_MID,"0,0,0,0,-1,-1,-1", Other);
+  mt_climate_appdata            = MyMetrics.InitString("xsq.climate.appdata", SM_STALE_MID,"no;no;0515;1;6;0", Other);
 
   mt_pos_odometer_start         = MyMetrics.InitFloat("xsq.odometer.start", SM_STALE_MID, 0, Kilometers);
   mt_pos_odometer_start_total   = MyMetrics.InitFloat("xsq.odometer.start.total", SM_STALE_MID, 0, Kilometers);
@@ -305,6 +310,14 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
     ResetTripCounters();
   }
 
+  if (MyBoot.GetCrashCount() > 1 && MyConfig.GetParamValueBool("xsq", "climate.system",false)) {
+    MyConfig.SetParamValueBool("xsq", "climate.system", false);
+    char buf[100];
+    snprintf(buf, sizeof(buf), "Detected crash count %d - disabled climate/heater start timer. So you don't get a climate message after every reboot. Find and fix the crash cause.", MyBoot.GetCrashCount());
+    MyNotify.NotifyString("alert", "xsq.climate", buf);
+    ESP_LOGW(TAG, "%s", buf);
+  }
+
   if (MyConfig.GetParamValueBool("xsq", "restart.wakeup",false)) {
     CommandWakeup();                                           // wake up the car to get the first data
   }
@@ -405,12 +418,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   m_resettrip         = MyConfig.GetParamValueBool("xsq", "resettrip", false);
   m_resettotal        = MyConfig.GetParamValueBool("xsq", "resettotal", false);
   m_tripnotify        = MyConfig.GetParamValueBool("xsq", "reset.notify", false);
-/*
-  m_TPMS_FL           = MyConfig.GetParamValueInt("xsq", "TPMS_FL", 0);
-  m_TPMS_FR           = MyConfig.GetParamValueInt("xsq", "TPMS_FR", 1);
-  m_TPMS_RL           = MyConfig.GetParamValueInt("xsq", "TPMS_RL", 2);
-  m_TPMS_RR           = MyConfig.GetParamValueInt("xsq", "TPMS_RR", 3);
-*/
   m_tpms_index[3]     = MyConfig.GetParamValueInt("xsq", "TPMS_FL", 0);
   m_tpms_index[2]     = MyConfig.GetParamValueInt("xsq", "TPMS_FR", 1);
   m_tpms_index[1]     = MyConfig.GetParamValueInt("xsq", "TPMS_RL", 2);
@@ -424,7 +431,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   m_modem_check       = MyConfig.GetParamValueBool("xsq", "modem.check", false);
   m_12v_charge        = MyConfig.GetParamValueBool("xsq", "12v.charge", true);
   m_v2_check          = MyConfig.GetParamValueBool("xsq", "v2.check", false);
-  m_climate_system    = MyConfig.GetParamValueBool("xsq", "climate.system", true);
+  m_climate_system    = MyConfig.GetParamValueBool("xsq", "climate.system", false);
   m_gps_onoff         = MyConfig.GetParamValueBool("xsq", "gps.onoff", true);
   m_gps_reactmin      = MyConfig.GetParamValueInt("xsq", "gps.reactmin", 50);
   m_network_type      = MyConfig.GetParamValue("xsq", "modem.net.type", "auto");
@@ -815,7 +822,25 @@ void OvmsVehicleSmartEQ::TimeBasedClimateData() {
     StdMetrics.ms_v_gen_mode->SetValue(std::string(buf));
     StdMetrics.ms_v_gen_current->SetValue(3);
     NotifyClimateTimer();
+    
+    // WIP: send climate data to app
+    if(MyConfig.GetParamValueBool("xsq", "climate.system.toapp",false)) {
+      mt_climate_appdata->SetValue(std::string(buf));
+      SendClimateAppData();
+    }
   }
+}
+
+// WIP: send climate data to app
+void OvmsVehicleSmartEQ::SendClimateAppData()
+{
+  std::ostringstream buf;
+  buf 
+  << "XSQ-APPDATA" << ","
+  << mt_climate_appdata->AsString()
+  ;
+
+  MyNotify.NotifyString("data", "xsq.climate.appdata", buf.str().c_str());
 }
 
 // check the 12V alert periodically and charge the 12V battery if needed
@@ -952,8 +977,8 @@ void OvmsVehicleSmartEQ::DoorLockState() {
 void OvmsVehicleSmartEQ::WifiRestart() {
   #ifdef CONFIG_OVMS_COMP_WIFI
     if (MyPeripherals && MyPeripherals->m_esp32wifi) {
-        MyPeripherals->m_esp32wifi->Restart();
         ESP_LOGI(TAG, "WiFi restart initiated");
+        MyPeripherals->m_esp32wifi->Restart();
     } else {
         ESP_LOGE(TAG, "WiFi restart failed - WiFi not available");
     }
@@ -1099,7 +1124,7 @@ void OvmsVehicleSmartEQ::HandleCharging() {
       }
     }    
     // if limit_soc is set, then calculate remaining time to limit_soc
-    if (limit_soc > 0) {
+    if (limit_soc > 0.0f) {
       int minsremaining_soc = calcMinutesRemaining(limit_soc, charge_voltage, charge_current);
 
       StdMetrics.ms_v_charge_duration_soc->SetValue(minsremaining_soc, Minutes);
@@ -1112,7 +1137,7 @@ void OvmsVehicleSmartEQ::HandleCharging() {
       }
     }
     // If limit_range is set, then calculate remaining time to that range
-    if (limit_range > 0 && max_range > 0.0f) {
+    if (limit_range > 0.0f && max_range > 0.0f) {
       float range_soc           = limit_range / max_range * 100.0f;
       int   minsremaining_range = calcMinutesRemaining(range_soc, charge_voltage, charge_current);
 
@@ -1359,9 +1384,6 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker) {
 
     #ifdef CONFIG_OVMS_COMP_SERVER_V2
       if(m_v2_check) CheckV2State();
-    #endif
-
-    #if defined(CONFIG_OVMS_COMP_WIFI) || defined(CONFIG_OVMS_COMP_CELLULAR)
       if(m_reboot_time > 0) Handlev2Server();
     #endif
 
@@ -2516,7 +2538,6 @@ OvmsVehicleSmartEQ::vehicle_command_t OvmsVehicleSmartEQ::MsgCommandCA(std::stri
   }
   return Success;
 }
-  
 
 /**
  * writer for command line interface

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -93,7 +93,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void Check12vState();
     void GPSOnOff();
     void TimeBasedClimateData();
-    void TimeBasedClimateDataApp();
     void CheckV2State();
     void DisablePlugin(const char* plugin);
     void ModemNetworkType();
@@ -113,6 +112,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void WifiRestart();
     void ModemRestart();
     void ModemEventRestart(std::string event, void* data);
+    void SendClimateAppData();
+    //void SendServiceLevel();
 
 public:
     vehicle_command_t CommandClimateControl(bool enable) override;
@@ -309,6 +310,7 @@ public:
     OvmsMetricInt           *mt_climate_de;             //!< climate day end
     OvmsMetricInt           *mt_climate_1to3;           //!< climate one to three (homelink 0-2) times in following time
     OvmsMetricString        *mt_climate_data;           //!< climate data from app/website
+    OvmsMetricString        *mt_climate_appdata;        //!< climate data to app/website
     OvmsMetricString        *mt_canbyte;                //!< DDT4all canbyte
     OvmsMetricFloat         *mt_dummy_pressure;         //!< Dummy pressure for TPMS
 
@@ -333,7 +335,7 @@ public:
     int m_v2_ticker;
     int m_modem_ticker;
     int m_park_timeout_secs;                //!< parking timeout in seconds
-  
+      
   protected:
     poll_vector_t       m_poll_vector;              // List of PIDs to poll
     int                 m_cfg_cell_interval_drv;    // Cell poll interval while driving, default 15 sec.


### PR DESCRIPTION
esp32wifi:
The OVMS will switch from Wifi APClient to Wifi Client mode after the timeout reached and a client is not connected. "APClient" will be restored upon reboot/network restart. new config:
- [network] ap2client.timeout   -- Wifi Mode APClient to client timeout in minutes (default 30 minutes), settings at Wifi
- [network] ap2client.enable    -- Wifi Mode APClient to client enable/disable (default enable), settings at Wifi

smart EQ:
- added auto disable time based climate control when crash counter > 1 to stop Notify spamming
- deactivated all Web slider checkboxes 