### PR TITLE
server V3: fixed job queue overflow

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,11 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- server V3:
+    The number of metrics sent per update is limited to 20 and is split into multiple packets if necessary. Only updated data is sent.
+    Prioritize GPS tracking metrics, update interval set at Vehicle stream setting for smoother tracking
+    new config:
+      [server.v3] "updatetime.priority" (bool) -- enable/disable prioritizing GPS tracking
 - smart EQ: removed vehicle specific GPS on/off at parking -> moved to cellular
 - Vehicle notifications: grid log (history records `*-LOG-Grid`) V2 additions:
     pos_odometer

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -1093,7 +1093,7 @@ void OvmsServerV3::Ticker1(std::string event, void* data)
     {
     int now = StandardMetrics.ms_m_monotonic->AsInt();
     int next = (m_peers==0) ? m_updatetime_idle : m_updatetime_connected;    
-    bool carawake = StandardMetrics.ms_v_env_awake->AsBool();
+    bool caron = StandardMetrics.ms_v_env_on->AsBool();
 
     if (m_sendall)
       {
@@ -1129,13 +1129,13 @@ void OvmsServerV3::Ticker1(std::string event, void* data)
       m_lasttx_priority = now;
       m_lasttx = now;
       }
-    else if ((m_lasttx_priority==0) || (m_updatetime_priority && carawake && m_vehicle_stream > 0 && (now > (m_lasttx_priority + m_vehicle_stream))))
+    else if ((m_lasttx_priority==0) || (m_updatetime_priority && caron && m_vehicle_stream > 0 && (now > (m_lasttx_priority + m_vehicle_stream))))
       {
       //ESP_LOGI(TAG, "Transmit GPS priority metrics");
       TransmitPriorityMetrics();
       m_lasttx_priority = now;
       }
-    else if ( (m_lasttx==0) || (now > (m_lasttx + next)) )
+    else if ((m_lasttx==0) || (now > (m_lasttx + next)))
       {
       //ESP_LOGI(TAG, "Transmit modified metrics");
       TransmitModifiedMetrics();

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -946,11 +946,13 @@ void OvmsServerV3::EventListener(std::string event, void* data)
     {
     ConfigChanged((OvmsConfigParam*) data);
     }
-  else if (event == "location.alert.flatbed.moved" || event == "location.alert.valet.bounds" ||
+  else if (event == "location.alert.flatbed.moved" || event == "location.alert.valet.bounds" ||    
+           event == "app.connected" || event == "app.disconnected" ||  
            event == "vehicle.charge.start" || event == "vehicle.charge.stop" ||
-           event == "app.connected" || event == "app.disconnected" ||           
+           event == "vehicle.charge.finished" || event == "vehicle.awake" ||
+           event == "vehicle.on" || event == "vehicle.off" ||           
            event == "vehicle.locked" || event == "vehicle.unlocked" ||
-           event == "server.v3.connected" || event == "vehicle.charge.finished")
+           event == "server.v3.connected")
     {
     m_lasttx = 0; // Force immediate update on these events
     }
@@ -1127,7 +1129,7 @@ void OvmsServerV3::Ticker1(std::string event, void* data)
       m_lasttx_priority = now;
       m_lasttx = now;
       }
-    else if (m_updatetime_priority && carawake && m_vehicle_stream > 0 && (now > (m_lasttx_priority + m_vehicle_stream)))
+    else if ((m_lasttx_priority==0) || (m_updatetime_priority && carawake && m_vehicle_stream > 0 && (now > (m_lasttx_priority + m_vehicle_stream))))
       {
       //ESP_LOGI(TAG, "Transmit GPS priority metrics");
       TransmitPriorityMetrics();

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -203,7 +203,7 @@ OvmsServerV3::OvmsServerV3(const char* name)
   m_lasttx_sendall = 0;
   m_lasttx_priority = 0;
   m_peers = 0;
-  m_vehicle_stream = 10;
+  m_vehicle_stream = 0;
   m_updatetime_idle = 600;
   m_updatetime_connected = 60;
   m_updatetime_awake = 60;      // disabled, too much interval confusion
@@ -409,7 +409,8 @@ static const char* s_priority_gps_metrics[] = {
   "m.time.utc",
   "v.e.on",
   "v.b.soc",
-  "v.c.charging"
+  "v.c.charging",
+  "v.e.lock"
 };
 
 static const size_t s_priority_gps_metrics_count =
@@ -944,6 +945,10 @@ void OvmsServerV3::EventListener(std::string event, void* data)
   if (event == "config.changed" || event == "config.mounted")
     {
     ConfigChanged((OvmsConfigParam*) data);
+    }
+  else if (event == "location.alert.flatbed.moved" || event == "location.alert.valet.bounds")
+    {
+    m_lasttx = 0; // Force immediate update on these events
     }
   }
 

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -946,7 +946,11 @@ void OvmsServerV3::EventListener(std::string event, void* data)
     {
     ConfigChanged((OvmsConfigParam*) data);
     }
-  else if (event == "location.alert.flatbed.moved" || event == "location.alert.valet.bounds")
+  else if (event == "location.alert.flatbed.moved" || event == "location.alert.valet.bounds" ||
+           event == "vehicle.charge.start" || event == "vehicle.charge.stop" ||
+           event == "app.connected" || event == "app.disconnected" ||           
+           event == "vehicle.locked" || event == "vehicle.unlocked" ||
+           event == "server.v3.connected" || event == "vehicle.charge.finished")
     {
     m_lasttx = 0; // Force immediate update on these events
     }

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -100,8 +100,9 @@ class OvmsServerV3 : public OvmsServer
     int m_msgid;
     int m_lasttx;
     int m_lasttx_sendall;
+    int m_lasttx_priority;
     int m_peers;
-    int m_streaming;
+    int m_vehicle_stream;
     int m_updatetime_idle;
     int m_updatetime_connected;
     int m_updatetime_awake;
@@ -109,6 +110,7 @@ class OvmsServerV3 : public OvmsServer
     int m_updatetime_charging;
     int m_updatetime_sendall;
     int m_updatetime_keepalive;
+    bool m_updatetime_priority;
     bool m_legacy_event_topic;
 
     bool m_connection_available;
@@ -130,6 +132,7 @@ class OvmsServerV3 : public OvmsServer
     void Disconnect();
     void TransmitAllMetrics();
     void TransmitModifiedMetrics();
+    void TransmitPriorityMetrics();
     int TransmitNotificationInfo(OvmsNotifyEntry* entry);
     int TransmitNotificationError(OvmsNotifyEntry* entry);
     int TransmitNotificationAlert(OvmsNotifyEntry* entry);

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -98,9 +98,9 @@ class OvmsServerV3 : public OvmsServer
     int m_connection_counter;
     bool m_sendall;
     int m_msgid;
-    int m_lasttx;
-    int m_lasttx_sendall;
-    int m_lasttx_priority;
+    int64_t m_lasttx;
+    int64_t m_lasttx_sendall;
+    int64_t m_lasttx_priority;
     int m_peers;
     int m_vehicle_stream;
     int m_updatetime_idle;
@@ -162,7 +162,7 @@ class OvmsServerV3Init
     void AutoInit();
 
   public:
-    void EventListener(std::string event, void* data);
+    void EventListenerInit(std::string event, void* data);
   };
 
 extern OvmsServerV3Init MyOvmsServerV3Init;

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -1757,7 +1757,7 @@ void OvmsWebServer::HandleCfgServerV3(PageEntry_t& p, PageContext_t& c)
     "<p><strong>Note:</strong> The update interval corresponds to the <strong>Vehicle stream</strong> setting!</p>");
   c.input("number", "…connected", "updatetime_connected", updatetime_connected.c_str(), "default: 60", "default: 60, update interval when client is connected", "min=\"0\" max=\"600\" step=\"1\"", "seconds");
   c.input("number", "…idle", "updatetime_idle", updatetime_idle.c_str(), "default: 600", "default: 600, update interval when client not connected", "min=\"0\" max=\"1200\" step=\"1\"", "seconds");
-  //c.input("number", "…on", "updatetime_on", updatetime_on.c_str(), "default: 5", "default: 5", "min=\"0\" max=\"600\" step=\"1\"", "seconds");
+  c.input("number", "…on", "updatetime_on", updatetime_on.c_str(), "default: 5", "default: 5", "min=\"0\" max=\"600\" step=\"1\"", "seconds");
   //c.input("number", "…charging", "updatetime_charging", updatetime_charging.c_str(), "default: 20", "default: 20", "min=\"0\" max=\"600\" step=\"1\"", "seconds");
   //c.input("number", "…awake", "updatetime_awake", updatetime_awake.c_str(), "default: 60", "default: 60", "min=\"0\" max=\"600\" step=\"1\"", "seconds");
   //c.input("number", "…sendall", "updatetime_sendall", updatetime_sendall.c_str(), "default: 900", "default: 900", "min=\"0\" max=\"1800\" step=\"1\"", "seconds");


### PR DESCRIPTION
- Fixed job queue overflow
- Limited to 20 readings per call
- Prioritized optional GPS tracking readings
- Optimized Ticker1
- Disabled some interval times/conditions in Ticker1; there are simply too many without use

based on PR is #1195