### PR TITLE
Server V3 On-Demand Metrics and Configuration

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,16 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- server V3 (additions):
+    Added client on-demand requests to reduce baseline data usage:
+      <prefix>/client/<clientid>/request/metric   -- payload: one or multiple metric name patterns
+                                                     Supports wildcards: * (all), prefix* (simple prefix match)
+                                                     Each matching metric is published immediately on its normal topic.
+      <prefix>/client/<clientid>/request/config   -- payload: param/instance (single pair)
+                                                     Response topic: <prefix>/client/<clientid>/config/<param>/<instance>
+    Subscription topic count increased (MQTT_CONN_NTOPICS=4) to include the two new request channels.
+    Pattern matcher kept intentionally minimal (no ? or mid-string *) for low CPU usage.
+    Requests do not clear modified flags; normal delta sending behaviour remains unaffected.
 - server V3:
     The number of metrics sent per update is limited to 20 and is split into multiple packets if necessary. Only updated data is sent.
     Prioritize GPS tracking metrics, update interval set at Vehicle stream setting for smoother tracking

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.h
@@ -43,7 +43,7 @@
 
 typedef std::map<std::string, uint32_t> OvmsServerV3ClientMap;
 
-#define MQTT_CONN_NTOPICS 2
+#define MQTT_CONN_NTOPICS 4   // active, command, request/metric, request/config
 
 class OvmsServerV3 : public OvmsServer
   {
@@ -65,6 +65,9 @@ class OvmsServerV3 : public OvmsServer
     void Ticker1(std::string event, void* data);
     void Ticker60(std::string event, void* data);
     void RequestUpdate(bool txall);
+    void ProcessClientMetricRequest(const std::string& clientid, const std::string& payload);
+    void ProcessClientConfigRequest(const std::string& clientid, const std::string& payload);
+    static bool MatchPattern(const std::string& name, const std::string& pattern);
 
   public:
     enum State


### PR DESCRIPTION
Implemented support for client-initiated requests to fetch specific metrics or config values via new MQTT topics, reducing baseline data usage. Increased MQTT subscription topic count to 4 to accommodate the new request channels. Added minimal pattern matching for metric requests and ensured normal delta sending remains unaffected. Updated chunk sizes for metric transmissions and improved update interval logic.