### PR TITLE
Add GPS auto start on vehicle awake option

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -4,6 +4,9 @@ Open Vehicle Monitor System v3 - Change log
 - Cellular: GPS auto pause on parking re-activate when Car awakes. This reduces time to first GPS fix.
   New config:
     [modem] enable.gps.awake   -- GPS powered on for park re-activate time when parked and Car awakes (default: false)
+- Cellular: GPS auto pause on parking reactivate when Car awakes. This reduces time to first GPS fix.
+  New config:    
+    [modem] gps.parkreactawake (bool)   -- GPS is switched on for the gps.parkreactlock (minutes) time when the GPS parking pause is active and the car wakes up (default: no)
 - Webserver: adjustable websocket TX job queue size to accomodate high update
     frequencies / stream payload sizes and/or slow clients / client connections
   New config:
@@ -36,9 +39,8 @@ Open Vehicle Monitor System v3 - Change log
     vehicle.gen.timermode.off -- Generator timer has been disabled
 - Cellular: GPS auto pause on parking reactivate option added (update position).
   New config:
-    [modem] gps.parkreactivate    -- park time in minutes for auto reactivate for (default 5 minutes) GPS lock (gps.parkreactlock), 0 = disabled (default)
-    [modem] gps.parkreactlock     -- by default, GPS lock for 5 minutes until automatic shutdown during parking time
-    [modem] gps.parkreactawake    -- GPS is switched on for the gps.parkreactlock time when the GPS parking pause is active and the car wakes up
+    [modem] gps.parkreactivate (minutes)   -- park time in minutes for auto reactivate for (default 5 minutes) GPS lock (gps.parkreactlock), 0 = disabled
+    [modem] gps.parkreactlock  (minutes)   -- GPS lock for 5 minutes until automatic shutdown during parking time
 
 2024-03-23 MB   3.3.005  OTA release
 - Cellular: GPS auto pause on parking option added (power saving).

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,9 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Cellular: GPS auto pause on parking re-activate when Car awakes. This reduces time to first GPS fix.
+  New config:
+    [modem] enable.gps.awake   -- GPS powered on for park re-activate time when parked and Car awakes (default: false)
 - Webserver: adjustable websocket TX job queue size to accomodate high update
     frequencies / stream payload sizes and/or slow clients / client connections
   New config:

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -34,10 +34,11 @@ Open Vehicle Monitor System v3 - Change log
     vehicle.gen.pilot.off     -- Pilot signal gone
     vehicle.gen.timermode.on  -- Generator timer has been enabled
     vehicle.gen.timermode.off -- Generator timer has been disabled
-- Cellular: GPS auto pause on parking re-activate option added (update position).
+- Cellular: GPS auto pause on parking reactivate option added (update position).
   New config:
-    [modem] gps.reactivate    -- park time in minutes for auto re-activate for (default 5 minutes) GPS lock (gps.reactlock), 0 = disabled (default)
-    [modem] gps.reactlock     -- by default, GPS lock for 5 minutes until automatic shutdown during parking time
+    [modem] gps.parkreactivate    -- park time in minutes for auto reactivate for (default 5 minutes) GPS lock (gps.parkreactlock), 0 = disabled (default)
+    [modem] gps.parkreactlock     -- by default, GPS lock for 5 minutes until automatic shutdown during parking time
+    [modem] gps.parkreactawake    -- GPS is switched on for the gps.parkreactlock time when the GPS parking pause is active and the car wakes up
 
 2024-03-23 MB   3.3.005  OTA release
 - Cellular: GPS auto pause on parking option added (power saving).

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,9 +1,6 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
-- Cellular: GPS auto pause on parking re-activate when Car awakes. This reduces time to first GPS fix.
-  New config:
-    [modem] enable.gps.awake   -- GPS powered on for park re-activate time when parked and Car awakes (default: false)
 - Cellular: GPS auto pause on parking reactivate when Car awakes. This reduces time to first GPS fix.
   New config:    
     [modem] gps.parkreactawake (bool)   -- GPS is switched on for the gps.parkreactlock (minutes) time when the GPS parking pause is active and the car wakes up (default: no)
@@ -39,8 +36,8 @@ Open Vehicle Monitor System v3 - Change log
     vehicle.gen.timermode.off -- Generator timer has been disabled
 - Cellular: GPS auto pause on parking reactivate option added (update position).
   New config:
-    [modem] gps.parkreactivate (minutes)   -- park time in minutes for auto reactivate for (default 5 minutes) GPS lock (gps.parkreactlock), 0 = disabled
-    [modem] gps.parkreactlock  (minutes)   -- GPS lock for 5 minutes until automatic shutdown during parking time
+    [modem] gps.parkreactivate (minutes)   -- park time in minutes for auto reactivate for GPS lock (gps.parkreactlock), 0 = disabled
+    [modem] gps.parkreactlock  (minutes)   -- GPS lock for 5 minutes until automatic shutdown during parking time (default 5 minutes)
 
 2024-03-23 MB   3.3.005  OTA release
 - Cellular: GPS auto pause on parking option added (power saving).

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -1711,7 +1711,7 @@ void modem::EventListener(std::string event, void* data)
       ESP_LOGI(TAG, "Vehicle awake, starting GPS");
       m_gps_startticker = 0;
       StartNMEA();
-      m_gps_stopticker = m_gps_parkpause;
+      m_gps_stopticker = m_gps_reactlock * 60; // default 5 minutes;
       }
     }
   }

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -1723,7 +1723,7 @@ void modem::ConfigChanged(std::string event, void* data)
   if (!param || param->GetName() == "modem")
     {
     bool enable_gps = MyConfig.GetParamValueBool("modem", "enable.gps", false);
-    bool enable_gps_awake = MyConfig.GetParamValueBool("modem", "enable.gps.awake", false);
+    bool gps_reactawake = MyConfig.GetParamValueBool("modem", "gps.parkreactawake", false);
     int gps_parkpause = MyConfig.GetParamValueInt("modem", "gps.parkpause", 0);
     int gps_reactivate = MyConfig.GetParamValueInt("modem", "gps.parkreactivate", 0);
     int gps_reactlock = MyConfig.GetParamValueInt("modem", "gps.parkreactlock", 5);
@@ -1734,18 +1734,18 @@ void modem::ConfigChanged(std::string event, void* data)
       m_gps_parkpause = gps_parkpause;
       m_gps_reactivate = gps_reactivate;
       m_gps_reactlock = gps_reactlock;
-      m_gps_awake_start = enable_gps_awake;
+      m_gps_awake_start = gps_reactawake;
       }
     else if (enable_gps != m_gps_enabled ||
             gps_parkpause != m_gps_parkpause || 
             gps_reactivate != m_gps_reactivate ||
             gps_reactlock != m_gps_reactlock ||
-            enable_gps_awake != m_gps_awake_start)
+            gps_reactawake != m_gps_awake_start)
       {
       // User changed GPS configuration; translate to status change:
       m_gps_usermode = GUM_DEFAULT;
       m_gps_enabled = enable_gps;
-      m_gps_awake_start = enable_gps_awake;
+      m_gps_awake_start = gps_reactawake;
       m_gps_parkpause = gps_parkpause;
       m_gps_reactivate = gps_reactivate;
       m_gps_reactlock = gps_reactlock;

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
@@ -181,6 +181,7 @@ class modem : public pcp, public InternalRamAllocated
     int                    m_gps_startticker;       // Re-activation countdown
     int                    m_gps_reactivate;        // = config modem gps.parkreactivate (minutes, 0=off)
     int                    m_gps_reactlock;         // = config modem gps.reactlock (minutes, default 5)
+    bool                   m_gps_awake_start;       // start GPS when vehicle awakes
     OvmsMutex              m_gps_mutex;             // lock for start/stop NMEA
 
     OvmsMutex              m_cmd_mutex;             // lock for the CMD channel

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -881,7 +881,7 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
 void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
 {
   std::string apn, apn_user, apn_pass, network_dns, pincode, error, gps_parkpause, gps_parkreactivate, gps_parkreactlock, vehicle_stream;
-  bool enable_gps, enable_gpstime, enable_net, enable_sms, wrongpincode;
+  bool enable_gps, enable_gpstime, enable_net, enable_sms, wrongpincode, enable_gps_awake;
   float cfg_sq_good, cfg_sq_bad;
 
   if (c.method == "POST") {
@@ -894,6 +894,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
     enable_net = (c.getvar("enable_net") == "yes");
     enable_sms = (c.getvar("enable_sms") == "yes");
     enable_gps = (c.getvar("enable_gps") == "yes");
+    enable_gps_awake = (c.getvar("gps_awake_start") == "yes");
     enable_gpstime = (c.getvar("enable_gpstime") == "yes");
     gps_parkpause = c.getvar("gps_parkpause");
     gps_parkreactivate = c.getvar("gps_parkreactivate");
@@ -921,6 +922,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
       MyConfig.SetParamValueBool("modem", "enable.net", enable_net);
       MyConfig.SetParamValueBool("modem", "enable.sms", enable_sms);
       MyConfig.SetParamValueBool("modem", "enable.gps", enable_gps);
+      MyConfig.SetParamValueBool("modem", "enable.gps.awake", enable_gps_awake);
       MyConfig.SetParamValueBool("modem", "enable.gpstime", enable_gpstime);
       MyConfig.SetParamValue("modem", "gps.parkpause", gps_parkpause);
       MyConfig.SetParamValue("modem", "gps.parkreactivate", gps_parkreactivate);
@@ -960,6 +962,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   enable_net = MyConfig.GetParamValueBool("modem", "enable.net", true);
   enable_sms = MyConfig.GetParamValueBool("modem", "enable.sms", true);
   enable_gps = MyConfig.GetParamValueBool("modem", "enable.gps", false);
+  enable_gps_awake = MyConfig.GetParamValueBool("modem", "enable.gps.awake", false);
   enable_gpstime = MyConfig.GetParamValueBool("modem", "enable.gpstime", false);
   gps_parkpause = MyConfig.GetParamValue("modem", "gps.parkpause","0");
   gps_parkreactivate = MyConfig.GetParamValue("modem", "gps.parkreactivate","0");
@@ -1022,6 +1025,8 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   c.fieldset_end();
 
   c.fieldset_start("GPS parking and tracking");
+  c.input_checkbox("Start GPS when Car awakes", "gps_awake_start", enable_gps_awake,
+    "<p>GPS powered on for park re-activate time when parked and Car awakes. This reduces time to first GPS fix, but increases power consumption when Car is awake.</p>");
   c.input("number", "GPS park pause", "gps_parkpause", gps_parkpause.c_str(), "Default: 0 = disabled",
     "<p>Auto pause GPS when parking for longer than this time / 0 = no auto pausing</p>"
     "<p>Pausing the GPS subsystem can help to avoid draining the 12V battery, see"


### PR DESCRIPTION
Introduces a new configuration option to power on GPS for a set time when the vehicle awakes from parking, reducing time to first GPS fix. Updates the modem logic, configuration handling, and web UI to support the new [modem] enable.gps.awake setting.