### PR TITLE
Remove m.time.utc from priority GPS metrics

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -9,7 +9,7 @@ Open Vehicle Monitor System v3 - Change log
       TransmitAllMetrics(): up to 100 metrics per tick, continues next call.
       TransmitModifiedMetrics(): up to 150 modified metrics per tick.
     Priority path for GPS/time metrics with optional extras:
-      Default priority: v.p.latitude, v.p.longitude, v.p.altitude, v.p.speed, v.p.gpsspeed, m.time.utc
+      Default priority: v.p.latitude, v.p.longitude, v.p.altitude, v.p.speed, v.p.gpsspeed
     New update Command:
       server v3 update priority                   -- send prioritized metrics
 - Webserver: Server V3 (MQTT) config page

--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -441,7 +441,6 @@ void OvmsServerV3::TransmitPriorityMetrics()
       "v.p.altitude",
       "v.p.speed",
       "v.p.gpsspeed",
-      "m.time.utc",
     };
 
     const size_t s_priority_gps_metrics_count =

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -1795,7 +1795,7 @@ void OvmsWebServer::HandleCfgServerV3(PageEntry_t& p, PageContext_t& c)
   c.input("number", "queue size sendall", "queue_sendall", queue_sendall.c_str(), "default: 100", "default: 100", "min=\"1\" max=\"500\" step=\"1\"", "size");
   c.input("number", "queue size modified", "queue_modified", queue_modified.c_str(), "default: 150", "default: 150", "min=\"1\" max=\"500\" step=\"1\"", "size");
   c.input_text("priority metrics", "metrics_priority", metrics_priority.c_str(), NULL,
-    "<p>default priority: v.p.latitude, v.p.longitude, v.p.altitude, v.p.speed, v.p.gpsspeed, m.time.utc</br>"
+    "<p>default priority: v.p.latitude, v.p.longitude, v.p.altitude, v.p.speed, v.p.gpsspeed</br>"
     "additional comma-separated list of metrics to prioritize when Car is awake, wildcard supported e.g. v.c.*, m.net.*</p>");
   c.input_text("metrics include", "metrics_include", metrics_include.c_str(), NULL,
     "<p>comma-separated list of metrics to include update, wildcard supported e.g. v.c.*, m.net.*</p>");


### PR DESCRIPTION
The metric m.time.utc has been removed from the default priority GPS metrics list in both the server and web configuration. Documentation and UI text have been updated accordingly to reflect this change.

I only put it in for testing and forgot to take it out again.