### PR TITLE
smart: EQ: Harden CAN poll parsing and add 12V ADC recalibration

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,12 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- smart EQ:
+    Hardened poll reply & CAN parsing (REQUIRE_LEN / DLC guards, corrected switch fallthrough).
+    Automatic 12V ADC factor recalculation using BMS 12V voltage with adjustable offset and web UI controls.
+    New config:
+    [xsq] calc.adcfactor (bool)             -- activate sutomatic ADC factor recalculation (default false)
+    [xsq] 12v.measured.BMS.offset (float)   -- 12V battery voltage measure offset BMS <> 12V System in V (default 0.25V)
 - Cellular: GPS auto pause on parking reactivate when Car awakes. This reduces time to first GPS fix.
   New config:    
     [modem] gps.parkreactawake (bool)   -- GPS is switched on for the gps.parkreactlock (minutes) time when the GPS parking pause is active and the car wakes up (default: no)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -40,11 +40,33 @@ Others
 =========================== ==============
 
 -------------------------
-Using Cabin Pre-heat/cool
--------------------------
-
+Using Cabin Pre-heat/cool:
 Only 5 Minutes Booster are Implementet white 
 Climatecontrol on or 
 homelink 1 = 5 Minutes
 homelink 2 = 10 Minutes
 homelink 3 = 15 Minutes
+For Timebased Pre-heat/cool you can use the Android App or Web UI.
+-------------------------
+
+-------------------------
+Using DDT4all:
+You can use some DDT4all commands. A list of all possible commands you can find at www.smart-EMOTION.de (german).
+-------------------------
+
+-------------------------
+Shell commands:
+xsq - read all data
+xsq ddt4list - list all ddt4all commands
+xsq ddt4all <value> - set ddt4all command
+xsq calcadc - calculated ADC values by BMS 12V measurement
+xsq calcadc <value> - calculated ADC by value
+-------------------------
+
+-------------------------
+Known Issues
+-------------------------
+- TPMS: The TPMS values are only pressure values. The iOS App needs the 'iOS TPMS fix' activated at Features Web UI to show the pressure values.
+- Lock/Unlock: The Lock/Unlock function is not really implemented. You can only close the car when it is open. The lock indicator always shows unlocked.
+- Charge Control: Not implemented yet.
+-------------------------

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -88,6 +88,21 @@ std::string SecondsToHHmm(int totalSeconds) {
     return oss.str();
 }
 
+// Central reply length guard for poll parsers (enhanced):
+// Logs only when reply_len changes to avoid log spam on repeated truncated frames.
+#define REQUIRE_LEN(minlen)                                                    \
+  do {                                                                         \
+    if (reply_len < (minlen)) {                                                \
+      static uint16_t __last_short_len = 0xFFFF;                               \
+      if (__last_short_len != reply_len) {                                     \
+        ESP_LOGV(TAG, "%s: short reply (%u < %u)",                             \
+          __FUNCTION__, (unsigned)reply_len, (unsigned)(minlen));              \
+        __last_short_len = reply_len;                                          \
+      }                                                                        \
+      return;                                                                  \
+    }                                                                          \
+  } while(0)
+
 /**
  * Incoming poll reply messages
  */
@@ -107,7 +122,7 @@ void OvmsVehicleSmartEQ::IncomingPollReply(const OvmsPoller::poll_job_t &job, ui
   
   switch (job.moduleid_rec) {
     case 0x7EC:
-      switch (job.pid) {
+      switch (job.pid) {        
         case 0x320C: // rqHV_Energy
           PollReply_EVC_HV_Energy(m_rxbuf.data(), m_rxbuf.size());
           break;
@@ -117,10 +132,13 @@ void OvmsVehicleSmartEQ::IncomingPollReply(const OvmsPoller::poll_job_t &job, ui
         case 0x3495: // rqDCDC_Load
           PollReply_EVC_DCDC_Load(m_rxbuf.data(), m_rxbuf.size());
           break;
-        case 0x3024: // rqDCDC_volt_measure
+        case 0x3023: // 14V DCDC voltage request
+          PollReply_EVC_DCDC_VoltReq(m_rxbuf.data(), m_rxbuf.size());
+          break;
+        case 0x3024: // 14V DCDC voltage measure
           PollReply_EVC_DCDC_Volt(m_rxbuf.data(), m_rxbuf.size());
           break;
-        case 0x3025: // rqDCDC_Amps
+        case 0x3025: // 14V DCDC current measure
           PollReply_EVC_DCDC_Amps(m_rxbuf.data(), m_rxbuf.size());
           break;
         case 0x3494: // rqDCDC_Power
@@ -173,35 +191,8 @@ void OvmsVehicleSmartEQ::IncomingPollReply(const OvmsPoller::poll_job_t &job, ui
         case 0x503B: // rqJB2AC_Ph3_RMS_A
           PollReply_OBL_JB2AC_Ph3_RMS_A(m_rxbuf.data(), m_rxbuf.size());
           break;
-        case 0x5049: // Mains phase frequency (Hz)
-          PollReply_OBL_JB2AC_Frequency(m_rxbuf.data(), m_rxbuf.size());
-          break;
         case 0x504A: // Mains active power consumed (W)
           PollReply_OBL_JB2AC_Power(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x504B: // Mains current sum (A)
-          PollReply_OBL_JB2AC_CurrentSum(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x504C: // Mains voltage sum (V)
-          PollReply_OBL_JB2AC_VoltageSum(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x504D: // HV Network measured current (A)
-          PollReply_OBL_JB2AC_HVNetCurrent(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x504E: // HV voltage measured (V)
-          PollReply_OBL_JB2AC_HVVoltageSum(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x5057: // Raw leakage current - DC part measurement (mA)
-          PollReply_OBL_JB2AC_RawDCCurrent(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x5058: // Raw leakage current - High Frequency 10kHz part measurement (mA)
-          PollReply_OBL_JB2AC_RawHF10kHz(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x5059: // Raw leakage current - High Frequency 1st part measurement (mA)
-          PollReply_OBL_JB2AC_RawHFCurrent(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x505A: // Raw leakage current - Low Frequency part measurement (50Hz)
-          PollReply_OBL_JB2AC_RawLFCurrent(m_rxbuf.data(), m_rxbuf.size());
           break;
         case 0x5062: // Mains ground resistance (Ohm)
           PollReply_OBL_JB2AC_GroundResistance(m_rxbuf.data(), m_rxbuf.size());
@@ -266,6 +257,12 @@ void OvmsVehicleSmartEQ::IncomingPollReply(const OvmsPoller::poll_job_t &job, ui
         case 0x81: // req.VIN
           PollReply_VIN(m_rxbuf.data(), m_rxbuf.size());
           break;
+        case 0x8003: // rq_VehicleState
+          PollReply_VehicleState(m_rxbuf.data(), m_rxbuf.size());
+          break;
+        case 0x605e: // rq_UNDERHOOD_OPENED
+          PollReply_DoorUnderhoodOpened(m_rxbuf.data(), m_rxbuf.size());
+          break;
       }
       break;
     default:
@@ -294,38 +291,30 @@ void OvmsVehicleSmartEQ::IncomingPollError(const OvmsPoller::poll_job_t &job, ui
 
 void OvmsVehicleSmartEQ::PollReply_BMS_BattVolts(const char* data, uint16_t reply_len, uint16_t start)
 {
-  // Each cell voltage uses 2 bytes (pair loop originally stepped by 2).
-  if (reply_len < 1) return;
-
-  bool cellstat = false;
-  float first = CAN_UINT(0);
-  if (first == 5120 && start == 0)
-    cellstat = false;
-  else if (first != 5120 && start == 0)
-    cellstat = true;
-  else
-    cellstat = true; // for subsequent parts assume active
-
-  if (!cellstat)
-    return;
-
+  REQUIRE_LEN(2);
   uint16_t max_bytes = reply_len & 0xFFFE;
   for (uint16_t off = 0; off < max_bytes; off += 2)
     {
-    uint16_t cell_index = (off / 2) + start;
-    float CV = CAN_UINT(off) / 1024.0f;
-    BmsSetCellVoltage(cell_index, CV);
-    ESP_LOGV(TAG, "CellVoltage: id=%u volt=%.3f", cell_index, CV);
+      if (off+1 >= reply_len)
+        break;
+      uint16_t cell_index = (off / 2) + start;
+      if (cell_index >= CELLCOUNT)   // safety bound
+        break;
+      float CV = CAN_UINT(off) / 1024.0f;
+      if (CV >= 0.5f && CV <= 5.5f)  // simple sanity window
+        BmsSetCellVoltage(cell_index, CV);
     }
 }
 
 void OvmsVehicleSmartEQ::PollReply_BMS_BattTemps(const char* data, uint16_t reply_len)
 {
   // Each temperature = 2 bytes. reply_len is number of bytes.
-  if (reply_len < 6) return;
+  REQUIRE_LEN(6);
 
   // We will not read beyond reply_len:
   uint16_t max_bytes = reply_len & 0xFFFE; // even boundary
+  if (max_bytes > 62) max_bytes = 62;      // max 31 pairs
+  // Each pair = 2 bytes:
   uint16_t max_pairs = max_bytes / 2;
   if (max_pairs > 31) max_pairs = 31;
 
@@ -360,38 +349,160 @@ void OvmsVehicleSmartEQ::PollReply_BMS_BattTemps(const char* data, uint16_t repl
   if (cellcount > 27) cellcount = 27; // 31 total - 3 offset = 28 max, but original loop used <30 -> 27 cells
   for (uint16_t i = 0; i < cellcount; i++)
     {
-    if (!std::isnan(BMStemps[i+3]))
-      BmsSetCellTemperature(i, BMStemps[i+3]);
+      if (!std::isnan(BMStemps[i+3]) && i < 27) // ensure bound 0..26
+        BmsSetCellTemperature(i, BMStemps[i+3]);
     }
 }
 
-void OvmsVehicleSmartEQ::PollReply_BMS_BattState(const char* data, uint16_t reply_len) {
-  // Offsets used: up to byte 22 -> need >= 23 bytes
-  if (reply_len < 23) return;
-  mt_bms_CV_Range_min->SetValue( CAN_UINT(0) / 1024.0 );
-  mt_bms_CV_Range_max->SetValue( CAN_UINT(2) / 1024.0 );
-  mt_bms_CV_Range_mean->SetValue( (mt_bms_CV_Range_max->AsFloat() + mt_bms_CV_Range_min->AsFloat()) / 2.0 );
-  mt_bms_BattLinkVoltage->SetValue( CAN_UINT(4) / 64.0 );
-  mt_bms_BattCV_Sum->SetValue( CAN_UINT(6) / 64.0 );
-  mt_bms_BattPower_voltage->SetValue( CAN_UINT(8) );
-  int16_t value = CAN_UINT(10);
-  if (value > 0x1fff) {
-    mt_bms_BattPower_current->SetValue( (float) value - 0xffff );
-  } else {
-    mt_bms_BattPower_current->SetValue( value );
+void OvmsVehicleSmartEQ::PollReply_BMS_BattState(const char* data, uint16_t reply_len)
+{
+  // New layout per “ReadData.Actual Data Read” spec:
+  // Byte 0 : 0x61 (positive response to 0x21)
+  // Byte 1 : 0x07 (identifier)
+  // Byte 2 : status / unused (observed 0x00)
+  // Byte 3-4  Minimum Cell Voltage        /1024 (V)
+  // Byte 5-6  Maximum Cell Voltage        /1024 (V)
+  // Byte 7-8  Traction (Link) Voltage     /64   (V)
+  // Byte 9-10 Sum of Cell Voltages        (raw total HV = BattCV_Sum/64)
+  // Byte 11-12 Battery Voltage            /64   (V)
+  // Byte 13-14 Battery Current            /32 (A)
+  // Byte 15   State Contactor             enum (0=open,1=precharge,2=closed,3=SNA)
+  // Byte 16   Interlock HV Plug           0=disable,1=enable
+  // Byte 17   Interlock Service Disc      0=disable,1=enable
+  // Byte 18-19 LBC FUSI Mode              enum (0=No Error,4=HVBatLevel1 Failure,6=HVBatLevel2 Failure)
+  // Byte 20-21 MG Output Revolution       /2 (rpm)
+  // Byte 22   SafetyMode1Flag             enum (0 Not Used,1 No Safety Mode,2 Safety Mode 1 Requested,3 Unavailable)
+  // Byte 23   Bitfield:
+  //            bits4-5 High voltage relay status flag (0 not active,1 active,2 undefined)
+  //            bits6-7 Relay on Permit Flag          (0 not active,1 active,2 undefined)
+  // Byte 24   Vehicle Mode Request        enum (0..7)
+  // Byte 25   Clamp 30 Voltage            /8 (V) (+ optional offset)
+  //
+  // Need at least up to byte 22 => length >= 23
+  REQUIRE_LEN(23);
+
+  float v_cell_min = (float)CAN_UINT(0) / 1024.0f;
+  float v_cell_max = (float)CAN_UINT(2) / 1024.0f;
+  float v_link     = (float)CAN_UINT(4) / 64.0f;
+  float cv_sum_raw = (float)CAN_UINT(6) / 64.0f;
+  float v_power_raw = (float)CAN_UINT(8);  // raw scaled*64
+  float v_pack_term = (float)CAN_UINT(9) / 64.0f; // battery terminal voltage (may equal link voltage depending on contactor)
+  uint16_t cur_u = CAN_UINT(10);
+  int16_t  cur_s = (int16_t)cur_u;
+  float    cur_raw = (float)cur_s;      // raw signed counts
+  float i_pack = cur_raw / 32.0f;
+
+  mt_bms_CV_Range_min->SetValue(v_cell_min);
+  mt_bms_CV_Range_max->SetValue(v_cell_max);
+  mt_bms_CV_Range_mean->SetValue((v_cell_min + v_cell_max) / 2.0f);
+
+  mt_bms_BattLinkVoltage->SetValue(v_link);
+  mt_bms_BattContactorVoltage->SetValue(v_pack_term);
+  mt_bms_BattCV_Sum->SetValue(cv_sum_raw);
+  mt_bms_BattPower_voltage->SetValue(v_power_raw); // store raw scaled*64 so existing power calc logic can adapt if needed
+  mt_bms_BattPower_current->SetValue(cur_raw);        // raw current counts
+
+  // Compute power (re-using prior scaling: voltage_raw/64 * current_raw/32)
+  float pack_power_kw = ((v_power_raw  / 64.0f) * ( (float)cur_raw / 32.0f )) / 1000.0f;
+  mt_bms_BattPower_power->SetValue(pack_power_kw);
+
+  int contactor_code = CAN_BYTE(12);
+  const char* contactor_txt;
+  switch (contactor_code)
+  {
+    case 0: contactor_txt="open"; break;
+    case 1: contactor_txt="precharge"; break;
+    case 2: contactor_txt="closed"; break;
+    case 3: contactor_txt="SNA"; break;
+    default: contactor_txt="Unknown"; break;
   }
-  mt_bms_BattPower_power->SetValue( mt_bms_BattPower_voltage->AsFloat() / 64.0 * mt_bms_BattPower_current->AsFloat() / 32.0 / 1000.0 );
+  mt_bms_HVcontactStateCode->SetValue(contactor_code);
+  mt_bms_HVcontactStateTXT->SetValue(contactor_txt);
 
-  mt_bms_HVcontactState->SetValue( CAN_BYTE(12) );
-  mt_bms_HV->SetValue( mt_bms_BattCV_Sum->AsFloat() );
-  mt_bms_EVmode->SetValue( CAN_BYTE(21) );
-  mt_bms_LV->SetValue( CAN_BYTE(22) / 8.0 );
+  // HV (sum of cell voltages) – keep legacy assignment:
+  mt_bms_HV->SetValue(mt_bms_BattCV_Sum->AsFloat());
 
-  mt_bms_Amps->SetValue( mt_bms_BattPower_current->AsFloat() );
-  mt_bms_Amps2->SetValue( mt_bms_BattPower_current->AsFloat() / 32.0 );
-  mt_bms_Power->SetValue( mt_bms_HV->AsFloat() * mt_bms_Amps2->AsFloat() / 1000.0 );
-  StdMetrics.ms_v_bat_current->SetValue( mt_bms_Amps2->AsFloat(0) * -1.0f );
-  StdMetrics.ms_v_bat_power->SetValue( mt_bms_Power->AsFloat(0) );
+  int veh_mode = CAN_BYTE(21);
+  const char* veh_mode_txt;
+  switch (veh_mode)
+  {
+    case 0: veh_mode_txt="No Request"; break;
+    case 1: veh_mode_txt="Slow Charging(Isolated Charging)"; break;
+    case 2: veh_mode_txt="Fast Charging"; break;
+    case 3: veh_mode_txt="Normal"; break;
+    case 4: veh_mode_txt="Quick Drop"; break;
+    case 5: veh_mode_txt="Cameleon (Non-Isolated Charging)"; break;
+    case 6: veh_mode_txt="Not Used"; break;
+    case 7: veh_mode_txt="Unavailable Value"; break;
+    default: veh_mode_txt="Unknown"; break;
+  }
+  mt_bms_EVmode->SetValue(veh_mode);
+  mt_bms_EVmode_txt->SetValue(veh_mode_txt);
+
+  // Clamp 30 Voltage:
+  float clamp30 = ((float)(uint8_t)CAN_BYTE(22)) / 8.0f + m_12v_measured_BMS_offset;
+  if (clamp30 > 5 && clamp30 < 20)  // plausible 12V system window
+    mt_bms_12v->SetValue(clamp30);
+
+  // Publish derived standard metrics (sign convention: discharge negative):
+  StdMetrics.ms_v_bat_current->SetValue(i_pack * -1.0f);
+  StdMetrics.ms_v_bat_power->SetValue(pack_power_kw);
+
+  mt_bms_interlock_hvplug->SetValue(((int)CAN_BYTE(13)) == 1);
+  mt_bms_interlock_service->SetValue(((int)CAN_BYTE(14)) == 1);
+
+  int16_t flags23 = (int16_t)CAN_UINT(20);
+  uint8_t hv_relay_flag = (flags23 >> 4) & 0x03;
+  uint8_t relay_permit_flag = (flags23 >> 6) & 0x03;
+
+  mt_bms_relay_hv_status->SetValue(hv_relay_flag);
+  const char* hv_relay_txt;
+  switch (hv_relay_flag)
+  {
+    case 0: hv_relay_txt="not active"; break;
+    case 1: hv_relay_txt="active"; break;
+    default: hv_relay_txt="undefined"; break;
+  }
+  mt_bms_relay_hv_status_txt->SetValue(hv_relay_txt);
+
+  mt_bms_relay_permit_flag->SetValue(relay_permit_flag);
+  const char* relay_permit_txt;
+  switch (relay_permit_flag)
+  {
+    case 0: relay_permit_txt="not active"; break;
+    case 1: relay_permit_txt="active"; break;
+    default: relay_permit_txt="undefined"; break;
+  }
+  mt_bms_relay_permit_flag_txt->SetValue(relay_permit_txt);
+
+  int fusi = CAN_BYTE(15);
+  const char* fusi_txt;
+  if (fusi == 0) fusi_txt = "No Error";
+  switch (fusi)
+  {
+    case 0: fusi_txt="No Error"; break;
+    case 4: fusi_txt="HVBatLevel1 Failure"; break;
+    case 6: fusi_txt="HVBatLevel2 Failure"; break;
+    default: fusi_txt="Unavailable Value"; break;
+  }
+  mt_bms_fusi_mode->SetValue((int)fusi);
+  mt_bms_fusi_mode_txt->SetValue(fusi_txt);
+
+  float mg_rpm_raw = CAN_UINT(17);
+  float mg_rpm = mg_rpm_raw / 2.0f;
+  mt_bms_mg_rpm->SetValue(mg_rpm);
+
+  int safety = CAN_BYTE(19);
+  const char* safety_txt;
+  switch (safety)
+  {
+    case 0: safety_txt="Not Used"; break;
+    case 1: safety_txt="No Safety Mode"; break;
+    case 2: safety_txt="Safety Mode 1 Requested"; break;
+    default: safety_txt="Unavailable Value"; break;
+  }
+  mt_bms_safety_mode->SetValue(safety);
+  mt_bms_safety_mode_txt->SetValue(safety_txt);
 }
 
 void OvmsVehicleSmartEQ::PollReply_HVAC(const char* data, uint16_t reply_len) {
@@ -399,7 +510,7 @@ void OvmsVehicleSmartEQ::PollReply_HVAC(const char* data, uint16_t reply_len) {
 }
 
 void OvmsVehicleSmartEQ::PollReply_TDB(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(5);             // minimal sanity
   float temp = (float)(CAN_UINT(2)) > 400.0f ? 
     (float)(CAN_UINT(2) - 400.0f) * 0.1f : 
     (float)(400.0f - CAN_UINT(2)) * -0.1f;
@@ -422,54 +533,101 @@ void OvmsVehicleSmartEQ::PollReply_TDB(const char* data, uint16_t reply_len) {
 }
 
 void OvmsVehicleSmartEQ::PollReply_VIN(const char* data, uint16_t reply_len) {
-  std::string vin = data;
-  StdMetrics.ms_v_vin->SetValue(vin.substr(0, vin.length() - 2));
+  // Expect at least 17 VIN chars; responses often carry +2 bytes (CRC / filler)
+  if (reply_len < 17) {
+    ESP_LOGW(TAG,"VIN reply too short (%u)", reply_len);
+    return;
+  }
+  size_t vinlen = (reply_len >= 19) ? 17 : reply_len; // if only 17, take all
+  std::string vin(data, vinlen);
+  // Basic sanity: only allow [A-Z0-9]
+  for (char &c: vin) {
+    if (!( (c>='A'&&c<='Z') || (c>='0'&&c<='9') ))
+    { ESP_LOGW(TAG,"Discarding VIN (invalid char)"); return; }
+  }
+  StdMetrics.ms_v_vin->SetValue(vin);
+}
+
+void OvmsVehicleSmartEQ::PollReply_VehicleState(const char* data, uint16_t reply_len) {
+  REQUIRE_LEN(1);
+  int code = CAN_BYTE(0);
+  std::string msgtxt = "";
+  switch(code) {
+    case 0: msgtxt = "SLEEPING"; break; 
+    case 1: msgtxt = "TECHNICAL WAKE UP"; break;
+    case 2: msgtxt = "CUT OFF PENDING"; break;
+    case 3: msgtxt = "BAT TEMPO LEVEL"; break;
+    case 4: msgtxt = "BAT TEMPO LEVEL"; break;
+    case 5: msgtxt = "ACCESSORY LEVEL"; break;
+    case 6: msgtxt = "IGNITION LEVEL"; break;
+    case 7: msgtxt = "STARTING IN PROGRESS"; break;
+    case 8: msgtxt = "ENGINE RUNNING"; break;
+    case 9: msgtxt = "AUTOSTART"; break;
+    case 10: msgtxt = "ENGINE SYSTEM STOP"; break;
+    default: msgtxt = "Unknown code"; break;
+  }
+  mt_vehicle_state->SetValue(msgtxt);
+  mt_vehicle_state_code->SetValue(code);
+  //mt_bus_awake->SetValue(code > 0);
+}
+
+void OvmsVehicleSmartEQ::PollReply_DoorUnderhoodOpened(const char* data, uint16_t reply_len) {
+  REQUIRE_LEN(1);
+  int code = CAN_BYTE(0);
+  StdMetrics.ms_v_door_hood->SetValue(code==1);
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_HV_Energy(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_evc_hv_energy->SetValue( CAN_UINT(0) / 200.0f );
   StdMetrics.ms_v_bat_capacity->SetValue(mt_evc_hv_energy->AsFloat());
   StdMetrics.ms_v_bat_cac->SetValue(mt_evc_hv_energy->AsFloat() * 1000.0f / mt_bms_HV->AsFloat());
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_State(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(1);
   mt_evc_LV_DCDC_amps->SetValue( CAN_BYTE(0) );
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_Load(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(1);
   mt_evc_LV_DCDC_load->SetValue( CAN_BYTE(0) == 0xFE ? 0 : CAN_BYTE(0) );
 }
 
+void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_VoltReq(const char* data, uint16_t reply_len) {
+  REQUIRE_LEN(1);
+  float value = CAN_BYTE(0);
+  mt_evc_LV_DCDC_volt_req->SetValue( value - 12.0f );
+}
 void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_Volt(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  mt_evc_LV_DCDC_volt->SetValue( CAN_BYTE(0) );
+  REQUIRE_LEN(1);  
+  float value = CAN_BYTE(0);
+  mt_evc_LV_DCDC_volt->SetValue( value - 4.0f);
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_Amps(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  mt_evc_LV_DCDC_power->SetValue( CAN_BYTE(0) );
+  REQUIRE_LEN(1);    
+  float value = CAN_BYTE(0);
+  mt_evc_LV_DCDC_power->SetValue( value );
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_Power(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_evc_LV_DCDC_state->SetValue( CAN_UINT(0) );
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_ext_power(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_evc_ext_power->SetValue(CAN_UINT(0)>0);
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_plug_present(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_evc_plug_present->SetValue(CAN_UINT(0)>0);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_ChargerAC(const char* data, uint16_t reply_len) {
-  if (reply_len < 16) return;
+  REQUIRE_LEN(16);
   int32_t value;
   //Get AC Currents (two rails from >= 20A, sum up for total current)
   value = CAN_UINT(6);
@@ -496,7 +654,9 @@ void OvmsVehicleSmartEQ::PollReply_OBL_ChargerAC(const char* data, uint16_t repl
   mt_obl_main_volts->SetElemValue(1, 0); mt_obl_main_volts->SetElemValue(2, 0);
   //Get AC Frequency
   if (mt_obl_main_amps->GetElemValue(0) > 0 || mt_obl_main_amps->GetElemValue(1) > 0) {
-    mt_obl_main_freq->SetValue( CAN_BYTE(11) / 100.0f);
+    float value = CAN_BYTE(11);
+    if (value < 0xF0)  //OBL showing only valid data while charging
+      mt_obl_main_freq->SetValue( CAN_BYTE(11) + 10.0f);
   } else {
     mt_obl_main_freq->SetValue(0);
   }
@@ -517,42 +677,42 @@ void OvmsVehicleSmartEQ::PollReply_OBL_ChargerAC(const char* data, uint16_t repl
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph1_RMS_A(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   float value = ((CAN_UINT(0) * 0.625) - 2000) / 10.0;
   mt_obl_main_amps->SetElemValue(0, value);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph2_RMS_A(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   float value = ((CAN_UINT(0) * 0.625) - 2000) / 10.0;
   mt_obl_main_amps->SetElemValue(1, value);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph3_RMS_A(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   float value = ((CAN_UINT(0) * 0.625) - 2000) / 10.0;
   mt_obl_main_amps->SetElemValue(2, value);
   UpdateChargeMetrics();
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph12_RMS_V(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_obl_main_volts->SetElemValue(0, CAN_UINT(0) / 2.0);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph23_RMS_V(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_obl_main_volts->SetElemValue(1, CAN_UINT(0) / 2.0);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph31_RMS_V(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_obl_main_volts->SetElemValue(2, CAN_UINT(0) / 2.0);
   UpdateChargeMetrics();
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Power(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   if(CAN_UINT(0) > 20000) {
     mt_obl_main_CHGpower->SetElemValue(0, (CAN_UINT(0) - 20000.0f) / 1000.0f);
   }else{
@@ -561,186 +721,94 @@ void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Power(const char* data, uint16_t re
   // mt_obl_main_CHGpower->SetElemValue(0, (CAN_UINT(0) - 20000) / 1000.0f);
   UpdateChargeMetrics();
 }
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Frequency(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  mt_obl_main_freq->SetValue((float) CAN_UINT(0) + 10.0f);
-}
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_CurrentSum(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  float value1 = (float) CAN_UINT(0);
-  float value2 = value1 -600.0f >= 0.0f ? value1 -600.0f : (-600.0f - value1) * -1.0f;
-  mt_obl_main_amps_sum->SetValue(value2 / 1000.0f);
-}
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_VoltageSum(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  float value1 = (float) CAN_UINT(0);
-  float value2 = value1 -16000.0f >= 0.0f ? value1 -16000.0f : (-16000.0f - value1) * -1.0f;
-  mt_obl_main_volts_sum->SetValue(value2 / 1000.0f);
-}
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_HVNetCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  float value1 = (float) CAN_UINT(0);
-  float value2 = value1 -200.0f >= 0.0f ? value1 -200.0f : (-200.0f - value1) * -1.0f;
-  mt_obl_main_hv_net_amps->SetValue(value2 / 1000.0f);
-}
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_HVVoltageSum(const char* data, uint16_t reply_len)
-{
-  if (reply_len < 1) return;
-  float value1 = (float)CAN_UINT(0);
-  float value2 = value1 >= 1023.0f ? (value1 - 1023.0f) : (1023.0f - value1) * -1.0f;
-  mt_obl_main_hv_volts_sum->SetValue(value2 / 1000.0f);
-}
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_RawDCCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  float value1 = (float) CAN_UINT(0);
-  float value2 = value1 -2048.0f >= 0.0f ? value1 -2048.0f : (-2048.0f - value1) * -1.0f;
-  mt_obl_main_current_leakage_dc_raw->SetValue(value2 / 1000.0f);
-} 
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_RawHF10kHz(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  float value1 = (float) CAN_UINT(0);
-  float value2 = value1 -2048.0f >= 0.0f ? value1 -2048.0f : (-2048.0f - value1) * -1.0f;
-  mt_obl_main_current_leakage_hf_10khz_raw->SetValue(value2 / 1000.0f);
-}
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_RawHFCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  float value1 = (float) CAN_UINT(0);
-  float value2 = value1 -2048.0f >= 0.0f ? value1 -2048.0f : (-2048.0f - value1) * -1.0f;
-  mt_obl_main_current_leakage_hf_raw->SetValue(value2 / 1000.0f);
-}
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_RawLFCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
-  float value1 = (float) CAN_UINT(0);
-  float value2 = value1 -2048.0f >= 0.0f ? value1 -2048.0f : (-2048.0f - value1) * -1.0f;
-  mt_obl_main_current_leakage_lf_raw->SetValue(value2 / 1000.0f);
-}
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_GroundResistance(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_obl_main_ground_resistance->SetValue((float) CAN_UINT(0));
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_LeakageDiag(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(1);
   int code = CAN_BYTE(0);
   std::string msgtxt = "";
   switch(code) {
-    case 0:{
-      msgtxt = "init";
-      break;
-    } 
-    case 1:{
-      msgtxt = "HF10";
-      break;
-    }
-    case 3:{
-      msgtxt = "Mains Ground Default";
-      break;
-    }
-    case 97:{
-      msgtxt = "Means Leakage LF+HF";
-      break;
-    }
-    case 5:{
-      msgtxt = "Earth Current default";
-      break;
-    }
-    case 81:{
-      msgtxt = "Means Leakage DC+HF";
-      break;
-    }
-    case 65:{
-      msgtxt = "Means Leakage HF";
-      break;
-    }
-    case 9:{
-      msgtxt = "Ground Default";
-      break;
-    }
-    case 49:{
-      msgtxt = "Means Leakage DC+LF";
-      break;
-    }
-    case 17:{
-      msgtxt = "Means Leakage DC";
-      break;
-    }
-    case 113:{
-      msgtxt = "Means Leakage DC+LF+HF";
-      break;
-    }
-    case 33:{
-      msgtxt = "Means Leakage LF";
-      break;
-    }
-    default:{
-      msgtxt = "Unknown code";
-      break;
-    }
+    case 0: msgtxt = "init"; break;
+    case 1: msgtxt = "HF10"; break;
+    case 3: msgtxt = "Mains Ground Default"; break;
+    case 97: msgtxt = "Means Leakage LF+HF"; break;
+    case 5: msgtxt = "Earth Current default"; break;
+    case 81: msgtxt = "Means Leakage DC+HF"; break;
+    case 65: msgtxt = "Means Leakage HF"; break;
+    case 9: msgtxt = "Ground Default"; break;
+    case 49: msgtxt = "Means Leakage DC+LF"; break;
+    case 17: msgtxt = "Means Leakage DC"; break;
+    case 113: msgtxt = "Means Leakage DC+LF+HF"; break;
+    case 33: msgtxt = "Means Leakage LF"; break;
+    default: msgtxt = "Unknown code"; break;
   }
   mt_obl_main_leakage_diag->SetValue(msgtxt);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_DCCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   float value1 = (float) CAN_UINT(0);
   float value2 = value1 -32768.0f >= 0.0f ? value1 -32768.0f : (-32768.0f - value1) * -1.0f;
   mt_obl_main_current_leakage_dc->SetValue(value2 / 1000.0f);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_HF10kHz(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   float value1 = (float) CAN_UINT(0);
   float value2 = value1 -32768.0f >= 0.0f ? value1 -32768.0f : (-32768.0f - value1) * -1.0f;
   mt_obl_main_current_leakage_hf_10khz->SetValue(value2 / 1000.0f);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_HFCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   float value1 = (float) CAN_UINT(0);
   float value2 = value1 -32768.0f >= 0.0f ? value1 -32768.0f : (-32768.0f - value1) * -1.0f;
   mt_obl_main_current_leakage_hf->SetValue(value2 / 1000.0f);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_LFCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   float value1 = (float) CAN_UINT(0);
   float value2 = value1 -32768.0f >= 0.0f ? value1 -32768.0f : (-32768.0f - value1) * -1.0f;
   mt_obl_main_current_leakage_lf->SetValue(value2 / 1000.0f);
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_MaxCurrent(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(1);
   mt_obl_main_max_current->SetValue((float) CAN_BYTE(0));
 }
 
 
 void OvmsVehicleSmartEQ::PollReply_obd_trip(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_obd_trip_km->SetValue((float) CAN_UINT(0));
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_time(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(3);
   int value_1 = CAN_UINT24(0);
   std::string timeStr = SecondsToHHmm(value_1);
   mt_obd_trip_time->SetValue( timeStr );
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_start_trip(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   mt_obd_start_trip_km->SetValue((float) CAN_UINT(0));
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_start_time(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(3);
   int value_1 = CAN_UINT24(0);
   std::string timeStr = SecondsToHHmm(value_1);
   mt_obd_start_trip_time->SetValue( timeStr );
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_mt_day(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   int value = CAN_UINT(0);
   if (value > 0) { // excluding value of 0 seems to be necessary for now
     // Send notification?
@@ -779,7 +847,7 @@ void OvmsVehicleSmartEQ::PollReply_obd_mt_day(const char* data, uint16_t reply_l
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_mt_km(const char* data, uint16_t reply_len) {
-  if (reply_len < 1) return;
+  REQUIRE_LEN(2);
   int value = CAN_UINT(0);
   StdMetrics.ms_v_env_service_range->SetValue(value); // set next service in km
   mt_obd_mt_km_usual->SetValue(value);
@@ -789,11 +857,20 @@ void OvmsVehicleSmartEQ::PollReply_obd_mt_level(const char* data, uint16_t reply
   if (reply_len < 1) return;
   int value = CAN_UINT(0);
   std::string txt;
-  if (value == 0) {
+  if (value == 0) 
+    {
     txt = "Service A";
-  } else {
+    }
+  else if (value == 1) 
+    {
     txt = "Service B";
-  }
+    } 
+  else 
+    {
+    std::ostringstream oss;
+    oss << "Unknown " << value;
+    txt = oss.str();
+    }
   mt_obd_mt_level->SetValue(txt.c_str());
   StdMetrics.ms_v_gen_substate->SetValue(txt.c_str());
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -53,6 +53,14 @@ static const char *TAG = "v-smarteq";
 #endif
 #include "buffered_shell.h"
 
+// Abort frame processing early on short DLC.
+#define REQ_DLC(minlen)                                                \
+  if (p_frame->FIR.B.DLC < (minlen)) {                                 \
+    ESP_LOGV(TAG,"CAN %03X: DLC %u < %u -> ignore frame",              \
+      p_frame->MsgID, p_frame->FIR.B.DLC, (unsigned)(minlen));         \
+    return;                                                            \
+  }
+
 OvmsVehicleSmartEQ* OvmsVehicleSmartEQ::GetInstance(OvmsWriter* writer)
 {
   OvmsVehicleSmartEQ* smarteq = (OvmsVehicleSmartEQ*) MyVehicleFactory.ActiveVehicle();
@@ -68,7 +76,7 @@ OvmsVehicleSmartEQ* OvmsVehicleSmartEQ::GetInstance(OvmsWriter* writer)
 static const OvmsPoller::poll_pid_t obdii_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {  0,300,10,10 }, 0, ISOTP_STD }, // rqBattState
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {  0,300,60,60 }, 0, ISOTP_STD }, // rqBattState
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {  0,300,300,300 }, 0, ISOTP_STD }, // rqBattTemperatures
 //  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {  0,300,300,60 }, 0, ISOTP_STD }, // rqBattVoltages_P1
 //  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {  0,300,300,60 }, 0, ISOTP_STD }, // rqBattVoltages_P2
@@ -77,18 +85,21 @@ static const OvmsPoller::poll_pid_t obdii_polls[] =
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {  0,300,60,300 }, 0, ISOTP_STD }, // OBD start Trip Distance km 
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {  0,300,60,300 }, 0, ISOTP_STD }, // OBD Trip time s
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {  0,300,60,300 }, 0, ISOTP_STD }, // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {  0,3600,3600,3600 }, 0, ISOTP_STD }, // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {  0,3600,3600,3600 }, 0, ISOTP_STD }, // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {  0,3600,3600,3600 }, 0, ISOTP_STD }, // maintenance level
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {  0,3600,3600,3600 }, 0, ISOTP_STD }, // req.VIN
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320c, {  0,300,60,60 }, 0, ISOTP_STD }, // rqHV_Energy
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x302A, {  0,300,60,60 }, 0, ISOTP_STD }, // rqDCDC_State
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {  0,300,60,60 }, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {  0,300,60,60 }, 0, ISOTP_STD }, // rqDCDC_volt_measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {  0,300,60,60 }, 0, ISOTP_STD }, // rqDCDC_Amps
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {  0,300,60,60 }, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x33BA, {  0,300,60,60 }, 0, ISOTP_STD }, // indicates ext power supply
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {  0,0,0,10 }, 0, ISOTP_STD }, // charging plug present
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {  0,3600,300,0 }, 0, ISOTP_STD }, // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {  0,3600,300,0 }, 0, ISOTP_STD }, // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {  0,3600,300,0 }, 0, ISOTP_STD }, // maintenance level
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {  0,3600,0,0 }, 0, ISOTP_STD }, // req.VIN
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x8003, {  0,300,10,10 }, 0, ISOTP_STD },   // rq VehicleState
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x605e, {  0,300,10,10 }, 0, ISOTP_STD },   // rq UNDERHOOD_OPENED
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320c, {  0,300,60,30 }, 0, ISOTP_STD }, // rqHV_Energy
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x302A, {  0,300,60,30 }, 0, ISOTP_STD }, // rqDCDC_State
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {  0,300,60,30 }, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {  0,300,60,30 }, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {  0,300,60,30 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {  0,300,60,30 }, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {  0,300,60,30 }, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x33BA, {  0,300,60,30 }, 0, ISOTP_STD }, // indicates ext power supply
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {  0,300,10,10 }, 0, ISOTP_STD }, // charging plug present
 };
 
 static const OvmsPoller::poll_pid_t slow_charger_polls[] =
@@ -151,6 +162,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   m_warning_unlocked = false;
   m_modem_restart = false;
   m_modem_ticker = 0;
+  m_ADCfactor_recalc = false;
+  m_ADCfactor_recalc_timer = 0;
 
   m_enable_write = false;
   m_candata_timer = 0;
@@ -176,12 +189,15 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   BmsSetCellDefaultThresholdsVoltage(0.020, 0.030);
   BmsSetCellDefaultThresholdsTemperature(2.0, 3.0);
 
-  mt_bms_temps                  = new OvmsMetricVector<float>("xsq.v.bms.temps", SM_STALE_HIGH, Celcius);
   mt_bus_awake                  = MyMetrics.InitBool("xsq.v.bus.awake", SM_STALE_MIN, false);
   mt_use_at_reset               = MyMetrics.InitFloat("xsq.use.at.reset", SM_STALE_MID, 0, kWh);
   mt_use_at_start               = MyMetrics.InitFloat("xsq.use.at.start", SM_STALE_MID, 0, kWh);
   mt_canbyte                    = MyMetrics.InitString("xsq.ddt4all.canbyte", SM_STALE_NONE, "", Other);
   mt_dummy_pressure             = MyMetrics.InitFloat("xsq.dummy.pressure", SM_STALE_NONE, 235, kPa);  // Dummy pressure for TPMS alert testing
+  mt_vehicle_state              = MyMetrics.InitString("xsq.v.state", SM_STALE_MIN, "UNKNOWN", Other);
+  mt_vehicle_state_code         = MyMetrics.InitInt("xsq.v.state.code", SM_STALE_MIN, 0, Other);
+  mt_adc_factor                 = MyMetrics.InitFloat("xsq.adc.factor", SM_STALE_NONE, 0, Other);
+  mt_adc_factor_history         = new OvmsMetricVector<float>("xsq.adc.factor.history", SM_STALE_NONE, Other);
 
   mt_obd_duration               = MyMetrics.InitInt("xsq.obd.duration", SM_STALE_MID, 0, Minutes);
   mt_obd_trip_km                = MyMetrics.InitFloat("xsq.obd.trip.km", SM_STALE_MID, 0, Kilometers);
@@ -211,27 +227,12 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_evc_hv_energy              = MyMetrics.InitFloat("xsq.evc.hv.energy", SM_STALE_MID, 0, kWh);
   mt_evc_LV_DCDC_amps           = MyMetrics.InitFloat("xsq.evc.lv.dcdc.amps", SM_STALE_MID, 0, Amps);
   mt_evc_LV_DCDC_load           = MyMetrics.InitFloat("xsq.evc.lv.dcdc.load", SM_STALE_MID, 0, Percentage);
+  mt_evc_LV_DCDC_volt_req       = MyMetrics.InitFloat("xsq.evc.lv.dcdc.volt.req", SM_STALE_MID, 0, Volts);
   mt_evc_LV_DCDC_volt           = MyMetrics.InitFloat("xsq.evc.lv.dcdc.volt", SM_STALE_MID, 0, Volts);
   mt_evc_LV_DCDC_power          = MyMetrics.InitFloat("xsq.evc.lv.dcdc.power", SM_STALE_MID, 0, Watts);
   mt_evc_LV_DCDC_state          = MyMetrics.InitInt("xsq.evc.lv.dcdc.state", SM_STALE_MID, 0, Other);
   mt_evc_ext_power              = MyMetrics.InitBool("xsq.evc.ext.power", SM_STALE_MIN, false);
   mt_evc_plug_present           = MyMetrics.InitBool("xsq.evc.plug.present", SM_STALE_MIN, false);
-
-  mt_bms_CV_Range_min           = MyMetrics.InitFloat("xsq.bms.cv.range.min", SM_STALE_MID, 0, Volts);
-  mt_bms_CV_Range_max           = MyMetrics.InitFloat("xsq.bms.cv.range.max", SM_STALE_MID, 0, Volts);
-  mt_bms_CV_Range_mean          = MyMetrics.InitFloat("xsq.bms.cv.range.mean", SM_STALE_MID, 0, Volts);
-  mt_bms_BattLinkVoltage        = MyMetrics.InitFloat("xsq.bms.batt.link.voltage", SM_STALE_MID, 0, Volts);
-  mt_bms_BattCV_Sum             = MyMetrics.InitFloat("xsq.bms.batt.cv.sum", SM_STALE_MID, 0, Volts);
-  mt_bms_BattPower_voltage      = MyMetrics.InitFloat("xsq.bms.batt.voltage", SM_STALE_MID, 0, Volts);
-  mt_bms_BattPower_current      = MyMetrics.InitFloat("xsq.bms.batt.current", SM_STALE_MID, 0, Amps);
-  mt_bms_BattPower_power        = MyMetrics.InitFloat("xsq.bms.batt.power", SM_STALE_MID, 0, kW);
-  mt_bms_HVcontactState         = MyMetrics.InitInt("xsq.bms.hv.contact.state", SM_STALE_MID, 0, Other);
-  mt_bms_HV                     = MyMetrics.InitFloat("xsq.bms.hv", SM_STALE_MID, 0, Volts);
-  mt_bms_EVmode                 = MyMetrics.InitInt("xsq.bms.ev.mode", SM_STALE_MID, 0, Other);
-  mt_bms_LV                     = MyMetrics.InitFloat("xsq.bms.lv", SM_STALE_MID, 0, Volts);
-  mt_bms_Amps                   = MyMetrics.InitFloat("xsq.bms.amps", SM_STALE_MID, 0, Amps);
-  mt_bms_Amps2                  = MyMetrics.InitFloat("xsq.bms.amp2", SM_STALE_MID, 0, Amps);
-  mt_bms_Power                  = MyMetrics.InitFloat("xsq.bms.power", SM_STALE_MID, 0, kW);
 
   mt_obl_fastchg                = MyMetrics.InitBool("xsq.obl.fastchg", SM_STALE_MIN, false);
   mt_obl_main_volts             = new OvmsMetricVector<float>("xsq.obl.volts", SM_STALE_HIGH, Volts);
@@ -245,14 +246,37 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_obl_main_current_leakage_hf_10khz  = MyMetrics.InitFloat("xsq.obl.current.hf10kHz", SM_STALE_MID, 0, Amps);
   mt_obl_main_current_leakage_hf        = MyMetrics.InitFloat("xsq.obl.current.hf", SM_STALE_MID, 0, Amps);
   mt_obl_main_current_leakage_lf        = MyMetrics.InitFloat("xsq.obl.current.lf", SM_STALE_MID, 0, Amps);
-  //mt_obl_main_current_leakage_dc_raw    = MyMetrics.InitFloat("xsq.obl.current.dc.raw", SM_STALE_MID, 0, Amps);
-  //mt_obl_main_current_leakage_hf_10khz_raw = MyMetrics.InitFloat("xsq.obl.current.hf10kHz.raw", SM_STALE_MID, 0, Amps);
-  //mt_obl_main_current_leakage_hf_raw    = MyMetrics.InitFloat("xsq.obl.current.hf.raw", SM_STALE_MID, 0, Amps);
-  //mt_obl_main_current_leakage_lf_raw    = MyMetrics.InitFloat("xsq.obl.current.lf.raw", SM_STALE_MID, 0, Amps);
-  //mt_obl_main_amps_sum          = MyMetrics.InitFloat("xsq.obl.amps.sum", SM_STALE_MID, 0, Amps);
-  //mt_obl_main_volts_sum         = MyMetrics.InitFloat("xsq.obl.volts.sum", SM_STALE_MID, 0, Volts);
-  //mt_obl_main_hv_net_amps       = MyMetrics.InitFloat("xsq.obl.hv.net.amps", SM_STALE_MID, 0, Amps);
-  //mt_obl_main_hv_net_volts      = MyMetrics.InitFloat("xsq.obl.hv.net.volts", SM_STALE_MID, 0, Volts);
+
+  mt_bms_temps                  = new OvmsMetricVector<float>("xsq.bms.temps", SM_STALE_HIGH, Celcius);
+  mt_bms_CV_Range_min           = MyMetrics.InitFloat("xsq.bms.cv.range.min", SM_STALE_MID, 0, Volts);
+  mt_bms_CV_Range_max           = MyMetrics.InitFloat("xsq.bms.cv.range.max", SM_STALE_MID, 0, Volts);
+  mt_bms_CV_Range_mean          = MyMetrics.InitFloat("xsq.bms.cv.range.mean", SM_STALE_MID, 0, Volts);
+  mt_bms_BattLinkVoltage        = MyMetrics.InitFloat("xsq.bms.batt.link.voltage", SM_STALE_MID, 0, Volts);
+  mt_bms_BattContactorVoltage   = MyMetrics.InitFloat("xsq.bms.batt.contactor.voltage", SM_STALE_MID, 0, Volts);
+  mt_bms_BattCV_Sum             = MyMetrics.InitFloat("xsq.bms.batt.cv.sum", SM_STALE_MID, 0, Volts);
+  mt_bms_BattPower_voltage      = MyMetrics.InitFloat("xsq.bms.batt.voltage", SM_STALE_MID, 0, Volts);
+  mt_bms_BattPower_current      = MyMetrics.InitFloat("xsq.bms.batt.current", SM_STALE_MID, 0, Amps);
+  mt_bms_BattPower_power        = MyMetrics.InitFloat("xsq.bms.batt.power", SM_STALE_MID, 0, kW);
+  mt_bms_HVcontactStateCode     = MyMetrics.InitInt("xsq.bms.contact.code", SM_STALE_MID, 0, Other);
+  mt_bms_HVcontactStateTXT      = MyMetrics.InitString("xsq.bms.contact", SM_STALE_MID, "", Other);
+  mt_bms_HV                     = MyMetrics.InitFloat("xsq.bms.hv", SM_STALE_MID, 0, Volts);
+  mt_bms_EVmode                 = MyMetrics.InitInt("xsq.bms.ev.mode.code", SM_STALE_MID, 0, Other);
+  mt_bms_EVmode_txt             = MyMetrics.InitString("xsq.bms.ev.mode", SM_STALE_MID, "", Other);
+  mt_bms_12v                    = MyMetrics.InitFloat("xsq.bms.12v", SM_STALE_MID, 0, Volts);
+  mt_bms_Amps                   = MyMetrics.InitFloat("xsq.bms.amps", SM_STALE_MID, 0, Amps);
+  mt_bms_Amps2                  = MyMetrics.InitFloat("xsq.bms.amp2", SM_STALE_MID, 0, Amps);
+  mt_bms_Power                  = MyMetrics.InitFloat("xsq.bms.power", SM_STALE_MID, 0, kW);
+  mt_bms_interlock_hvplug       = MyMetrics.InitBool("xsq.bms.interlock.hvplug",SM_STALE_MID, false);
+  mt_bms_interlock_service      = MyMetrics.InitBool("xsq.bms.interlock.service", SM_STALE_MID, false);
+  mt_bms_fusi_mode              = MyMetrics.InitInt("xsq.bms.fusi.code",SM_STALE_MID, 0, Other);
+  mt_bms_fusi_mode_txt          = MyMetrics.InitString("xsq.bms.fusi",SM_STALE_MID, "", Other);
+  mt_bms_mg_rpm                 = MyMetrics.InitFloat("xsq.bms.mg.rpm",SM_STALE_MID, 0, Other);
+  mt_bms_safety_mode            = MyMetrics.InitInt("xsq.bms.safety.code",SM_STALE_MID, 0, Other);
+  mt_bms_safety_mode_txt        = MyMetrics.InitString("xsq.bms.safety",SM_STALE_MID, "", Other);
+  mt_bms_relay_hv_status        = MyMetrics.InitInt("xsq.bms.relay.hv.code",SM_STALE_MID, 0, Other);
+  mt_bms_relay_hv_status_txt    = MyMetrics.InitString("xsq.bms.relay.hv",SM_STALE_MID, "", Other);
+  mt_bms_relay_permit_flag      = MyMetrics.InitInt("xsq.bms.relay.permit.code",SM_STALE_MID, 0, Other);
+  mt_bms_relay_permit_flag_txt  = MyMetrics.InitString("xsq.bms.relay.permit",SM_STALE_MID, "", Other);
 
   // Start CAN bus in Listen-only mode - will be set according to m_enable_write in ConfigChanged()
   RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
@@ -268,7 +292,12 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   cmd_xsq->RegisterCommand("tpmsset", "set TPMS dummy value", xsq_tpms_set);
   cmd_xsq->RegisterCommand("ddt4all", "DDT4all Command", xsq_ddt4all,"<number>",1,1);
   cmd_xsq->RegisterCommand("ddt4list", "DDT4all Command List", xsq_ddt4list);
+  cmd_xsq->RegisterCommand("calcadc", "Recalculate ADC factor (optional: 12V voltage override)", xsq_calc_adc, "[voltage]", 0, 1);
 
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  MyEvents.RegisterEvent(TAG,"vehicle.charge.12v.start", std::bind(&OvmsVehicleSmartEQ::EventListener, this, _1, _2));
+  MyEvents.RegisterEvent(TAG,"vehicle.charge.12v.stop", std::bind(&OvmsVehicleSmartEQ::EventListener, this, _1, _2));
   MyConfig.RegisterParam("xsq", "smartEQ", true, true);
 
   ConfigChanged(NULL);
@@ -352,8 +381,6 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
     
     #ifdef CONFIG_OVMS_COMP_WIFI
       // Features option: auto restart modem on wifi disconnect
-      using std::placeholders::_1;
-      using std::placeholders::_2;
       MyEvents.RegisterEvent(TAG,"system.wifi.sta.disconnected", std::bind(&OvmsVehicleSmartEQ::ModemEventRestart, this, _1, _2));
 #endif
 
@@ -447,6 +474,8 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   m_modem_check       = MyConfig.GetParamValueBool("xsq", "modem.check", false);
   m_12v_charge        = MyConfig.GetParamValueBool("xsq", "12v.charge", true);
   m_v2_check          = MyConfig.GetParamValueBool("xsq", "v2.check", false);
+  m_12v_measured_BMS_offset = MyConfig.GetParamValueFloat("xsq", "12v.measured.BMS.offset", 0.25);
+  m_enable_calcADCfactor = MyConfig.GetParamValueBool("xsq", "calc.adcfactor", false);
   m_climate_system    = MyConfig.GetParamValueBool("xsq", "climate.system", false);
   m_network_type      = MyConfig.GetParamValue("xsq", "modem.net.type", "auto");
   m_indicator         = MyConfig.GetParamValueBool("xsq", "indicator", false);              //!< activate indicator e.g. 7 times or whtever
@@ -475,6 +504,19 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   }
   StdMetrics.ms_v_charge_limit_soc->SetValue((float) MyConfig.GetParamValueInt("xsq", "suffsoc", 0), Percentage );
   StdMetrics.ms_v_charge_limit_range->SetValue((float) MyConfig.GetParamValueInt("xsq", "suffrange", 0), Kilometers );
+}
+
+void OvmsVehicleSmartEQ::EventListener(std::string event, void* data) {
+  if (event == "vehicle.charge.start") {
+    if(m_enable_calcADCfactor && !m_ADCfactor_recalc) {
+      m_ADCfactor_recalc_timer = 4;   // wait at least 4 min. before recalculation
+      m_ADCfactor_recalc = true;      // recalculate ADC factor when HV charging
+    }
+  }
+  if (event == "vehicle.charge.stop") {
+      m_ADCfactor_recalc_timer = 0;
+      m_ADCfactor_recalc = false;     // stop recalculation when HV charging stopped
+  }
 }
 
 uint64_t OvmsVehicleSmartEQ::swap_uint64(uint64_t val) {
@@ -509,6 +551,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
   switch (p_frame->MsgID) {
     case 0x17e: //gear shift
     {
+      REQ_DLC(7);      // uses bytes up to at least index 6, so DLC must be 7 or more
       switch(CAN_BYTE(6)) {
         case 0x00: // Parking
           StdMetrics.ms_v_env_gear->SetValue(0);
@@ -530,28 +573,38 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       break;
     }
     case 0x350:
+      REQ_DLC(7);
       StdMetrics.ms_v_env_locked->SetValue((CAN_BYTE(6) == 0x96));
       break;
     case 0x392:
+      REQ_DLC(6);
       StdMetrics.ms_v_env_hvac->SetValue((CAN_BYTE(1) & 0x40) > 0);
       StdMetrics.ms_v_env_cabintemp->SetValue(CAN_BYTE(5) - 40.0f);
       break;
-    case 0x42E: // HV Voltage
-      _temp = ((c >> 13) & 0x7Fu) > 40.0f ? ((c >> 13) & 0x7Fu) - 40.0f : (40.0f - ((c >> 13) & 0x7Fu)) * -1.0f;
-      if(_temp != 87) StdMetrics.ms_v_bat_temp->SetValue(_temp); // HVBatteryTemperature
-      StdMetrics.ms_v_bat_voltage->SetValue((float) ((CAN_UINT(3)>>5)&0x3ff) / 2); // HV Voltage
-      StdMetrics.ms_v_charge_climit->SetValue((c >> 20) & 0x3Fu); // MaxChargingNegotiatedCurrent
+    case 0x42E:        // HV voltage / temp frame
+      REQ_DLC(6);
+      _temp = ((c >> 13) & 0x7Fu) > 40.0f
+              ? ((c >> 13) & 0x7Fu) - 40.0f
+              : (40.0f - ((c >> 13) & 0x7Fu)) * -1.0f;
+      if (_temp != 87.0f)
+        StdMetrics.ms_v_bat_temp->SetValue(_temp);
+      // needs bytes 3 & 4 (CAN_UINT(3)) ? DLC=5 already covered by 6 above
+      StdMetrics.ms_v_bat_voltage->SetValue((float)((CAN_UINT(3) >> 5) & 0x3ff) / 2.0f);
+      StdMetrics.ms_v_charge_climit->SetValue((c >> 20) & 0x3Fu);
       break;
     case 0x4F8:
+      REQ_DLC(3);
       StdMetrics.ms_v_env_handbrake->SetValue((CAN_BYTE(0) & 0x08) > 0);
       StdMetrics.ms_v_env_awake->SetValue((CAN_BYTE(0) & 0x40) > 0); // Ignition on
       break;
     case 0x5D7: // Speed, ODO
+      REQ_DLC(6);
       StdMetrics.ms_v_pos_speed->SetValue((float) CAN_UINT(0) / 100.0f);
       StdMetrics.ms_v_pos_odometer->SetValue((float) (CAN_UINT32(2)>>4) / 100.0f);
       mt_pos_odo_trip->SetValue((float) (CAN_UINT(4)>>4) / 100.0f); // ODO trip //TODO: check if this is correct
       break;
     case 0x5de:
+      REQ_DLC(8);
       StdMetrics.ms_v_env_headlights->SetValue((CAN_BYTE(0) & 0x04) > 0);
       StdMetrics.ms_v_door_fl->SetValue((CAN_BYTE(1) & 0x08) > 0);
       StdMetrics.ms_v_door_fr->SetValue((CAN_BYTE(1) & 0x02) > 0);
@@ -560,6 +613,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       StdMetrics.ms_v_door_trunk->SetValue((CAN_BYTE(7) & 0x10) > 0);
       break;
     case 0x646:
+      REQ_DLC(3);
       mt_use_at_reset->SetValue(CAN_BYTE(1) * 0.1);
       mt_use_at_start->SetValue(CAN_BYTE(2) * 0.1);
       if( MyConfig.GetParamValueBool("xsq", "bcvalue",  false)){
@@ -568,8 +622,10 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
         StdMetrics.ms_v_gen_kwh_grid_total->SetValue(0.0f);
       }
       break;
-    case 0x654: // SOC(b)
-      StdMetrics.ms_v_bat_soc->SetValue(CAN_BYTE(3));
+    case 0x654:        // SOC / charge port status
+      REQ_DLC(4);
+      _soc = (float) CAN_BYTE(3);
+      if (_soc <= 100.0f) StdMetrics.ms_v_bat_soc->SetValue(_soc); // SOC
       StdMetrics.ms_v_door_chargeport->SetValue((CAN_BYTE(0) & 0x20) != 0); // ChargingPlugConnected
       _duration_full = (((c >> 22) & 0x3ffu) < 0x3ff) ? (c >> 22) & 0x3ffu : 0;
       mt_obd_duration->SetValue((int)(_duration_full), Minutes);
@@ -577,7 +633,6 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       _bat_temp = StdMetrics.ms_v_bat_temp->AsFloat(0) - 20.0;
       _full_km = MyConfig.GetParamValueFloat("xsq", "full.km", 126.0);
       _range_cac = _full_km + (_bat_temp); // temperature compensation +/- range
-      _soc = StdMetrics.ms_v_bat_soc->AsFloat();
       if (_range_est != 1023.0f) 
         {
         StdMetrics.ms_v_bat_range_est->SetValue(_range_est);
@@ -589,9 +644,10 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
           }
         }
       break;
-    case 0x658: //
+    case 0x658:
+      REQ_DLC(6);
       _soh = (float)(CAN_BYTE(4) & 0x7Fu);
-      StdMetrics.ms_v_bat_soh->SetValue(_soh); // SOH
+      if (_soh <= 100.0f) StdMetrics.ms_v_bat_soh->SetValue(_soh); // SOH
       StdMetrics.ms_v_bat_health->SetValue(
         (_soh >= 95.0f) ? "excellent"
       : (_soh >= 85.0f) ? "good"
@@ -639,19 +695,22 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       lastCharging = isCharging;
       break;
     case 0x668:
+      REQ_DLC(1);
       vehicle_smart_car_on((CAN_BYTE(0) & 0x40) > 0); // Drive Ready
       break;
     case 0x673:
-    {
+      REQ_DLC(8);
       // Read TPMS pressure values:
-      for (int i = 0; i < 4; i++) {
-        if (CAN_BYTE(2 + i) != 0xff) {
+      for (int i = 0; i < 4; i++) 
+        {
+        if (CAN_BYTE(2 + i) != 0xff) 
+          {
           m_tpms_pressure[i] = (float) CAN_BYTE(2 + i) * 3.1; // kPa
           setTPMSValue(i, m_tpms_index[i]);
         }
       }
       break;
-    }
+    
     default:
       //ESP_LOGD(TAG, "IFC %03x 8 %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
       break;
@@ -723,7 +782,11 @@ void OvmsVehicleSmartEQ::DisablePlugin(const char* plugin) {
 }
 
 bool OvmsVehicleSmartEQ::ExecuteCommand(const std::string& command) {
-  
+  if (command.empty()) {
+    ESP_LOGE(TAG,"ExecuteCommand: empty command");
+    return Fail;
+  }
+
   std::string result = BufferedShell::ExecuteCommand(command, true);
   bool success = !result.empty();  // Consider command successful if output is not empty
   
@@ -825,22 +888,24 @@ void OvmsVehicleSmartEQ::TimeBasedClimateData() {
     if(_data[6]>-1) { mt_climate_1to3->SetValue(_data[6]);}
 
     if(_data[3]>0) { 
-      _climate_h = (_data[3] / 100) % 24;                      // Extract hours and ensure 24h format
-      _climate_m = _data[3] % 100;                             // Extract minutes
-      if(mt_climate_m->AsInt() >= 60) {                        // Handle invalid minutes
-          _climate_h = (_climate_h + _climate_m / 60) % 24;
-          _climate_m = mt_climate_m->AsInt() % 60;
-      }
-      
-      if (_data[3] >= 0 && _data[3] <= 2359) {
-        std::ostringstream oss;
-        oss << std::setfill('0') << std::setw(4) << _data[3];
-        mt_climate_time->SetValue(oss.str());
+      if (_data[3] > 2359 || (_data[3] % 100) > 59) {
+        ESP_LOGE(TAG,"Invalid HHMM time %d", _data[3]);
       } else {
-          ESP_LOGE(TAG, "Invalid time value: %d", _data[3]);
+        _climate_h = (_data[3] / 100) % 24;                      // Extract hours and ensure 24h format
+        _climate_m = _data[3] % 100;                             // Extract minutes
+        if(mt_climate_m->AsInt() >= 60) {                        // Handle invalid minutes
+            _climate_h = (_climate_h + _climate_m / 60) % 24;
+            _climate_m = mt_climate_m->AsInt() % 60;
+        }
+        
+        if (_data[3] >= 0 && _data[3] <= 2359) {
+          std::ostringstream oss;
+          oss << std::setfill('0') << std::setw(4) << _data[3];
+          mt_climate_time->SetValue(oss.str());
+        } else {
+            ESP_LOGE(TAG, "Invalid time value: %d", _data[3]);
+        }
       }
-      mt_climate_h->SetValue(_climate_h);
-      mt_climate_m->SetValue(_climate_m);
     } else {
       mt_climate_time->SetValue(_oldtime);
     }     
@@ -879,6 +944,7 @@ void OvmsVehicleSmartEQ::Check12vState() {
           m_12v_ticker = 0;
           ESP_LOGI(TAG, "Initiating climate control due to 12V alert");
           m_12v_charge_state = true;
+          m_climate_ticker = 3;
           CommandClimateControl(true);
           m_climate_ticker = 3;
       }
@@ -923,6 +989,50 @@ void OvmsVehicleSmartEQ::CheckV2State() {
   #else
       ESP_LOGD(TAG, "V2 server support not enabled");
   #endif // CONFIG_OVMS_COMP_SERVER_V2
+}
+
+void OvmsVehicleSmartEQ::ReCalcADCfactor(float can12V, OvmsWriter* writer) {
+  #ifdef CONFIG_OVMS_COMP_ADC
+    if (can12V < 10.0f || can12V > 15.0f) {
+      ESP_LOGW(TAG, "Skip ADC factor recalculation (invalid 12V input %.2f)", can12V);
+      if (writer) writer->printf("Skip ADC factor recalculation (invalid 12V input %.2f)\n", can12V);
+      return;
+    }
+    adc1_config_width(ADC_WIDTH_BIT_12);
+    adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_11);
+    uint32_t sum = 0;
+    for (int i=0;i<20;i++) {
+      vTaskDelay(3 / portTICK_PERIOD_MS);
+      sum += adc1_get_raw(ADC1_CHANNEL_0);
+    }
+    float adc_factor_prev = MyConfig.GetParamValueFloat("system.adc","factor12v", 195.7f);
+    float avg_raw = sum / 20.0f;
+    float V_batt = can12V;
+    float adc_factor_new = (V_batt > 0) ? (avg_raw / V_batt) : 0;
+    ESP_LOGI(TAG, "ADC recalculation: avg_raw=%.2f  V_batt=%.3f  factor=%.3f", avg_raw, V_batt, adc_factor_new);
+    if (writer) writer->printf("ADC recalculation: avg_raw=%.2f  V_batt=%.3f  factor=%.3f\n", avg_raw, V_batt, adc_factor_new);
+    if (adc_factor_new < 160.0f || adc_factor_new > 230.0f) {
+      ESP_LOGW(TAG, "Reject ADC factor %.3f (out of bounds, keeping %.3f)", adc_factor_new, adc_factor_prev);
+      if (writer) writer->printf("Reject ADC factor %.3f (out of bounds, keeping %.3f)\n", adc_factor_new, adc_factor_prev);
+      return;
+    }
+    m_adc_factor_history.push_back(adc_factor_new);
+    if (m_adc_factor_history.size() > 20)
+      m_adc_factor_history.pop_front();
+    float hist[20];
+    size_t n = m_adc_factor_history.size();
+    for (size_t i=0; i<n; ++i)
+      hist[i] = m_adc_factor_history[i];
+    if (n > 0)
+      mt_adc_factor_history->SetElemValues(0, n, hist);
+    mt_adc_factor->SetValue(adc_factor_new);
+    MyConfig.SetParamValueFloat("system.adc","factor12v", adc_factor_new);
+    ESP_LOGI(TAG, "New ADC factor stored: %.3f (prev %.3f, history size %u)", adc_factor_new, adc_factor_prev, (unsigned)n);
+    if (writer) writer->printf("New ADC factor stored: %.3f (prev %.3f, history size %u)\n", adc_factor_new, adc_factor_prev, (unsigned)n);
+  #else
+    ESP_LOGD(TAG, "ADC support not enabled");
+    if (writer) writer->puts("ADC support not enabled");
+  #endif
 }
 
 void OvmsVehicleSmartEQ::DoorLockState() {
@@ -1010,8 +1120,8 @@ void OvmsVehicleSmartEQ::HandleEnergy() {
 
   // Are we driving?
   if (power != 0.0 && StdMetrics.ms_v_env_on->AsBool()) {
-    // Update energy used and recovered
-    float energy = power / 3600.0;    // 1 second worth of energy in kwh's
+    // Update energy used and recovered   
+    float energy = power / 3600.0;       // 1 second worth of energy in kwh's
     if (energy < 0.0f){
       StdMetrics.ms_v_bat_energy_used->SetValue( StdMetrics.ms_v_bat_energy_used->AsFloat() - energy);
       StdMetrics.ms_v_bat_energy_used_total->SetValue( StdMetrics.ms_v_bat_energy_used_total->AsFloat() - energy);
@@ -1054,8 +1164,8 @@ void OvmsVehicleSmartEQ::Handlev2Server(){
  * Called once per 10 seconds from Ticker10
  */
 void OvmsVehicleSmartEQ::HandleCharging() {
-  float act_soc        = StdMetrics.ms_v_bat_soc->AsFloat(0);
-  float limit_soc       = StdMetrics.ms_v_charge_limit_soc->AsFloat(0);
+  float act_soc        = StdMetrics.ms_v_bat_soc->AsFloat(0, Percentage);
+  float limit_soc       = StdMetrics.ms_v_charge_limit_soc->AsFloat(0, Percentage);
   float limit_range     = StdMetrics.ms_v_charge_limit_range->AsFloat(0, Kilometers);
   float max_range       = StdMetrics.ms_v_bat_range_full->AsFloat(0, Kilometers);
   float charge_current  = -StdMetrics.ms_v_bat_current->AsFloat(0, Amps);
@@ -1176,7 +1286,7 @@ void OvmsVehicleSmartEQ::UpdateChargeMetrics() {
  * TODO: Should be calculated based on actual charge curve. Maybe in a later version?
  */
 int OvmsVehicleSmartEQ::calcMinutesRemaining(float target_soc, float charge_voltage, float charge_current) {
-  float bat_soc = StdMetrics.ms_v_bat_soc->AsFloat(100);
+  float bat_soc = StdMetrics.ms_v_bat_soc->AsFloat(0, Percentage);
   if (bat_soc > target_soc) {
     return 0;   // Done!
   }
@@ -1209,9 +1319,19 @@ void OvmsVehicleSmartEQ::HandlePollState() {
 void OvmsVehicleSmartEQ::CalculateEfficiency() {
   // float consumption = 0;
   if (StdMetrics.ms_v_pos_speed->AsFloat() >= 5) {
-    StdMetrics.ms_v_charge_kwh_grid->SetValue(((StdMetrics.ms_v_bat_energy_used->AsFloat() - StdMetrics.ms_v_bat_energy_recd->AsFloat()) / StdMetrics.ms_v_pos_trip->AsFloat()) * 100.0);
-    StdMetrics.ms_v_charge_kwh_grid_total->SetValue(((StdMetrics.ms_v_bat_energy_used_total->AsFloat() - StdMetrics.ms_v_bat_energy_recd_total->AsFloat()) / mt_pos_odometer_trip_total->AsFloat()) * 100.0);
-    StdMetrics.ms_v_bat_consumption->SetValue(mt_use_at_reset->AsFloat() * 10.0);
+    float mt_use_at_reset = StdMetrics.ms_v_bat_energy_used->AsFloat() - StdMetrics.ms_v_bat_energy_recd->AsFloat();
+    float mt_use_at_total = StdMetrics.ms_v_bat_energy_used_total->AsFloat() - StdMetrics.ms_v_bat_energy_recd_total->AsFloat();
+    float trip_km = StdMetrics.ms_v_pos_trip->AsFloat();
+    float trip_total_km = mt_pos_odometer_trip_total->AsFloat();
+    if (mt_use_at_reset > 0.1f) 
+      {
+      StdMetrics.ms_v_bat_consumption->SetValue(mt_use_at_reset * 10.0f);
+      if (trip_km > 0.1f) StdMetrics.ms_v_charge_kwh_grid->SetValue((mt_use_at_reset / trip_km) * 100.0f);
+      }
+    if (mt_use_at_total > 0.1f) 
+      {
+      if (trip_total_km > 0.1f) StdMetrics.ms_v_charge_kwh_grid_total->SetValue((mt_use_at_total / trip_total_km) * 100.0f);
+      }
   }
 }
 
@@ -1337,40 +1457,54 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker) {
               m_warning_unlocked = false;
           }
   
-  if (ticker % 60 == 0) { // Every 60 seconds
-
-    if(mt_climate_on->AsBool()) TimeCheckTask();
-    if(m_12v_charge && !StdMetrics.ms_v_env_on->AsBool()) Check12vState();
-    if(m_enable_lock_state && !StdMetrics.ms_v_env_on->AsBool()) DoorLockState();
-
-    #ifdef CONFIG_OVMS_COMP_SERVER_V2
-      if(m_v2_check) CheckV2State();
-    #endif
-
-    #if defined(CONFIG_OVMS_COMP_WIFI) || defined(CONFIG_OVMS_COMP_CELLULAR)
-      if(m_reboot_time > 0) Handlev2Server();
-    #endif
-
-    #ifdef CONFIG_OVMS_COMP_CELLULAR
-      if(m_network_type != m_network_type_ls) ModemNetworkType();
-    #endif
-
-    // DDT4ALL session timeout on 5 minutes
-    if (m_ddt4all) {
-      m_ddt4all_ticker++;
-      if (m_ddt4all_ticker >= 5) {
-        m_ddt4all = false;
-        m_ddt4all_ticker = 0;
-        ESP_LOGI(TAG, "DDT4ALL session timeout reached");
-        MyNotify.NotifyString("info", "xsq.ddt4all", "DDT4ALL session timeout reached");
-      }
-    }
-  }
-
-  if (ticker % 10 == 0) { // Every 10 seconds
+  if (ticker % 10 == 0) // Every 10 seconds
+    {
     if(m_enable_LED_state) OnlineState();
     if(m_climate_system) TimeBasedClimateData();
-  }
+    }
+}
+
+void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
+  if(mt_climate_on->AsBool()) TimeCheckTask();
+  if(m_12v_charge && !StdMetrics.ms_v_env_on->AsBool()) Check12vState();
+  if(m_enable_lock_state && !StdMetrics.ms_v_env_on->AsBool()) DoorLockState();
+
+  #ifdef CONFIG_OVMS_COMP_SERVER_V2
+    if(m_v2_check) CheckV2State();
+  #endif
+
+  #if defined(CONFIG_OVMS_COMP_WIFI) || defined(CONFIG_OVMS_COMP_CELLULAR)
+    if(m_reboot_time > 0) Handlev2Server();
+  #endif
+
+  #ifdef CONFIG_OVMS_COMP_CELLULAR
+    if(m_network_type != m_network_type_ls) ModemNetworkType();
+  #endif
+
+  // DDT4ALL session timeout on 5 minutes
+  if (m_ddt4all) 
+    {
+    m_ddt4all_ticker++;
+    if (m_ddt4all_ticker >= 5) 
+      {
+      m_ddt4all = false;
+      m_ddt4all_ticker = 0;
+      ESP_LOGI(TAG, "DDT4ALL session timeout reached");
+      MyNotify.NotifyString("info", "xsq.ddt4all", "DDT4ALL session timeout reached");
+      }
+    }
+
+  #ifdef CONFIG_OVMS_COMP_ADC
+  if (m_enable_calcADCfactor && m_ADCfactor_recalc) 
+    {
+    if (--m_ADCfactor_recalc_timer == 0) 
+      {
+      m_ADCfactor_recalc = false;
+      m_ADCfactor_recalc_timer = 4; // reset timer
+      ReCalcADCfactor(mt_bms_12v->AsFloat());
+      }
+    }
+  #endif
 }
 
 /**
@@ -1452,10 +1586,16 @@ OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCan(uint32_t txid,uin
   std::string request;
   std::string response;
   std::string reqstr = m_hl_canbyte;
+  if (reqstr.size() % 2 != 0) 
+    {
+    ESP_LOGE(TAG,"Invalid hex length");
+    return Fail;
+    }
 
-  if (wakeup) 
-  CommandWakeup();
-  else CommandWakeup2();
+  if (wakeup)
+    CommandWakeup();
+  else
+    CommandWakeup2();
 
   vTaskDelay(2000 / portTICK_PERIOD_MS);
   uint8_t protocol = ISOTP_STD;
@@ -1494,14 +1634,14 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandHomelink(int button, i
     }
     case 1:
     {
-      res = CommandClimateControl(true);
       m_climate_ticker = 2;
+      res = CommandClimateControl(true);
       break;
     }
     case 2:
-    {
-      res = CommandClimateControl(true);
+    {      
       m_climate_ticker = 3;
+      res = CommandClimateControl(true);
       break;
     }
     default:
@@ -1581,6 +1721,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandLock(const char* pin) 
   std::string request;
   std::string response;
   std::string reqstr = MyConfig.GetParamValue("xsq", "lock.byte", "30010000");
+  if (reqstr.size() % 2 != 0) 
+    {
+    ESP_LOGE(TAG,"Invalid hex length");
+    return Fail;
+    }
   
   request = hexdecode("10C0");
   int err = PollSingleRequest(m_can1, txid, rxid, request, response, timeout_ms, protocol);
@@ -1632,6 +1777,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandUnlock(const char* pin
   std::string request;
   std::string response;
   std::string reqstr = MyConfig.GetParamValue("xsq", "unlock.byte", "30010001");
+  if (reqstr.size() % 2 != 0) 
+    {
+    ESP_LOGE(TAG,"Invalid hex length");
+    return Fail;
+    }
   
   request = hexdecode("10C0");
   int err = PollSingleRequest(m_can1, txid, rxid, request, response, timeout_ms, protocol);
@@ -1687,6 +1837,11 @@ void OvmsVehicleSmartEQ::xsq_ddt4all(int verbosity, OvmsWriter* writer, OvmsComm
   smarteq->CommandDDT4all(atoi(argv[0]), writer);
 }
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, OvmsWriter* writer) {
+  if (number < 0 || number > 1000) {
+    writer->printf("DDT4all command out of range");
+    return Fail;
+  }
+
   OvmsVehicle::vehicle_command_t res = Fail;
   ESP_LOGI(TAG, "DDT4all number=%d", number);
 
@@ -2678,6 +2833,7 @@ void OvmsVehicleSmartEQ::NotifySOClimit() {
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::Command12Vcharge(int verbosity, OvmsWriter* writer) {
   writer->puts("12V charge on:");
+ 
   writer->printf("  12V: %s\n", (char*) StdMetrics.ms_v_bat_12v_voltage->AsUnitString("-", Native, 1).c_str());
   writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
   writer->printf("  CAC: %s\n", (char*) StdMetrics.ms_v_bat_cac->AsUnitString("-", Native, 1).c_str());
@@ -2722,7 +2878,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4List(int verbosity
   writer->printf("  Clear Diagnostic Information: 100\n");
   writer->printf("  activate DDT4all Commands for 5 minutes: 999\n");
   writer->printf("  -------------------------------\n");
-  writer->printf("  indicator 5x: 0\n");
+  writer->printf("  indicator 5x on: 0\n");
   writer->printf("  open tailgate (unlocked Car): 1\n");
   writer->printf("  -------------------------------\n");
   writer->printf("  AUTO WIPE true: 3\n");
@@ -2819,6 +2975,52 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4List(int verbosity
   writer->printf("  Digital Speedometer in km/h: 68\n");
   writer->printf("  Digital Speedometer always km/h: 69\n");
   return Success;
+}
+
+void OvmsVehicleSmartEQ::xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv) {
+  OvmsVehicleSmartEQ* smarteq = GetInstance(writer);
+  if (!smarteq)
+    return;
+  #ifdef CONFIG_OVMS_COMP_ADC
+  if (argc == 1) 
+    {
+    char* endp = nullptr;
+    double val = strtod(argv[0], &endp);
+    if (endp == argv[0] || *endp != 0) 
+      {
+      writer->puts("Error: invalid number");
+      return;
+      }
+    if (val < 11.0 || val > 15.0) 
+      {
+      writer->puts("Error: voltage out of plausible range (11.0–15.0)");
+      return;
+      }
+    writer->printf("Recalculating ADC factor using override voltage %.2fV\n", val);
+    smarteq->ReCalcADCfactor((float)val, writer);
+    return;
+    } 
+  else if (argc == 0) 
+    {
+    if (!smarteq->mt_bms_12v->IsDefined()) 
+      {
+      writer->puts("Error: BMS 12V metric not defined");
+      return;
+      }
+    float val = smarteq->mt_bms_12v->AsFloat();
+    if (val < 11.0 || val > 15.0) 
+      {
+      writer->puts("Error: BMS 12V voltage out of plausible range (11.0–15.0)");
+      return;
+      }
+    smarteq->ReCalcADCfactor(val, writer);
+    writer->printf("Recalculating ADC factor using %.2fV BMS voltage\n", val);
+    return;
+   }
+  #else
+    writer->puts("ADC component not enabled");
+    return;
+  #endif
 }
 
 /**
@@ -3009,7 +3211,7 @@ const std::string OvmsVehicleSmartEQ::GetFeature(int key)
 
 class OvmsVehicleSmartEQInit {
   public:
-  OvmsVehicleSmartEQInit();
+    OvmsVehicleSmartEQInit();
 } MyOvmsVehicleSmartEQInit __attribute__ ((init_priority (9000)));
 
 OvmsVehicleSmartEQInit::OvmsVehicleSmartEQInit() {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -34,6 +34,7 @@
 
 #include <atomic>
 #include <stdint.h>
+#include <deque>
 #include "can.h"
 #include "vehicle.h"
 
@@ -42,6 +43,7 @@
 #include "ovms_metrics.h"
 #include "ovms_command.h"
 #include "freertos/timers.h"
+#include "esp_timer.h"
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
 #include "ovms_webserver.h"
 #endif
@@ -111,6 +113,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void WifiRestart();
     void ModemRestart();
     void ModemEventRestart(std::string event, void* data);
+    void ReCalcADCfactor(float can12V, OvmsWriter* writer=nullptr);
+    void EventListener(std::string event, void* data);
 
 public:
     vehicle_command_t CommandClimateControl(bool enable) override;
@@ -162,6 +166,7 @@ public:
     static void xsq_tpms_set(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_ddt4all(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_ddt4list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
+    static void xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
 
   private:
     unsigned int m_candata_timer;
@@ -170,9 +175,12 @@ public:
     bool m_charge_finished;
     float m_tpms_pressure[4]; // kPa
     int m_tpms_index[4];
+    bool m_ADCfactor_recalc;       // request recalculation of ADC factor
+    int m_ADCfactor_recalc_timer;  // countdown timer for ADC factor recalculation
 
   protected:
     void Ticker1(uint32_t ticker) override;
+    void Ticker60(uint32_t ticker) override;
     void PollerStateTicker(canbus *bus) override;
     void GetDashboardConfig(DashboardConfig& cfg);
     virtual void CalculateEfficiency();
@@ -184,9 +192,12 @@ public:
     void PollReply_HVAC(const char* data, uint16_t reply_len);
     void PollReply_TDB(const char* data, uint16_t reply_len);
     void PollReply_VIN(const char* data, uint16_t reply_len);
+    void PollReply_VehicleState(const char* data, uint16_t reply_len);
+    void PollReply_DoorUnderhoodOpened(const char* data, uint16_t reply_len);
     void PollReply_EVC_HV_Energy(const char* data, uint16_t reply_len);
     void PollReply_EVC_DCDC_State(const char* data, uint16_t reply_len);
     void PollReply_EVC_DCDC_Load(const char* data, uint16_t reply_len);
+    void PollReply_EVC_DCDC_VoltReq(const char* data, uint16_t reply_len);
     void PollReply_EVC_DCDC_Volt(const char* data, uint16_t reply_len);
     void PollReply_EVC_DCDC_Amps(const char* data, uint16_t reply_len);
     void PollReply_EVC_DCDC_Power(const char* data, uint16_t reply_len);
@@ -214,15 +225,6 @@ public:
     void PollReply_OBL_JB2AC_HFCurrent(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_LFCurrent(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_MaxCurrent(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_CurrentSum(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_VoltageSum(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_HVNetCurrent(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_HVVoltageSum(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_RawDCCurrent(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_RawHF10kHz(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_RawHFCurrent(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_RawLFCurrent(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_Frequency(const char* data, uint16_t reply_len);
 
   protected:
     bool m_enable_write;                    // canwrite
@@ -251,6 +253,7 @@ public:
     std::string m_network_type;             //!< Network type from xsq.modem.net.type
     std::string m_network_type_ls;          //!< Network type last state reminder
     bool m_extendedStats;                   //!< extended stats for trip and maintenance data
+    std::deque<float> m_adc_factor_history; // ring buffer (max 20) for ADC factors
 
     #define DEFAULT_BATTERY_CAPACITY 17600
     #define MAX_POLL_DATA_LEN 126
@@ -262,41 +265,66 @@ public:
 
   protected:
     OvmsCommand *cmd_xsq;                               // command for xsq
-    OvmsMetricVector<float> *mt_bms_temps;              // BMS temperatures
     OvmsMetricBool          *mt_bus_awake;              // Can Bus active
     OvmsMetricFloat         *mt_use_at_reset;           // kWh use at reset in Display
     OvmsMetricFloat         *mt_use_at_start;           // kWh use at start in Display
+    OvmsMetricString        *mt_canbyte;                //!< DDT4all canbyte
+    OvmsMetricFloat         *mt_dummy_pressure;         //!< Dummy pressure for TPMS
+    OvmsMetricString        *mt_vehicle_state;          //!< vehicle state
+    OvmsMetricInt           *mt_vehicle_state_code;     //!< vehicle state code
+    OvmsMetricFloat         *mt_adc_factor;             // calculated ADC factor for 12V measurement
+    OvmsMetricVector<float> *mt_adc_factor_history;     // last 20 calculated ADC factors for 12V measurement
+
     OvmsMetricFloat         *mt_pos_odo_trip;           // odometer trip in km 
     OvmsMetricFloat         *mt_pos_odometer_start;     // remind odometer start
     OvmsMetricFloat         *mt_pos_odometer_start_total;     // remind odometer start for kWh/100km
     OvmsMetricFloat         *mt_pos_odometer_trip_total;// counted km for kWh/100km
-    OvmsMetricBool          *mt_obl_fastchg;            // ODOmeter at Start
+
     OvmsMetricFloat         *mt_evc_hv_energy;          //!< available energy in kWh
     OvmsMetricFloat         *mt_evc_LV_DCDC_amps;       //!< current of DC/DC LV system, not 12V battery!
     OvmsMetricFloat         *mt_evc_LV_DCDC_load;       //!< load in % of DC/DC LV system, not 12V battery!
+    OvmsMetricFloat         *mt_evc_LV_DCDC_volt_req;   //!< voltage request in V of DC/DC LV system, not 12V battery!
     OvmsMetricFloat         *mt_evc_LV_DCDC_volt;       //!< voltage in V of DC/DC output of LV system, not 12V battery!
     OvmsMetricFloat         *mt_evc_LV_DCDC_power;      //!< power in W (x/10) of DC/DC output of LV system, not 12V battery!
     OvmsMetricInt           *mt_evc_LV_DCDC_state;      //!< DC/DC state
     OvmsMetricBool          *mt_evc_ext_power;          //!< indicates ext power supply
     OvmsMetricBool          *mt_evc_plug_present;       //!< charging plug present
+
+    OvmsMetricVector<float> *mt_bms_temps;              // BMS temperatures
     OvmsMetricFloat         *mt_bms_CV_Range_min;       //!< minimum cell voltage in V, no offset
     OvmsMetricFloat         *mt_bms_CV_Range_max;       //!< maximum cell voltage in V, no offset
     OvmsMetricFloat         *mt_bms_CV_Range_mean;      //!< average cell voltage in V, no offset
     OvmsMetricFloat         *mt_bms_BattLinkVoltage;    //!< Link voltage to drivetrain inverter
+    OvmsMetricFloat         *mt_bms_BattContactorVoltage;   //!< voltage at the battery contactor
     OvmsMetricFloat         *mt_bms_BattCV_Sum;         //!< Sum of single cell voltages
     OvmsMetricFloat         *mt_bms_BattPower_voltage;  //!< voltage value sample (raw), (x/64) for actual value
     OvmsMetricFloat         *mt_bms_BattPower_current;  //!< current value sample (raw), (x/32) for actual value
     OvmsMetricFloat         *mt_bms_BattPower_power;    //!< calculated power of sample in kW
-    OvmsMetricInt           *mt_bms_HVcontactState;     //!< contactor state: 0 := OFF, 1 := PRECHARGE, 2 := ON
+    OvmsMetricInt           *mt_bms_HVcontactStateCode; //!< contactor state: 0 := OFF, 1 := PRECHARGE, 2 := ON
+    OvmsMetricString        *mt_bms_HVcontactStateTXT;  //!< contactor state text
     OvmsMetricFloat         *mt_bms_HV;                 //!< total voltage of HV system in V
-    OvmsMetricInt           *mt_bms_EVmode;             //!< Mode the EV is actually in: 0 = none, 1 = slow charge, 2 = fast charge, 3 = normal, 4 = fast balance
-    OvmsMetricFloat         *mt_bms_LV;                 //!< 12V onboard voltage / LV system
+    OvmsMetricInt           *mt_bms_EVmode;             //!< Mode the EV is actually in: 0 = none, 1 = slow charge, 2 = fast charge, 3 = normal, 4 = Quick Drop, 5 = Cameleon (Non-Isolated Charging)
+    OvmsMetricString        *mt_bms_EVmode_txt;         //!< Mode the EV is actually in text
+    OvmsMetricFloat         *mt_bms_12v;                //!< 12V onboard voltage / Clamp 30 Voltage
     OvmsMetricFloat         *mt_bms_Amps;               //!< battery current in ampere (x/32) reported by by BMS
     OvmsMetricFloat         *mt_bms_Amps2;              //!< battery current in ampere read by live data on CAN or from BMS
     OvmsMetricFloat         *mt_bms_Power;              //!< power as product of voltage and amps in kW
+    OvmsMetricBool          *mt_bms_interlock_hvplug;       //!< HV plug interlock
+    OvmsMetricBool          *mt_bms_interlock_service;      //!< Service disconnect interlock
+    OvmsMetricInt           *mt_bms_fusi_mode;              //!< FUSI mode code
+    OvmsMetricString        *mt_bms_fusi_mode_txt;          //!< FUSI mode text
+    OvmsMetricFloat         *mt_bms_mg_rpm;                 //!< MG output revolution (rpm/2)
+    OvmsMetricInt           *mt_bms_safety_mode;            //!< Safety mode code
+    OvmsMetricString        *mt_bms_safety_mode_txt;        //!< Safety mode text
+    OvmsMetricInt           *mt_bms_relay_hv_status;        //!< HV relay status flag
+    OvmsMetricString        *mt_bms_relay_hv_status_txt;    //!< HV relay status text
+    OvmsMetricInt           *mt_bms_relay_permit_flag;      //!< Relay on permit flag
+    OvmsMetricString        *mt_bms_relay_permit_flag_txt;  //!< Relay on permit flag text
+
     OvmsMetricVector<float> *mt_obl_main_amps;          //!< AC current of L1, L2, L3
     OvmsMetricVector<float> *mt_obl_main_volts;         //!< AC voltage of L1, L2, L3
-    OvmsMetricVector<float> *mt_obl_main_CHGpower;      //!< Power of rail1, rail2 W (x/2) & max available kw (x/64)
+    OvmsMetricVector<float> *mt_obl_main_CHGpower;      //!< Power of rail1, rail2 W (x/2) & max available kw (x/64)    
+    OvmsMetricBool          *mt_obl_fastchg;            // ODOmeter at Start
     OvmsMetricFloat         *mt_obl_main_freq;          //!< AC input frequency
     OvmsMetricFloat         *mt_obl_main_ground_resistance;           //!< Ground resistance in (Ohm)
     OvmsMetricInt           *mt_obl_main_max_current;                 //!< Charger max current setting (A)
@@ -305,16 +333,8 @@ public:
     OvmsMetricFloat         *mt_obl_main_current_leakage_hf_10khz;    //!< HF 10kHz leakage (A)
     OvmsMetricFloat         *mt_obl_main_current_leakage_hf;          //!< HF leakage current (A)
     OvmsMetricFloat         *mt_obl_main_current_leakage_lf;          //!< LF leakage current (A)
-    OvmsMetricFloat         *mt_obl_main_hv_net_amps;                 //!< Net current (A)
-    OvmsMetricFloat         *mt_obl_main_hv_net_volts;                //!< Net voltage (V)
-    OvmsMetricFloat         *mt_obl_main_amps_sum;                    //!< Current sum (A)
-    OvmsMetricFloat         *mt_obl_main_volts_sum;                   //!< Voltage sum (V)
-    OvmsMetricFloat         *mt_obl_main_hv_volts_sum;                //!< HV Voltage sum (V)
     OvmsMetricFloat         *mt_obl_main_current_leakage_ac;          //!< AC leakage current (A)
-    OvmsMetricFloat         *mt_obl_main_current_leakage_dc_raw;      //!< DC leakage current raw value
-    OvmsMetricFloat         *mt_obl_main_current_leakage_hf_10khz_raw;//!< HF 10kHz leakage raw value
-    OvmsMetricFloat         *mt_obl_main_current_leakage_hf_raw;     //!< HF leakage current raw value
-    OvmsMetricFloat         *mt_obl_main_current_leakage_lf_raw;     //!< LF leakage current raw value
+
     OvmsMetricInt           *mt_obd_duration;           //!< obd duration
     OvmsMetricFloat         *mt_obd_trip_km;            //!< obd trip data km
     OvmsMetricFloat         *mt_obd_start_trip_km;      //!< obd trip data km start
@@ -324,6 +344,7 @@ public:
     OvmsMetricInt           *mt_obd_mt_day_usual;       //!< Maintaince usual days
     OvmsMetricInt           *mt_obd_mt_km_usual;        //!< Maintaince usual km
     OvmsMetricString        *mt_obd_mt_level;           //!< Maintaince level
+
     OvmsMetricBool          *mt_climate_on;             //!< climate at time on/off
     OvmsMetricBool          *mt_climate_weekly;         //!< climate weekly auto on/off at day start/end
     OvmsMetricString        *mt_climate_time;           //!< climate time
@@ -333,21 +354,21 @@ public:
     OvmsMetricInt           *mt_climate_de;             //!< climate day end
     OvmsMetricInt           *mt_climate_1to3;           //!< climate one to three (homelink 0-2) times in following time
     OvmsMetricString        *mt_climate_data;           //!< climate data from app/website
-    OvmsMetricString        *mt_canbyte;                //!< DDT4all canbyte
-    OvmsMetricFloat         *mt_dummy_pressure;         //!< Dummy pressure for TPMS
-
+    
   protected:
     bool m_climate_start;
     bool m_climate_start_day;
     bool m_climate_init;                    //!< climate init after boot
     bool m_v2_restart;
     bool m_v2_check;
-    bool m_indicator;                       //!< activate indicator e.g. 7 times or whtever
+    bool m_indicator;                       //!< activate indicator e.g. 7 times or whatever
     bool m_ddt4all;                         //!< DDT4ALL mode
     bool m_warning_unlocked;                //!< unlocked warning
     bool m_modem_check;                     //!< modem check enabled
     bool m_modem_restart;                   //!< modem restart enabled
     bool m_notifySOClimit;                  //!< notify SOClimit reached one time
+    bool m_enable_calcADCfactor;            //!< enable calculation of ADC factor
+    float m_12v_measured_BMS_offset;       //!< 12V battery voltage measure offset BMS <> 12V System in V
     int m_ddt4all_ticker;                   //!< DDT4ALL active ticker 
     int m_ddt4all_exec;                     //!< DDT4ALL ticker for next execution
     int m_led_state;
@@ -356,7 +377,7 @@ public:
     int m_v2_ticker;
     int m_modem_ticker;
     int m_park_timeout_secs;                //!< parking timeout in seconds
-  
+    
   protected:
     poll_vector_t       m_poll_vector;              // List of PIDs to poll
     int                 m_cfg_cell_interval_drv;    // Cell poll interval while driving, default 15 sec.


### PR DESCRIPTION
Improved CAN poll reply and frame parsing with length/DLC guards to prevent processing of incomplete data and added switch fallthrough corrections. Introduced automatic 12V ADC factor recalculation using BMS 12V voltage, with configurable offset and web UI controls. Updated documentation and web UI to reflect new features and configuration options.

combined #1213 and #1214

I simply combined the updates. Unfortunately, separating them is no longer so easy.