### PR TITLE
Cellular config: add network type selection

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -1619,8 +1619,6 @@ void modem::SetCellularModemDriver(const char* ModelType)
   m_mux_channel_DATA = m_driver->GetMuxChannelDATA();
   m_mux_channel_POLL = m_driver->GetMuxChannelPOLL();
   m_mux_channel_CMD = m_driver->GetMuxChannelCMD();
-  MyConfig.SetParamValue("modem", "model", ModelType);
-  MyConfig.SetParamValue("modem", "net.typessupported", m_driver->GetNetTypes().c_str());
 
   if (m_model != "auto")
     MyEvents.SignalEvent("system.modem.installed", NULL);

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
@@ -277,12 +277,15 @@ class modemdriver : public InternalRamAllocated
     virtual bool State1Enter(modem::modem_state1_t newstate);
     virtual modem::modem_state1_t State1Activity(modem::modem_state1_t curstate);
     virtual modem::modem_state1_t State1Ticker1(modem::modem_state1_t curstate);
+    virtual std::string GetNetTypes();
+    virtual bool SetNetworkType(std::string);
 
   protected:
     unsigned int m_pwridx;
     time_t m_t_pwrcycle;
     modem* m_modem;
     int m_statuspoller_step;
+    std::string net_type;
   };
 
 template<typename Type> modemdriver* CreateCellularModemDriver()

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular_modem_driver.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular_modem_driver.cpp
@@ -198,3 +198,45 @@ modem::modem_state1_t modemdriver::State1Ticker1(modem::modem_state1_t curstate)
     }
   return curstate;
   }
+
+std::string modemdriver::GetNetTypes()
+  {
+    return "auto";
+  }
+
+#define SET_NET_MODE(at) if(m_modem->m_mux != NULL) m_modem->muxtx(GetMuxChannelCMD(), at); else m_modem->tx(at);
+
+bool modemdriver::SetNetworkType(std::string new_net_type)
+  {
+  if (m_modem != NULL && (new_net_type != net_type || net_type == "undef") )
+    {
+    std::string net_avail=GetNetTypes();
+    net_type = new_net_type;
+    ESP_LOGI(TAG, "Set network mode to %s", net_type.c_str());
+    if (net_type == "auto" && net_avail.find("auto") < string::npos)
+      {
+      SET_NET_MODE("AT+CNMP=2\r\n");
+      }
+    else if (net_type == "2G" && net_avail.find("2G") < string::npos)
+      {
+      SET_NET_MODE("AT+CNMP=13\r\n");
+      }
+    else if (net_type == "3G" && net_avail.find("3G") < string::npos)
+      {
+      SET_NET_MODE("AT+CNMP=14\r\n");
+      }
+    else if (net_type == "4G" && net_avail.find("4G") < string::npos)
+      {
+      SET_NET_MODE("AT+CNMP=38\r\n");
+      }
+    else
+      {
+      ESP_LOGE(TAG, "Requested network type %s is invalid -> set to automatic mode", net_type.c_str());
+      SET_NET_MODE("AT+CNMP=2\r\n");  // no valid mode -> set to AUTO
+      net_type = "auto";
+      }
+    return true;
+    }
+    return false;
+  }
+

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -955,13 +955,16 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   }
 
   // read configuration:
-  model = MyConfig.GetParamValue("modem", "model");
   apn = MyConfig.GetParamValue("modem", "apn");
   apn_user = MyConfig.GetParamValue("modem", "apn.user");
   apn_pass = MyConfig.GetParamValue("modem", "apn.password");
   pincode = MyConfig.GetParamValue("modem", "pincode");
+
+  modem* m_modem=MyPeripherals->m_cellular_modem;
+  model = m_modem && m_modem->m_driver ? m_modem->m_model : "auto";
   modem_net_type = MyConfig.GetParamValue("modem", "net.type","auto");
-  modem_net_types_avail = MyConfig.GetParamValue("modem", "net.typessupported","auto"); 
+  modem_net_types_avail = m_modem && m_modem->m_driver ? m_modem->m_driver->GetNetTypes() : "auto"; 
+
   wrongpincode = MyConfig.GetParamValueBool("modem", "wrongpincode",false);
   network_dns = MyConfig.GetParamValue("network", "dns");
   enable_net = MyConfig.GetParamValueBool("modem", "enable.net", true);
@@ -1014,6 +1017,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   c.input_text("…password", "apn_pass", apn_pass.c_str());
   c.input_text("DNS", "network_dns", network_dns.c_str(), "optional fixed DNS servers (space separated)",
     "<p>Set this to i.e. <code>8.8.8.8 8.8.4.4</code> (Google public DNS) if you encounter problems with your network provider DNS</p>");
+
   if ( model != "auto")
   {
     c.input_radiobtn_start("Network type preference", "modem_net_type");
@@ -1028,7 +1032,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
     "<p>The 3G standard has been switched off in most areas around the world. 2G/GSM is often still available.</p>");
   }
   else{
-    c.input_info("Modem model not identified yet - Network type preference not available.", info.c_str());
+    c.input_info("Network type preference", "Modem model not identified yet");
     modem_net_type="undef";
   }
 

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -880,7 +880,7 @@ void OvmsWebServer::HandleCfgVehicle(PageEntry_t& p, PageContext_t& c)
  */
 void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
 {
-  std::string apn, apn_user, apn_pass, network_dns, pincode, error, gps_parkpause, gps_parkreactivate, gps_parkreactlock, vehicle_stream;
+  std::string apn, apn_user, apn_pass, network_dns, pincode, error, gps_parkpause, gps_parkreactivate, gps_parkreactlock, vehicle_stream, model, modem_net_type, modem_net_types_avail;
   bool enable_gps, enable_gpstime, enable_net, enable_sms, wrongpincode, gps_parkreactawake;
   float cfg_sq_good, cfg_sq_bad;
 
@@ -902,6 +902,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
     vehicle_stream = c.getvar("vehicle_stream");
     cfg_sq_good = atof(c.getvar("cfg_sq_good").c_str());
     cfg_sq_bad = atof(c.getvar("cfg_sq_bad").c_str());
+    modem_net_type = c.getvar("modem_net_type");
 
     if (cfg_sq_bad >= cfg_sq_good)
       {
@@ -919,6 +920,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
         }
       MyConfig.SetParamValue("modem", "pincode", pincode);
       MyConfig.SetParamValue("network", "dns", network_dns);
+      if (modem_net_type != "undef") MyConfig.SetParamValue("modem", "net.type", modem_net_type);
       MyConfig.SetParamValueBool("modem", "enable.net", enable_net);
       MyConfig.SetParamValueBool("modem", "enable.sms", enable_sms);
       MyConfig.SetParamValueBool("modem", "enable.gps", enable_gps);
@@ -953,10 +955,13 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   }
 
   // read configuration:
+  model = MyConfig.GetParamValue("modem", "model");
   apn = MyConfig.GetParamValue("modem", "apn");
   apn_user = MyConfig.GetParamValue("modem", "apn.user");
   apn_pass = MyConfig.GetParamValue("modem", "apn.password");
   pincode = MyConfig.GetParamValue("modem", "pincode");
+  modem_net_type = MyConfig.GetParamValue("modem", "net.type","auto");
+  modem_net_types_avail = MyConfig.GetParamValue("modem", "net.typessupported","auto"); 
   wrongpincode = MyConfig.GetParamValueBool("modem", "wrongpincode",false);
   network_dns = MyConfig.GetParamValue("network", "dns");
   enable_net = MyConfig.GetParamValueBool("modem", "enable.net", true);
@@ -1009,7 +1014,25 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
   c.input_text("…password", "apn_pass", apn_pass.c_str());
   c.input_text("DNS", "network_dns", network_dns.c_str(), "optional fixed DNS servers (space separated)",
     "<p>Set this to i.e. <code>8.8.8.8 8.8.4.4</code> (Google public DNS) if you encounter problems with your network provider DNS</p>");
-  c.fieldset_end();
+  if ( model != "auto")
+  {
+    c.input_radiobtn_start("Network type preference", "modem_net_type");
+    if (modem_net_types_avail.find(modem_net_type) == string::npos) modem_net_type = "auto";
+    c.input_radiobtn_option("modem_net_type", "auto", "auto", modem_net_type == "auto");
+    if (modem_net_types_avail.find("2G") != string::npos) c.input_radiobtn_option("modem_net_type", "2G (GSM)", "2G", modem_net_type == "2G");
+    if (modem_net_types_avail.find("3G") != string::npos) c.input_radiobtn_option("modem_net_type", "3G (UMTS/)", "3G", modem_net_type == "3G");
+    if (modem_net_types_avail.find("4G") != string::npos) c.input_radiobtn_option("modem_net_type", "4G (LTE)", "4G", modem_net_type == "4G");
+    if (modem_net_types_avail.find("5G") != string::npos) c.input_radiobtn_option("modem_net_type", "5G", "5G", modem_net_type == "5G");
+    c.input_radiobtn_end(
+    "<p>Automatic mode should work in most cases. In case of frequent net losses, it can help to limit the network type.</p>"
+    "<p>The 3G standard has been switched off in most areas around the world. 2G/GSM is often still available.</p>");
+  }
+  else{
+    c.input_info("Modem model not identified yet - Network type preference not available.", info.c_str());
+    modem_net_type="undef";
+  }
+
+    c.fieldset_end();
 
   c.fieldset_start("Features");
   c.input_checkbox("Enable SMS", "enable_sms", enable_sms);

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_5360.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_5360.cpp
@@ -56,6 +56,10 @@ simcom5360::~simcom5360()
   {
   }
 
+std::string simcom5360::GetNetTypes() {
+  return "auto 2G 3G";
+}
+
 const char* simcom5360::GetModel()
   {
   return model;
@@ -66,7 +70,7 @@ const char* simcom5360::GetName()
   return name;
   }
 
-void simcom5360::StatusPoller()
+  void simcom5360::StatusPoller()
   {
   if (m_modem->m_mux != NULL)
     {
@@ -137,7 +141,7 @@ modem::modem_state1_t simcom5360::State1Ticker1(modem::modem_state1_t curstate)
         m_modem->tx("AT+CPIN?;+CREG=1;+CTZU=1;+CTZR=1;+CLIP=1;+CMGF=1;+CNMI=1,2,0,0,0;+CSDH=1;+CMEE=2;+CSQ;+AUTOCSQ=1,1;E0;S0=0\r\n");
         break;
       case 12:
-        m_modem->tx("AT+CGMR;+ICCID\r\n");
+        m_modem->tx("AT+CGMR;+CICCID\r\n");
         break;
       case 16:
         m_modem->tx("AT+CMUXSRVPORT=3,1\r\n");

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_5360.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_5360.h
@@ -50,6 +50,7 @@ class simcom5360 : public modemdriver
     int GetMuxChannelPOLL() { return 3; }
     int GetMuxChannelCMD()  { return 4; }
     void StatusPoller();
+    std::string GetNetTypes();
 
     bool State1Leave(modem::modem_state1_t oldstate);
     bool State1Enter(modem::modem_state1_t newstate);

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7000.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7000.cpp
@@ -57,6 +57,10 @@ simcom7000::~simcom7000()
   {
   }
 
+std::string simcom7000::GetNetTypes() {
+  return "auto 2G 4G";
+}
+
 const char* simcom7000::GetModel()
   {
   return model;
@@ -117,7 +121,7 @@ modem::modem_state1_t simcom7000::State1Ticker1(modem::modem_state1_t curstate)
         m_modem->tx("AT+CPIN?;+CREG=1;+CTZU=1;+CTZR=1;+CMGF=1;+CNMI=1,2,0,0,0;+CSDH=1;+CMEE=2;+CSQ;S0=0\r\n");
         break;
       case 12:
-        m_modem->tx("AT+CGMR;+ICCID\r\n");
+        m_modem->tx("AT+CGMR;+CICCID\r\n");
         break;
       case 20:
         // start MUX mode, route URCs to MUX channel 3 (POLL)

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7000.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7000.h
@@ -51,6 +51,8 @@ class simcom7000 : public modemdriver
     int GetMuxChannelCMD()  { return 4; }
 
     void PowerCycle();
+    std::string GetNetTypes();
+
     bool State1Leave(modem::modem_state1_t oldstate);
     bool State1Enter(modem::modem_state1_t newstate);
     modem::modem_state1_t State1Activity(modem::modem_state1_t curstate);

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7600.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7600.cpp
@@ -57,6 +57,10 @@ simcom7600::~simcom7600()
   {
   }
 
+std::string simcom7600::GetNetTypes() {
+  return "auto 2G 3G 4G";
+}
+
 const char* simcom7600::GetModel()
   {
   return model;
@@ -110,7 +114,7 @@ void simcom7600::ShutdownNMEA()
     { ESP_LOGE(TAG, "Attempt to transmit on non running mux"); }
   }
 
-void simcom7600::StatusPoller()
+  void simcom7600::StatusPoller()
   {
   if (m_modem->m_mux != NULL)
     {
@@ -218,7 +222,7 @@ modem::modem_state1_t simcom7600::State1Ticker1(modem::modem_state1_t curstate)
         m_modem->tx("AT+CPIN?;+CREG=1;+CGREG=1;+CEREG=1;+CTZU=1;+CTZR=1;+CLIP=1;+CMGF=1;+CNMI=1,2,0,0,0;+CSDH=1;+CMEE=2;+CSQ;+AUTOCSQ=1,1;E0;S0=0\r\n");
         break;
       case 12:
-        m_modem->tx("AT+CGMR;+ICCID\r\n");
+        m_modem->tx("AT+CGMR;+CICCID\r\n");
         break;
       case 20:
         // start MUX mode, route URCs to MUX channel 3 (POLL)

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7600.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7600.h
@@ -55,6 +55,8 @@ class simcom7600 : public modemdriver
 
     void PowerCycle();
     void PowerOff();
+    std::string GetNetTypes();
+
     bool State1Leave(modem::modem_state1_t oldstate);
     bool State1Enter(modem::modem_state1_t newstate);
     modem::modem_state1_t State1Activity(modem::modem_state1_t curstate);

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7670.cpp
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7670.cpp
@@ -69,6 +69,10 @@ simcom7670::~simcom7670()
     MySimcom7670 = NULL;
   }
 
+std::string simcom7670::GetNetTypes() {
+  return "auto 2G 4G";
+}
+
 void simcom7670::StartupNMEA()
   {
     // GPS config for simcom 7670 - will use AT+CGNSSINFO to get location

--- a/vehicle/OVMS.V3/components/simcom/src/simcom_7670.h
+++ b/vehicle/OVMS.V3/components/simcom/src/simcom_7670.h
@@ -49,6 +49,7 @@ class simcom7670 : public modemdriver
     void StatusPoller();
     modem::modem_state1_t State1Ticker1(modem::modem_state1_t state);
     void SendGNSSRequest(std::string event, void* data);
+    std::string GetNetTypes();
 
   private:
     TimerHandle_t m_timer;


### PR DESCRIPTION
Add the option to select the mobile network mode (e.g. 2G, 4G) to the cellular configuration.
This allows to switch off the automatic selection in case of frequent net losses.

This has been tested for the SIMCOM 7670E and should be checked for the other models.


Two more fixes:
- correct the AT command to read the SIM ICCID:  `AT+CICCID` instead of `AT+ICCID`.
- GPS was switched off when parked, even, when the feature was disabled. Missing check has been added.
