### PR TITLE
Simcom 7670: check and utilize GPS hot start capability

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.cpp
@@ -317,6 +317,7 @@ modem::modem(const char* name, uart_port_t uartnum, int baud, int rxpin, int txp
   m_err_uart_frame = 0;
   m_err_driver_buffer_full = 0;
   m_nmea = NULL;
+  m_gps_hot_start = false;
   m_gps_enabled = false;
   m_gps_usermode = GUM_DEFAULT;
   m_gps_parkpause = 0;
@@ -1380,6 +1381,11 @@ void modem::StandardLineHandler(int channel, OvmsBuffer* buf, std::string line)
       m_line_unfinished = -1;
       m_line_buffer.clear();
       }
+    }
+  else if (line.compare(0, 11, "+CGNSSPWR: ") == 0)
+    {
+    m_gps_hot_start = line.find("(1,1)") < std::string::npos || line.find("(0,1)") < std::string::npos;
+    ESP_LOGV(TAG, "GPS hot start : %s ", m_gps_hot_start ? "OK" : "not supported");
     }
   }
 

--- a/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/ovms_cellular.h
@@ -174,6 +174,8 @@ class modem : public pcp, public InternalRamAllocated
     GsmPPPOS*              m_ppp;
     GsmNMEA*               m_nmea;
 
+    bool                   m_gps_hot_start;
+
     bool                   m_gps_enabled;           // = config modem enable.gps
     gps_usermode_t         m_gps_usermode;          // manual GPS control status
     int                    m_gps_parkpause;         // = config modem gps.parkpause (seconds, 0=off)

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -1024,7 +1024,7 @@ void OvmsWebServer::HandleCfgModem(PageEntry_t& p, PageContext_t& c)
     if (modem_net_types_avail.find(modem_net_type) == string::npos) modem_net_type = "auto";
     c.input_radiobtn_option("modem_net_type", "auto", "auto", modem_net_type == "auto");
     if (modem_net_types_avail.find("2G") != string::npos) c.input_radiobtn_option("modem_net_type", "2G (GSM)", "2G", modem_net_type == "2G");
-    if (modem_net_types_avail.find("3G") != string::npos) c.input_radiobtn_option("modem_net_type", "3G (UMTS/)", "3G", modem_net_type == "3G");
+    if (modem_net_types_avail.find("3G") != string::npos) c.input_radiobtn_option("modem_net_type", "3G (UMTS)", "3G", modem_net_type == "3G");
     if (modem_net_types_avail.find("4G") != string::npos) c.input_radiobtn_option("modem_net_type", "4G (LTE)", "4G", modem_net_type == "4G");
     if (modem_net_types_avail.find("5G") != string::npos) c.input_radiobtn_option("modem_net_type", "5G", "5G", modem_net_type == "5G");
     c.input_radiobtn_end(


### PR DESCRIPTION
Check and apply the GPS hot start capability of the firmware of the simcom 7670 modem. 
