### PR TITLE
Add 'Update now' button to firmware config page

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -2837,6 +2837,7 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
     auto_hour = c.getvar("auto_hour");
     server = c.getvar("server");
     tag = c.getvar("tag");
+    hardware = GetOVMSProduct();
 
     if (action.substr(0,3) == "set") {
       info.partition_boot = c.getvar("boot_old");


### PR DESCRIPTION
Introduces a new 'Update now' button to the firmware configuration page, allowing users to trigger an OTA firmware update directly. The hardware version is now displayed, and the update process uses the selected server, tag, and hardware to construct the OTA URL and initiate the update.

<img width="564" height="64" alt="upd_btn_1" src="https://github.com/user-attachments/assets/4cea6b43-f410-4a18-b8d1-501b5b0e510a" />


<img width="1123" height="687" alt="upd_btn_2" src="https://github.com/user-attachments/assets/3e20c899-4ced-4d8e-940f-6e30150bf62b" />
