### PR TITLE
Vehicle Smarteq: get TPMS values, when CAN write is disabled

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -221,18 +221,22 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       REQ_DLC(1);
       vehicle_smart_car_on((CAN_BYTE(0) & 0x40) > 0); // Drive Ready
       break;
-    /*case 0x673:  // TPMS status -> PollReply_TPMS_InputCapt
-      REQ_DLC(2);
-      // Read TPMS pressure values:
-      for (int i = 0; i < 4; i++) 
-        {
-        if (CAN_BYTE(2 + i) != 0xff) 
+    case 0x673:  
+      // TPMS values only used, when CAN write is disabled, otherwise utilize PollReply_TPMS_InputCapt
+      if ( !m_enable_write )
+      {
+        REQ_DLC(7);
+        // Read TPMS pressure values:
+        for (int i = 0; i < 4; i++) 
           {
-          m_tpms_pressure[i] = (float) CAN_BYTE(2 + i) * 3.1; // kPa
-          setTPMSValue(i, m_tpms_index[i]);
+          if (CAN_BYTE(2 + i) != 0xff) 
+            {
+            m_tpms_pressure[i] = (float) CAN_BYTE(2 + i) * 3.1; // kPa
+            setTPMSValue(i, m_tpms_index[i]);
+          }
         }
       }
-      break;*/    
+      break;    
     default:
       //ESP_LOGI(TAG, "PID:%x DATA: %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
       break;


### PR DESCRIPTION
The latest version of the Smart EQ code is utilizing a poll request to extract the tire pressure values.

The car is providing TPMS values on a regular basis on the CAN bus as well.

This PR reenables the latter value extraction in case the CAN write is disabled. 