### PR TITLE
Add and refactor Smart EQ trip and consumption metrics

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -865,19 +865,19 @@ void OvmsVehicleSmartEQ::PollReply_obd_time(const char* data, uint16_t reply_len
   REQUIRE_LEN(3);
   int value_1 = CAN_UINT24(0);
   std::string timeStr = SecondsToHHmm(value_1);
-  mt_obd_trip_time->SetValue( timeStr );
+  mt_reset_time->SetValue( timeStr );
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_start_trip(const char* data, uint16_t reply_len) {
   REQUIRE_LEN(2);
-  mt_obd_start_trip_km->SetValue((float) CAN_UINT(0));
+  mt_start_distance->SetValue((float) CAN_UINT(0));
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_start_time(const char* data, uint16_t reply_len) {
   REQUIRE_LEN(3);
   int value_1 = CAN_UINT24(0);
   std::string timeStr = SecondsToHHmm(value_1);
-  mt_obd_start_trip_time->SetValue( timeStr );
+  mt_start_time->SetValue( timeStr );
 }
 
 void OvmsVehicleSmartEQ::PollReply_obd_mt_day(const char* data, uint16_t reply_len) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -487,26 +487,26 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandStat(int verbosity, Ov
   
   if (m_extendedStats)
   { 
-    if (mt_use_at_reset->IsDefined())
+    if (mt_reset_consumption->IsDefined())
       {
-      const std::string& use_at_reset = mt_use_at_reset->AsUnitString("-", ToUser, 1);
-      writer->printf("RESET kWh/100km: %s\n", use_at_reset.c_str());
+      const std::string& reset_used = mt_reset_consumption->AsUnitString("-", ToUser, 1);
+      writer->printf("RESET kWh/100km: %s\n", reset_used.c_str());
       }
     
-    if (mt_obd_trip_km->IsDefined())
+    if (mt_reset_distance->IsDefined())
       {
-      const std::string& obd_trip_km = mt_obd_trip_km->AsUnitString("-", ToUser, 1);
-      writer->printf("RESET Trip km: %s\n", obd_trip_km.c_str());
+      const std::string& reset_trip_km = mt_reset_distance->AsUnitString("-", ToUser, 1);
+      writer->printf("RESET Trip km: %s\n", reset_trip_km.c_str());
       }
-    if (mt_obd_trip_time->IsDefined())
+    if (mt_reset_time->IsDefined())
       {
-      const std::string& obd_trip_time = mt_obd_trip_time->AsUnitString("-", ToUser, 1);
-      writer->printf("RESET Trip time: %s\n", obd_trip_time.c_str());
+      const std::string& reset_time = mt_reset_time->AsUnitString("-", ToUser, 1);
+      writer->printf("RESET Trip time: %s\n", reset_time.c_str());
       }
     if (mt_use_at_start->IsDefined())
       {
-      const std::string& use_at_reset = mt_use_at_start->AsUnitString("-", ToUser, 1);
-      writer->printf("START kWh/100km: %s\n", use_at_reset.c_str());
+      const std::string& use_at_start = mt_use_at_start->AsUnitString("-", ToUser, 1);
+      writer->printf("START kWh: %s\n", use_at_start.c_str());
       }
     if (mt_obd_start_trip_km->IsDefined())
       {
@@ -626,8 +626,8 @@ void OvmsVehicleSmartEQ::xsq_trip_reset(int verbosity, OvmsWriter* writer, OvmsC
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandTripReset(int verbosity, OvmsWriter* writer) {
     metric_unit_t rangeUnit = (MyConfig.GetParamValue("vehicle", "units.distance") == "M") ? Miles : Kilometers;
     writer->puts("Trip reset values:");
-    writer->printf("  distance: %s\n", (char*) mt_obd_trip_km->AsUnitString("-", rangeUnit, 1).c_str());
-    writer->printf("  time: %s\n", (char*) mt_obd_trip_time->AsUnitString("-", Native, 1).c_str());
+    writer->printf("  distance: %s\n", (char*) mt_start_distance->AsUnitString("-", rangeUnit, 1).c_str());
+    writer->printf("  time: %s\n", (char*) mt_start_time->AsUnitString("-", Native, 1).c_str());
     writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
     writer->printf("  CAC: %s\n", (char*) StdMetrics.ms_v_bat_cac->AsUnitString("-", Native, 1).c_str());
     writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -44,7 +44,7 @@ static const OvmsPoller::poll_pid_t obdii_polls[] =
 //  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {  0,300,300,60 }, 0, ISOTP_STD }, // rqBattVoltages_P2
 
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200c, {  0,300,300,300 }, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2101, {  0,300,60,0 }, 0, ISOTP_STD }, // OBD Trip Distance km
+  //{ 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2101, {  0,300,60,0 }, 0, ISOTP_STD }, // OBD Trip Distance km
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {  0,300,60,0 }, 0, ISOTP_STD }, // OBD start Trip Distance km 
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {  0,300,60,0 }, 0, ISOTP_STD }, // OBD Trip time s
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {  0,300,60,0 }, 0, ISOTP_STD }, // OBD start Trip time s

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -299,6 +299,37 @@ public:
     OvmsMetricFloat         *mt_adc_factor;             // calculated ADC factor for 12V measurement
     OvmsMetricVector<float> *mt_adc_factor_history;     // last 20 calculated ADC factors for 12V measurement
     OvmsMetricString        *mt_poll_state;             // Poller state
+    OvmsMetricString        *mt_reset_time;             // Time since last reset (hh:mm)
+    OvmsMetricString        *mt_start_time;             // Time since start (hh:mm)
+    OvmsMetricFloat         *mt_start_distance;         // Trip distance since start (km)
+    OvmsMetricFloat         *mt_start_consumption;      // Average consumption since start (kWh/100km)
+
+    // 0x646 metrics
+    OvmsMetricFloat         *mt_reset_consumption;      // Average trip consumption (kWh/100km) reset
+    OvmsMetricFloat         *mt_reset_distance;         // Trip distance (km) reset
+    OvmsMetricFloat         *mt_reset_energy;           // Trip energy consumption (kWh) reset
+    OvmsMetricFloat         *mt_reset_speed;            // Average trip speed (km/h) reset
+    // 0x658 metrics
+    OvmsMetricString        *mt_bat_serial;             // Battery serial number (hex string)
+    // 0x637 metrics
+    OvmsMetricFloat         *mt_energy_used;            // Energy used since mission start (kWh)
+    OvmsMetricFloat         *mt_energy_recd;            // Energy recovered since mission start (kWh)
+    OvmsMetricFloat         *mt_aux_consumption;        // Auxiliary consumption since mission start (kWh)
+    OvmsMetricInt           *mt_eco_score;              // Eco score indicator (%)
+    OvmsMetricFloat         *mt_total_recovery;         // Total energy recovery (kWh)
+    OvmsMetricBool          *mt_charge_flap_warning;    // Charge flap open warning
+    // 0x62d metrics
+    OvmsMetricFloat         *mt_worst_consumption;      // Worst average consumption (kWh/100km)
+    OvmsMetricFloat         *mt_best_consumption;       // Best average consumption (kWh/100km)
+    OvmsMetricFloat         *mt_bcb_power_mains;        // BCB power from mains (W)
+    // 0x634 metrics
+    OvmsMetricInt           *mt_tcu_refuse_sleep;       // TCU refuse to sleep status
+    OvmsMetricInt           *mt_charging_timer_value;   // Charging timer value (min)
+    OvmsMetricBool          *mt_remote_preac;           // Remote pre-AC activation
+    OvmsMetricInt           *mt_charging_timer_status;  // Charging timer status
+    OvmsMetricInt           *mt_charge_prohibited;      // Charge prohibited status
+    OvmsMetricInt           *mt_charge_authorization;   // Charge authorization status
+    OvmsMetricInt           *mt_ext_charge_manager;     // External charging manager
 
     OvmsMetricFloat         *mt_pos_odometer_trip;           // odometer trip in km 
     OvmsMetricFloat         *mt_pos_odometer_start;          // remind odometer start


### PR DESCRIPTION
Introduces new metrics for trip start/reset times, distances, consumptions, and battery serial, and refactors CAN frame parsing to extract and store these values. Updates command output and OBD poll handling to use the new metrics, and improves code clarity and metric naming for Smart EQ vehicle support.