### PR TITLE
Expand climate schedule duration range to 5-30 min

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_climate.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_climate.cpp
@@ -112,9 +112,9 @@ void OvmsWebServer::HandleCfgPreconditionSchedule(PageEntry_t& p, PageContext_t&
         // Validate optional duration if present
         if (slash_pos != std::string::npos) {
           int duration = atoi(entry.substr(slash_pos + 1).c_str());
-          if (duration != 5 && duration != 10 && duration != 15) {
+          if (duration < 5 || duration > 30) {
             valid = false;
-            error += "<li>" + std::string(day_full[i]) + ": invalid duration (use 5, 10, or 15)</li>";
+            error += "<li>" + std::string(day_full[i]) + ": invalid duration (use 5 to 30)</li>";
             break;
           }
         }

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -397,9 +397,9 @@ void OvmsVehicleFactory::vehicle_climate_schedule_set(int verbosity, OvmsWriter*
     {
       std::string duration_str = entry.substr(slash_pos + 1);
       int duration = atoi(duration_str.c_str());
-      if (duration != 5 && duration != 10 && duration != 15)
+      if (duration < 5 || duration > 30)
       {
-        writer->printf("ERROR: Invalid duration '%s'. Use 5, 10, or 15 minutes\n", duration_str.c_str());
+        writer->printf("ERROR: Invalid duration '%s'. Use 5 to 30 minutes\n", duration_str.c_str());
         return;
       }
     }
@@ -696,6 +696,10 @@ void OvmsVehicle::CheckPreconditionSchedule()
         if (slash_pos != std::string::npos)
         {
           duration = atoi(entry.substr(slash_pos + 1).c_str());
+          if (duration < 5 || duration > 30)
+          {
+            duration = 10; // Fallback to default
+          }
         }
 
         ESP_LOGI(TAG, "Scheduled precondition triggered for %s at %02d:%02d (duration: %d min)",


### PR DESCRIPTION
Updated climate precondition schedule validation to allow durations between 5 and 30 minutes instead of only 5, 10, or 15. Error messages and fallback logic were adjusted accordingly to improve flexibility and user feedback.