### PR TITLE
Move climate precondition scheduling to VehicleTicker1

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -1315,7 +1315,7 @@ void OvmsVehicle::VehicleTicker1(std::string event, void* data)
       CommandClimateControl(true);
       ESP_LOGI(TAG,"Restarting climate control as per schedule");
       }
-    }
+    } // end ((m_ticker % 60) == 0)
 
   if (m_12v_shutdown_ticker > 0 && --m_12v_shutdown_ticker == 0)
     {


### PR DESCRIPTION
Climate precondition scheduling logic was relocated from Ticker60 to VehicleTicker1 for improved timing and control. Log messages were updated for clarity, and redundant code was removed from Ticker60.

I don't see why, but at Ticker60 will not work.