### PR TITLE
smart EQ: Refactor climate control and 12V charge logic

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -37,28 +37,6 @@ static const char *TAG = "v-smarteq";
 
 void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker) 
   {
-  // climate start 2-3 times when Homelink 2 or 3
-  if (m_climate_ticker >= 1 && !StdMetrics.ms_v_env_hvac->AsBool() && !m_climate_start)
-      CommandClimateControl(true);
-
-  if (m_climate_start && StdMetrics.ms_v_env_hvac->AsBool()) 
-    {
-    m_climate_start = false;
-    if (m_12v_charge_state) 
-      {
-      Notify12Vcharge();
-      } 
-    else 
-      {
-      NotifyClimate();
-      }
-    if (m_climate_ticker >= 1) 
-      { 
-      --m_climate_ticker;
-      ESP_LOGI(TAG,"Climate ticker: %d", m_climate_ticker);
-      }
-    }
-
   if (m_ddt4all_exec >= 1) 
     { 
     --m_ddt4all_exec;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -56,11 +56,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   ESP_LOGI(TAG, "Start smart EQ vehicle module");
 
   m_climate_init = true;
-  m_climate_start = false;
   m_climate_start_day = false;
-  m_climate_ticker = 0;
   m_12v_ticker = 0;
-  m_12v_charge_state = false;
   m_ddt4all = false;
   m_ddt4all_ticker = 0;
   m_ddt4all_exec = 0;
@@ -783,11 +780,9 @@ void OvmsVehicleSmartEQ::vehicle_smart_car_on(bool isOn) {
 
     m_warning_unlocked = false;
     m_warning_dooropen = false;
-
-    #ifdef CONFIG_OVMS_COMP_CELLULAR
-      m_12v_ticker = 0;
-      m_climate_ticker = 0;
-    #endif
+    m_12v_ticker = 0;
+    m_climate_restart = false;
+    m_climate_restart_ticker = 0;
   }
   else if (!isOn && StdMetrics.ms_v_env_on->AsBool()) {
     // Log once that car is being turned off

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -415,7 +415,6 @@ public:
     OvmsMetricString        *mt_bcm_gen_mode;           //!< Generator mode text
     
   protected:
-    bool m_climate_start;
     bool m_climate_start_day;
     bool m_climate_init;                      //!< climate init after boot
     bool m_indicator;                       //!< activate indicator e.g. 7 times or whatever
@@ -430,7 +429,6 @@ public:
     int m_ddt4all_ticker;                   //!< DDT4ALL active ticker 
     int m_ddt4all_exec;                     //!< DDT4ALL ticker for next execution
     int m_led_state;
-    int m_climate_ticker;
     int m_12v_ticker;
     int m_modem_ticker;
     int m_park_timeout_secs;                //!< parking timeout in seconds


### PR DESCRIPTION
Replaces m_climate_ticker and m_climate_start with Vehicle new m_climate_restart and m_climate_restart_ticker for improved climate control scheduling. 
Updates Homelink and 12V charge routines to use new logic, ensuring more reliable activation and notification. 
Cleans up unused variables and simplifies ticker handling for better maintainability.