### PR TITLE
Add copy function for climate schedule configuration

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -3,14 +3,19 @@ Open Vehicle Monitor System v3 - Change log
 ????-??-?? ???  ???????  OTA release
 - Vehicle framework: Scheduled precondition control with duration support
     Centralized implementation for all vehicles with per-vehicle override capability.
-    Supports multiple time slots per day with individual duration settings.
+    Supports multiple time slots per day with individual duration settings (5-30 minutes).
     Global enable/disable switch with config persistence.
+    copy function to duplicate schedules across multiple days.
   New commands:
     climatecontrol schedule set <day> <times>  -- Set schedule for a day, times format: HH:MM[/duration][,HH:MM[/duration],...]
                                                      Examples: "07:30", "07:30/10", "07:00/5,17:30/15"
                                                      Duration in minutes
     climatecontrol schedule list               -- List all configured schedules with next scheduled event
     climatecontrol schedule clear <day|all>    -- Clear schedule for specific day or all days
+    climatecontrol schedule copy <source-day> <target-days>
+                                               -- Copy schedule from one day to others
+                                                     Examples: "mon tue-fri", "fri sat,sun"
+                                                     Supports range syntax (tue-fri) and comma-separated lists
     climatecontrol schedule enable             -- Enable scheduled precondition (global switch)
     climatecontrol schedule disable            -- Disable scheduled precondition (global switch)
     climatecontrol schedule status             -- Show schedule status and configured times
@@ -24,6 +29,9 @@ Open Vehicle Monitor System v3 - Change log
     - Automatic trigger based on system time
     - Integration with existing climate control
     - Web UI configuration page at /cfg/preconditionschedule
+    - Automatic restart mechanism for extended runtime (configurable HVAC duration)
+    - Duplicate prevention (same time won't trigger twice)
+    - Copy function for quick weekly schedule setup
 - smart EQ:
     Add multiple CAN frame parsers for energy and charging metrics
     Add automatic 12V ADC factor recalculation history tracking

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -741,6 +741,7 @@ class OvmsVehicleFactory
     static void vehicle_climate_schedule_set(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void vehicle_climate_schedule_list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void vehicle_climate_schedule_clear(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
+    static void vehicle_climate_schedule_copy(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void vehicle_climate_schedule_enable(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void vehicle_climate_schedule_disable(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void vehicle_climate_schedule_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);


### PR DESCRIPTION
Introduces a 'copy' command and web UI feature to duplicate climate schedules from one day to multiple other days, supporting both range and comma-separated day specifications. Updates the web interface to include copy and clear-all options, improves validation, and documents the new functionality in the changelog.