### PR TITLE
smartEQ: Remove climate control features and related code

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -768,47 +768,6 @@ void OvmsVehicleSmartEQ::NotifyMaintenance() {
   MyNotify.NotifyString("info","xsq.maintenance",buf.c_str());
 }
 
-void OvmsVehicleSmartEQ::xsq_climate(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv) {
-  OvmsVehicleSmartEQ* smarteq = GetInstance(writer);
-  if (!smarteq)
-    return;
-  
-    smarteq->CommandSetClimate(verbosity, writer);
-}
-OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandSetClimate(int verbosity, OvmsWriter* writer) {
-    int _ds = mt_climate_ds->AsInt();
-    int _de = mt_climate_de->AsInt() == 0 ? 6 : mt_climate_de->AsInt() - 1;
-    int _min = mt_climate_1to3->AsInt();
-    const char* _days[7] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-    const char* _time[3] = {"5 min", "10 min", "15 min"};
-
-    writer->puts("Climate values:");
-    writer->printf("  on: %s\n", mt_climate_on->AsBool() ? "yes" : "no");
-    writer->printf("  time: %s:%s h\n", mt_climate_h->AsString().c_str(),mt_climate_m->AsString().c_str());
-    writer->printf("  weekly: %s\n", mt_climate_weekly->AsBool() ? "yes" : "no");
-    writer->printf("  start Day: %s\n", _days[_ds]);
-    writer->printf("  end Day: %s\n", _days[_de]);
-    writer->printf("  runtime: %s\n", _time[_min]);
-    return Success;
-}
-void OvmsVehicleSmartEQ::NotifyClimateTimer() {
-  StringWriter buf(200);
-  CommandSetClimate(COMMAND_RESULT_NORMAL, &buf);
-  MyNotify.NotifyString("info","xsq.climate.timer",buf.c_str());
-}
-OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimate(int verbosity, OvmsWriter* writer) {
-  writer->puts("Climate on:");
-  writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
-  writer->printf("  CAC: %s\n", (char*) StdMetrics.ms_v_bat_cac->AsUnitString("-", Native, 1).c_str());
-  writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
-  return Success;
-}
-void OvmsVehicleSmartEQ::NotifyClimate() {
-  StringWriter buf(200);
-  CommandClimate(COMMAND_RESULT_NORMAL, &buf);
-  MyNotify.NotifyString("info","xsq.climate",buf.c_str());
-}
-
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandSOClimit(int verbosity, OvmsWriter* writer) {
   writer->puts("SOC limit reached:");
   writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
@@ -976,6 +935,10 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandPreset(int verbosity, 
     "gps.off",
     "gps.reactmin",
     "precondition",
+    "climate.system",
+    "climate.data",
+    "climate.notify",
+    "climate.data.store",
     "gps.deact"
   };
   

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -68,14 +68,10 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     {
     if(m_enable_LED_state) 
       OnlineState();
-    if(m_climate_system) 
-      TimeBasedClimateData();
     }
   }
 
 void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
-  if(mt_climate_on->AsBool()) 
-    TimeCheckTask();
   if(m_12v_charge && !StdMetrics.ms_v_env_on->AsBool()) 
     Check12vState();
   if(m_enable_lock_state && !m_warning_unlocked && StdMetrics.ms_v_env_parktime->AsInt() > m_park_timeout_secs +10) 
@@ -109,7 +105,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
       m_ADCfactor_recalc = false;
       m_ADCfactor_recalc_timer = 4;
       // calculate new ADC factor
-      float can12V = mt_bms_12v->AsFloat(0.0f) + 0.25f;   // BMS 12V voltage + offset
+      float can12V = mt_evc_LV_DCDC_volt->AsFloat(0.0f) + 0.25f;   // BMS 12V voltage + offset
       if (can12V >= 13.10f) {
         ReCalcADCfactor(can12V, nullptr);  // nullptr = no Log-Output
         ESP_LOGI(TAG, "Auto ADC recalibration started (%.2fV)", can12V);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -55,8 +55,6 @@ OvmsVehicleSmartEQ* OvmsVehicleSmartEQ::GetInstance(OvmsWriter* writer)
 OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   ESP_LOGI(TAG, "Start smart EQ vehicle module");
 
-  m_climate_init = true;
-  m_climate_start_day = false;
   m_12v_ticker = 0;
   m_ddt4all = false;
   m_ddt4all_ticker = 0;
@@ -147,16 +145,6 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_obd_mt_km_usual            = MyMetrics.InitInt("xsq.obd.mt.km.usual", SM_STALE_MID, 0, Kilometers);
   mt_obd_mt_level               = MyMetrics.InitString("xsq.obd.mt.level", SM_STALE_MID, "unknown", Other);
 
-  mt_climate_on                 = MyMetrics.InitBool("xsq.climate.on", SM_STALE_MID, false);
-  mt_climate_weekly             = MyMetrics.InitBool("xsq.climate.weekly", SM_STALE_MID, false);
-  mt_climate_time               = MyMetrics.InitString("xsq.climate.time", SM_STALE_MID, "0515", Other);
-  mt_climate_h                  = MyMetrics.InitInt("xsq.climate.h", SM_STALE_MID, 5, Other);
-  mt_climate_m                  = MyMetrics.InitInt("xsq.climate.m", SM_STALE_MID, 15, Other);
-  mt_climate_ds                 = MyMetrics.InitInt("xsq.climate.ds", SM_STALE_MID, 1, Other);
-  mt_climate_de                 = MyMetrics.InitInt("xsq.climate.de", SM_STALE_MID, 6, Other);
-  mt_climate_1to3               = MyMetrics.InitInt("xsq.climate.1to3", SM_STALE_MID, 0, Other);
-  mt_climate_data               = MyMetrics.InitString("xsq.climate.data", SM_STALE_MID,"0,0,0,0,-1,-1,-1", Other);
-
   mt_pos_odometer_start         = MyMetrics.InitFloat("xsq.odometer.start", SM_STALE_MID, 0, Kilometers);
   mt_pos_odometer_start_total   = MyMetrics.InitFloat("xsq.odometer.start.total", SM_STALE_MID, 0, Kilometers);
   mt_pos_odometer_trip_total    = MyMetrics.InitFloat("xsq.odometer.trip.total", SM_STALE_MID, 0, Kilometers);
@@ -216,13 +204,12 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
 
   // init commands:
-  cmd_xsq = MyCommandApp.RegisterCommand("xsq","SmartEQ 453 Gen.4");
+  cmd_xsq = MyCommandApp.RegisterCommand("xsq","smartEQ 453 Gen.4");
   cmd_xsq->RegisterCommand("start", "Show OBD trip start", xsq_trip_start);
   cmd_xsq->RegisterCommand("reset", "Show OBD trip total", xsq_trip_reset);
   cmd_xsq->RegisterCommand("counter", "Show vehicle trip counter", xsq_trip_counters);
   cmd_xsq->RegisterCommand("total", "Show vehicle trip total", xsq_trip_total);
   cmd_xsq->RegisterCommand("mtdata", "Show Maintenance data", xsq_maintenance);
-  cmd_xsq->RegisterCommand("climate", "Show Climate timer data", xsq_climate);
   cmd_xsq->RegisterCommand("tpmsset", "set TPMS dummy value", xsq_tpms_set);
   cmd_xsq->RegisterCommand("ddt4all", "DDT4all Command", xsq_ddt4all,"<number>",1,1);
   cmd_xsq->RegisterCommand("ddt4list", "DDT4all Command List", xsq_ddt4list);
@@ -361,10 +348,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     m_12v_charge           = getBool("12v.charge", true);
     m_enable_calcADCfactor = getBool("calc.adcfactor", false);
     m_adc_samples          = getInt("adc.samples", 4);
-    m_climate_system       = getBool("climate.system", true);
-    m_climate_notify       = getBool("climate.notify", false);
-    m_climate_data_store   = getBool("climate.data.store", true);
-    m_climate_data         = getString("climate.data", "0,0,0,0,-1,-1,-1");
     m_indicator            = getBool("indicator", false);
     m_extendedStats        = getBool("extended.stats", false);
     m_park_timeout_secs    = getInt("park.timeout", 600);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -108,9 +108,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void ResetChargingValues();
     void ResetTripCounters();
     void ResetTotalCounters();
-    void TimeCheckTask();
     void Check12vState();
-    void TimeBasedClimateData();
     void DisablePlugin(const char* plugin);
     bool ExecuteCommand(const std::string& command);
     void setTPMSValue(int index, int indexcar);
@@ -148,10 +146,8 @@ public:
     virtual vehicle_command_t CommandTripStart(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandTripReset(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandMaintenance(int verbosity, OvmsWriter* writer);
-    virtual vehicle_command_t CommandSetClimate(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandTripCounters(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandTripTotal(int verbosity, OvmsWriter* writer);
-    virtual vehicle_command_t CommandClimate(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t Command12Vcharge(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandTPMSset(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandDDT4all(int number, OvmsWriter* writer);
@@ -164,11 +160,9 @@ public:
     void WebInit();
     void WebDeInit();
     static void WebCfgFeatures(PageEntry_t& p, PageContext_t& c);
-    static void WebCfgClimate(PageEntry_t& p, PageContext_t& c);
     static void WebCfgTPMS(PageEntry_t& p, PageContext_t& c);
     static void WebCfgADC(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
-    static void WebCfgClimateSchedule(PageEntry_t& p, PageContext_t& c);
 #endif
     void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
@@ -179,7 +173,6 @@ public:
     static void xsq_trip_start(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_trip_reset(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_maintenance(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
-    static void xsq_climate(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_trip_counters(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_trip_total(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_tpms_set(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
@@ -277,10 +270,6 @@ public:
     bool m_tpms_alert_enable;               // TPMS Alert enabled
     bool m_12v_charge;                      //!< 12V charge on/off
     bool m_12v_charge_state;                //!< 12V charge state
-    bool m_climate_system;                  //!< climate system on/off
-    bool m_climate_notify;                  //!< climate notification on/off
-    bool m_climate_data_store;              //!< climate data store on/off
-    std::string m_climate_data;             //!< climate data stored
     std::string m_hl_canbyte;               //!< canbyte variable for unv
     bool m_extendedStats;                   //!< extended stats for trip and maintenance data
     std::deque<float> m_adc_factor_history; // ring buffer (max 20) for ADC factors
@@ -395,16 +384,6 @@ public:
     OvmsMetricInt           *mt_obd_mt_day_usual;       //!< Maintaince usual days
     OvmsMetricInt           *mt_obd_mt_km_usual;        //!< Maintaince usual km
     OvmsMetricString        *mt_obd_mt_level;           //!< Maintaince level
-
-    OvmsMetricBool          *mt_climate_on;             //!< climate at time on/off
-    OvmsMetricBool          *mt_climate_weekly;         //!< climate weekly auto on/off at day start/end
-    OvmsMetricString        *mt_climate_time;           //!< climate time
-    OvmsMetricInt           *mt_climate_h;              //!< climate time hour
-    OvmsMetricInt           *mt_climate_m;              //!< climate time minute
-    OvmsMetricInt           *mt_climate_ds;             //!< climate day start
-    OvmsMetricInt           *mt_climate_de;             //!< climate day end
-    OvmsMetricInt           *mt_climate_1to3;           //!< climate one to three (homelink 0-2) times in following time
-    OvmsMetricString        *mt_climate_data;           //!< climate data from app/website
  
     OvmsMetricVector<float> *mt_tpms_temp;              // 4 wheel temperatures (°C)
     OvmsMetricVector<float> *mt_tpms_pressure;          // 4 wheel pressures (kPa)
@@ -415,8 +394,6 @@ public:
     OvmsMetricString        *mt_bcm_gen_mode;           //!< Generator mode text
     
   protected:
-    bool m_climate_start_day;
-    bool m_climate_init;                      //!< climate init after boot
     bool m_indicator;                       //!< activate indicator e.g. 7 times or whatever
     bool m_ddt4all;                         //!< DDT4ALL mode
     bool m_warning_unlocked;                //!< unlocked warning


### PR DESCRIPTION
Eliminated all climate control timer, data, and web configuration code from the smartEQ vehicle module. This includes removal of climate-related metrics, commands, web pages, feature handling, and periodic tasks, simplifying the codebase and configuration options.