### PR TITLE
Server V3: Transmit only defined metrics in server sync

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -335,7 +335,7 @@ void OvmsServerV3::TransmitAllMetrics()
     // Clear our modified slot for full-sync pass:
     cur->ClearModified(MyOvmsServerV3Modifier);
 
-    if (included)
+    if (included && cur->IsDefined())
       {
       TransmitMetric(cur); // applies filter again internally, harmless
       sent++;
@@ -395,7 +395,7 @@ void OvmsServerV3::TransmitModifiedMetrics()
     OvmsMetric* cur = m;
     m = m->m_next;
     // Check & clear modification flag for our modifier slot.
-    if (cur->IsModifiedAndClear(MyOvmsServerV3Modifier))
+    if (cur->IsModifiedAndClear(MyOvmsServerV3Modifier) && cur->IsDefined())
       {
       TransmitMetric(cur);
       sent++;


### PR DESCRIPTION
Added checks to ensure only defined metrics are transmitted during full-sync and modified metrics transmission. This prevents sending undefined metrics and improves data integrity.