### PR TITLE
Server V3: Transmit metrics only if defined

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v3/src/ovms_server_v3.cpp
@@ -470,7 +470,7 @@ void OvmsServerV3::TransmitPriorityMetrics()
       if (name.empty() || already_processed(name)) return;
       OvmsMetric* m = MyMetrics.Find(name.c_str());
       if (!m) return;
-      if (m->IsModifiedAndClear(MyOvmsServerV3Modifier))
+      if (m->IsModifiedAndClear(MyOvmsServerV3Modifier) && m->IsDefined())
         TransmitMetric(m);
       mark_processed(name);
     };
@@ -975,7 +975,8 @@ void OvmsServerV3::MetricModified(OvmsMetric* metric)
     return;
     
   if (m_metrics_immediately.CheckFilter(metric_name) && 
-      metric->IsModifiedAndClear(MyOvmsServerV3Modifier))
+      metric->IsModifiedAndClear(MyOvmsServerV3Modifier) &&
+      metric->IsDefined())
     {
     TransmitMetric(metric);
     }
@@ -1439,7 +1440,8 @@ void OvmsServerV3::ProcessClientMetricRequest(const std::string& clientid, const
   const std::string name(m->m_name);
   if (!reqfilter.CheckFilter(name))
     continue;
-  TransmitMetric(m);
+  if (m->IsDefined())
+    TransmitMetric(m);
   }
 }
 


### PR DESCRIPTION
Added checks to ensure metrics are transmitted only when they are defined. This prevents sending undefined metrics in TransmitPriorityMetrics, MetricModified, and ProcessClientMetricRequest.

That's all (today), I'm finished with V3