### PR TITLE
Update vehicle_thinkcity.cpp

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.cpp
@@ -239,7 +239,44 @@ void OvmsVehicleThinkCity::IncomingFrameCan1(CAN_frame_t* p_frame)
 		        StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RL, (float)d[3] * 0.3625, PSI);
 		    }
 		  break;
-
+    case 0x345: // TPMS Status Alerts and Warnings
+      {
+        std::vector<short> tpms_alert(4);
+        uint8_t tpms_warning;
+        
+        for (int j = 0; j < 4; j++)
+        {
+          tpms_warning = 0;
+          
+          if (j == MS_V_TPMS_IDX_FL)  // Front-left tire
+            tpms_warning = (d[0] & 0x0E) >> 1;  // Extract LF warning bits
+          else if (j == MS_V_TPMS_IDX_FR) // Front-right tire
+            tpms_warning = (d[1] & 0xE0) >> 5;  // Extract RF warning bits
+          else if (j == MS_V_TPMS_IDX_RR)  // Rear-right tire
+            tpms_warning = (d[1] & 0x0E) >> 1;  // Extract RR warning bits
+          else if (j ==MS_V_TPMS_IDX_RL)  //Rear-left tire
+            tpms_warning = (d[2] & 0xE0) >> 5;  // Extract LR warning bits
+          
+          if ((tpms_warning == 2) || (tpms_warning == 7)) // Very Low (Red) or missing sensor
+          {
+            tpms_alert[j] = 2; // "ALERT"
+          }
+          else if ((tpms_warning == 5) || (tpms_warning == 0)) // Fast deflation or Unknown State
+          {
+            tpms_alert[j] = 1; // "WARN"
+          }
+          else if (tpms_warning == 6) // Normal Tire Pressure
+          {
+            tpms_alert[j] = 0; // "OK"
+          }
+          else // Undefined States
+          {
+            tpms_alert[j] = 0; // Mark as undefined/unknown
+          }
+        }
+        StandardMetrics.ms_v_tpms_alert->SetValue(tpms_alert); // Use SetElemValues for vector
+      }
+      break;
     case 0x511:
       // Enerdel battery pack?
       // TODO: Enable battery pack cells monitoring


### PR DESCRIPTION
TPMS Status (0x345) Case added.  This addition uses Standard Metrics for TPMS Alerts and Warnings to allow TPMS Sensor Status data to be reflected in the TPMS GUI of the vehicle App as well as in the notifications.  These changes were included in a local build, tested on 2 THINK City vehicles and functionality verified.   
![Screenshot_20251119_123257_Open Vehicle](https://github.com/user-attachments/assets/78f011a4-8eee-48fd-b6e0-f1b74104a039)
New Behavior:  On starting to drive, each tire in the TPMS GUI now shows a check mark if the tire sensor is confirmed working and tire pressure not very low.  Otherwise, that tire label comes up RED and with an Alert triangle.  
![Screenshot_20251118_171004_Open Vehicle](https://github.com/user-attachments/assets/55c3143d-0d01-4507-b50e-3a77690032cf)

After about a minute when first pressures come in, the triangles and check marks go away and are replaced by pressures.  
![Screenshot_20251118_171037_Google](https://github.com/user-attachments/assets/681acf07-7ee8-4470-9884-e5326d3512b4)

The color assignments remain as long as alert conditions persist.  Testing confirmed the RED alert goes away a few minutes after correcting a low pressure condition. 

Remaining issue: Left vs Right tire data always or often appears switched, however this is likely due to the Automatic TPMS Learning incorporated with THINK City cars.  Direct TPMS CAN data collection has shown that either the L/R tire order in the data is flipped or that it could go either way when the TPMS sensors are automatically "learned".  Until we know for sure which it is, no sense in changing anything.