### PR TITLE
smartEQ: Refactor TPMS sensor index configuration storage

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -807,7 +807,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandTPMSset(int verbosity,
   float dummy_pressure = mt_dummy_pressure->AsFloat();
   for (int i = 0; i < 4; i++) {
     m_tpms_pressure[i] = dummy_pressure; // kPa
-    setTPMSValue(i, m_tpms_index_sq[i]);
+    setTPMSValue(i, m_tpms_index[i]);
   }
   writer->printf("set TPMS dummy pressure: %.2f", dummy_pressure);
   return Success;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -363,10 +363,10 @@ void OvmsVehicleSmartEQ::WebCfgTPMS(PageEntry_t& p, PageContext_t& c) {
       // Read all TPMS values using sq->
       tpms_temp        = getBool("tpms.temp", sq->m_tpms_temp_enable);
       enable           = getBool("tpms.alert.enable", sq->m_tpms_alert_enable);
-      TPMS_FL          = getStringInt("TPMS_FL", sq->m_tpms_index_sq[0]);
-      TPMS_FR          = getStringInt("TPMS_FR", sq->m_tpms_index_sq[1]);
-      TPMS_RL          = getStringInt("TPMS_RL", sq->m_tpms_index_sq[2]);
-      TPMS_RR          = getStringInt("TPMS_RR", sq->m_tpms_index_sq[3]);
+      TPMS_FL          = getStringInt("TPMS_FL", sq->m_tpms_index[0]);
+      TPMS_FR          = getStringInt("TPMS_FR", sq->m_tpms_index[1]);
+      TPMS_RL          = getStringInt("TPMS_RL", sq->m_tpms_index[2]);
+      TPMS_RR          = getStringInt("TPMS_RR", sq->m_tpms_index[3]);
       front_pressure   = getString("tpms.front.pressure", sq->m_front_pressure);
       rear_pressure    = getString("tpms.rear.pressure", sq->m_rear_pressure);
       pressure_warning = getString("tpms.value.warn", sq->m_pressure_warning);
@@ -377,13 +377,13 @@ void OvmsVehicleSmartEQ::WebCfgTPMS(PageEntry_t& p, PageContext_t& c) {
       tpms_temp        = sq->m_tpms_temp_enable;
       enable           = sq->m_tpms_alert_enable;
       
-      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index_sq[0]);
+      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index[0]);
       TPMS_FL = buf;
-      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index_sq[1]);
+      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index[1]);
       TPMS_FR = buf;
-      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index_sq[2]);
+      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index[2]);
       TPMS_RL = buf;
-      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index_sq[3]);
+      snprintf(buf, sizeof(buf), "%d", sq->m_tpms_index[3]);
       TPMS_RR = buf;
       
       snprintf(buf, sizeof(buf), "%.0f", sq->m_front_pressure);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -83,7 +83,6 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
     m_tpms_temperature[i] = 2.0f;
     m_tpms_lowbatt[i] = false;
     m_tpms_missing_tx[i] = false;
-    m_tpms_index_sq[i] = i;
     }
 
   // BMS configuration:
@@ -276,14 +275,6 @@ OvmsVehicleSmartEQ::~OvmsVehicleSmartEQ() {
  * ConfigChanged: reload single/all configuration variables (cfgupdate)
  */
 void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
-  if (!param || param->GetName() == "vehicle")
-    {    // read TPMS sensor index configuration
-    m_tpms_index_sq[0] = MyConfig.GetParamValueInt("vehicle", "tpms.fl", 0);
-    m_tpms_index_sq[1] = MyConfig.GetParamValueInt("vehicle", "tpms.fr", 1);
-    m_tpms_index_sq[2] = MyConfig.GetParamValueInt("vehicle", "tpms.rl", 2);
-    m_tpms_index_sq[3] = MyConfig.GetParamValueInt("vehicle", "tpms.rr", 3);
-    }
-
   if (param && param->GetName() != "xsq")
     return;
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -191,7 +191,6 @@ public:
     float m_tpms_temperature[4]; // °C
     bool m_tpms_lowbatt[4]; // 0=ok, 1=low
     bool m_tpms_missing_tx[4]; // 0=ok, 1=missing
-    int m_tpms_index_sq[4];
     bool m_ADCfactor_recalc;       // request recalculation of ADC factor
     int m_ADCfactor_recalc_timer;  // countdown timer for ADC factor recalculation
 


### PR DESCRIPTION
Moved TPMS sensor index values from 'xsq' to 'vehicle' config parameter and renamed internal variable to m_tpms_index_sq. Updated related logic in commands, web configuration, and config change handling. Bumped version to 2.1.0 and preset version to 4.