### PR TITLE
Fix TPMS index mapping for rear tires

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_thinkcity/src/vehicle_thinkcity.cpp
@@ -232,11 +232,11 @@ void OvmsVehicleThinkCity::IncomingFrameCan1(CAN_frame_t* p_frame)
 		    }
 		    if (d[2]!=0xFF) // Rear-right
 		    {
-		        StandardMetrics.ms_v_tpms_pressure->SetElemValue(m_tpms_index[2], (float)d[2] * 0.3625, PSI);
+		        StandardMetrics.ms_v_tpms_pressure->SetElemValue(m_tpms_index[3], (float)d[2] * 0.3625, PSI);
 		    }
 		    if (d[3]!=0xFF) // Rear-left
 		    {
-		        StandardMetrics.ms_v_tpms_pressure->SetElemValue(m_tpms_index[3], (float)d[3] * 0.3625, PSI);
+		        StandardMetrics.ms_v_tpms_pressure->SetElemValue(m_tpms_index[2], (float)d[3] * 0.3625, PSI);
 		    }
 		  break;
     case 0x345: // TPMS Status Alerts and Warnings
@@ -252,9 +252,9 @@ void OvmsVehicleThinkCity::IncomingFrameCan1(CAN_frame_t* p_frame)
             tpms_warning = (d[0] & 0x0E) >> 1;  // Extract LF warning bits
           else if (j == m_tpms_index[1]) // Front-right tire
             tpms_warning = (d[1] & 0xE0) >> 5;  // Extract RF warning bits
-          else if (j == m_tpms_index[2])  // Rear-right tire
+          else if (j == m_tpms_index[3])  // Rear-right tire
             tpms_warning = (d[1] & 0x0E) >> 1;  // Extract RR warning bits
-          else if (j == m_tpms_index[3])  //Rear-left tire
+          else if (j == m_tpms_index[2])  //Rear-left tire
             tpms_warning = (d[2] & 0xE0) >> 5;  // Extract LR warning bits
           
           if ((tpms_warning == 2) || (tpms_warning == 7)) // Very Low (Red) or missing sensor


### PR DESCRIPTION
Corrects the mapping of TPMS pressure and warning values for rear-left and rear-right tires to ensure accurate metric assignment. This resolves swapped index usage in CAN frame processing.

#1263 
#1268 
