### PR TITLE
Update vehicle_hyundai_ioniqvfl.cpp

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniqvfl/src/vehicle_hyundai_ioniqvfl.cpp
@@ -102,7 +102,7 @@ OvmsVehicleHyundaiVFL::OvmsVehicleHyundaiVFL()
   }
 
   // Init BMS:
-  BmsSetCellArrangementVoltage(96, 12);
+  BmsSetCellArrangementVoltage(96, 8);
   BmsSetCellArrangementTemperature(12, 1);
   BmsSetCellLimitsVoltage(2.0, 5.0);
   BmsSetCellLimitsTemperature(-39, 200);


### PR DESCRIPTION
Ioniq 28kWh has 12 battery pack with average of 8 cell in a pack