### PR TITLE
smartEQ: Refactor BMS, EVC and OBL metrics to use vectors

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -57,18 +57,21 @@ You can use some DDT4all commands. A list of all possible commands you can find 
 -------------------------
 Shell commands:
 -------------------------
-xsq start                  -- Show OBD trip start data
-xsq reset                  -- Show OBD trip total data
-xsq counter                -- Show vehicle trip counter
-xsq total                  -- Show vehicle trip total
-xsq mtdata                 -- Show maintenance data
-xsq tpmsset                -- Set TPMS dummy value for testing
+xsq mtdata                 -- maintenance data
 xsq ddt4all <number>       -- Execute DDT4all command by number
 xsq ddt4list               -- List all available DDT4all commands
 xsq calcadc [voltage]      -- Recalculate ADC factor (optional: 12V voltage override)
 xsq wakeup                 -- Wake up the car
 xsq ed4scan                -- Output ED4scan-like BMS diagnostic data
 xsq preset                 -- Apply smart EQ config preset
+
+xsq tpms stat              -- Show smartEQ TPMS status incl. battery & missing
+xsq tpms setdummy          -- Set TPMS dummy value for testing
+
+xsq show start             -- Show OBD trip start data
+xsq show reset             -- Show OBD trip total data
+xsq show counter           -- Show vehicle trip counter
+xsq show total             -- Show vehicle trip total data
 
 -------------------------
 Known Issues
@@ -89,11 +92,6 @@ metrics
     xsq.v.bat.consumption.worst           -- Worst average consumption [kWh/100km]
     xsq.v.bat.consumption.best            -- Best average consumption [kWh/100km]
     xsq.v.charge.bcb.power                -- BCB power from mains [W]
-    xsq.v.charge.timer.value              -- Charging timer value [min]
-    xsq.v.charge.timer.status             -- Charging timer status
-    xsq.v.charge.prohibited               -- Charge prohibited status
-    xsq.v.charge.authorization            -- Charge authorization status
-    xsq.v.charge.ext.manager              -- External charging manager status
     xsq.v.reset.time                      -- Trip time (reset) [hh:mm]
     xsq.v.reset.consumption               -- Average trip consumption (reset) [kWh/100km]
     xsq.v.reset.distance                  -- Trip distance (reset) [km]
@@ -118,57 +116,41 @@ metrics
     xsq.obd.mt.day.usual                  -- Usual maintenance interval [days]
     xsq.obd.mt.km.usual                   -- Usual maintenance interval [km]
     xsq.obd.mt.level                      -- Maintenance level status
-
-    xsq.tpms.temp                         -- TPMS tyre temperatures vector [°C]
-    xsq.tpms.pressure                     -- TPMS tyre pressures vector [kPa]
-    xsq.tpms.alert                        -- TPMS alert levels vector
+    
     xsq.tpms.lowbatt                      -- TPMS low battery status vector
     xsq.tpms.missing                      -- TPMS missing transmission status vector
     xsq.tpms.dummy                        -- Dummy pressure for TPMS alert testing [kPa]
 
     xsq.bcm.state                         -- BCM vehicle state
     xsq.bcm.gen.mode                      -- BCM generator mode
-
+    
     xsq.evc.hv.energy                     -- EVC HV energy [kWh]
     xsq.evc.12V.dcdc.act.req              -- DCDC active request [bool]
-    xsq.evc.12V.dcdc.amps                 -- DCDC current [A]
-    xsq.evc.12V.dcdc.load                 -- DCDC load [%]
-    xsq.evc.12V.dcdc.volt.req             -- DCDC voltage request [V]
-    xsq.evc.12V.dcdc.volt                 -- DCDC voltage [V]
-    xsq.evc.12V.dcdc.power                -- DCDC power [W]
-    xsq.evc.12V.volt.usm                  -- USM 12V voltage [V]
-    xsq.evc.12V.volt.can                  -- 12V battery voltage from CAN [V]
-    xsq.evc.12V.batt.volt.req.int         -- 12V battery voltage request internal [V]
+    xsq.evc.12v.dcdc                      -- EVC 12V system values vector: [0]=dcdc_volt_req(V), [1]=dcdc_volt(V), [2]=dcdc_power(W), [3]=usm_volt(V), [4]=batt_volt(V), [5]=batt_volt_req(V), [6]=dcdc_amps(A), [7]=dcdc_load(%)
     xsq.evc.traceability                  -- EVC frame traceability information [string] 
 
     xsq.obl.fastchg                       -- Fast charge active [bool]
     xsq.obl.volts                         -- OBL voltage phases vector [V]
     xsq.obl.amps                          -- OBL current phases vector [A]
     xsq.obl.power                         -- OBL power phases vector [kW]
-    xsq.obl.misc                          -- OBL miscellaneous data vector
+    xsq.obl.misc                          -- OBL miscellaneous data vector: [0]=freq(Hz), [1]=ground_resistance(Ohm), [2]=max_current(A), [3]=dc_current(mA), [4]=hf10kHz_current(mA), [5]=hf_current(mA), [6]=lf_current(mA)
     xsq.obl.leakdiag                      -- OBL leakage diagnostic status
-    xsq.obl.current                       -- OBL leakage currents vector [A]
 
     xsq.bms.prod.data                     -- BMS production data formatted (serial, MM/YYYY)
     xsq.bms.temps                         -- BMS temperature sensors vector [°C]
-    xsq.bms.voltages                      -- Voltage values [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor, [5]=cv_sum [V]
+    xsq.bms.voltages                      -- BMS voltage values vector: [0]=cell_min(V), [1]=cell_max(V), [2]=cell_mean(V), [3]=link_volt(V), [4]=pack_volt(V), [5]=ocv_volt(V), [6]=12v_system(V)
     xsq.bms.contactor.cycles              -- HV contactor maximum/available cycles
     xsq.bms.soc.values                    -- SOC values vector [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display [%]
     xsq.bms.soc.recal.state               -- SOC recalibration state
     xsq.bms.soh                           -- State of Health [%]
-    xsq.bms.cap.usable.max                -- Maximum usable capacity [Ah]
-    xsq.bms.cap.init                      -- Initial capacity [Ah]
-    xsq.bms.cap.estimate                  -- Estimated capacity [Ah]
-    xsq.bms.cap.loss.pct                  -- Capacity loss percentage [%]
+    xsq.bms.cap                           -- BMS capacity values vector: [0]=usable_max(Ah), [1]=init(Ah), [2]=estimate(Ah), [3]=loss_pct(%)
     xsq.bms.mileage                       -- Battery mileage [km]
     xsq.bms.energy.nominal                -- Nominal battery energy [kWh]
-    xsq.bms.ocv.voltage                   -- Open circuit voltage [V]
     xsq.bms.voltage.state                 -- Voltage state description
     xsq.bms.cell.resistance               -- Cell resistance values vector
     xsq.bms.batt.power                    -- Battery power [kW]
     xsq.bms.contact                       -- HV contactor state text
     xsq.bms.ev.mode                       -- EV mode text
-    xsq.bms.12v                           -- 12V system voltage [V]
     xsq.bms.interlock.hvplug              -- HV plug interlock status [bool]
     xsq.bms.interlock.service             -- Service interlock status [bool]
     xsq.bms.fusi                          -- FUSI mode text

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -160,23 +160,6 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       mt_best_consumption->SetValue(best_consumption);
       mt_bcb_power_mains->SetValue(bcb_power_mains);
       break;
-      }    
-    case 0x634:
-      REQ_DLC(2);
-      {
-      uint8_t raw_timer = CAN_BYTE(1) & 0x7F;
-      uint16_t charging_timer_value = (uint16_t)raw_timer * 15;
-      uint8_t charging_timer_status = CAN_BYTE(2) & 0x03;
-      uint8_t charge_prohibited = (CAN_BYTE(2) >> 2) & 0x03;
-      uint8_t charge_authorization = (CAN_BYTE(2) >> 4) & 0x03;
-      uint8_t ext_charge_manager = (CAN_BYTE(2) >> 6) & 0x03;
-      
-      mt_charging_timer_value->SetValue(charging_timer_value);
-      mt_charging_timer_status->SetValue(charging_timer_status);
-      mt_charge_prohibited->SetValue(charge_prohibited);
-      mt_charge_authorization->SetValue(charge_authorization);
-      mt_ext_charge_manager->SetValue(ext_charge_manager);
-      break;
       }
     case 0x637:
       REQ_DLC(6);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -568,9 +568,9 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandStat(int verbosity, Ov
     const std::string& health = StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0);
     writer->printf("SOH: %s %s\n", soh.c_str(), health.c_str());
     }
-  if (mt_evc_hv_energy->IsDefined())
+  if (StdMetrics.ms_v_bat_capacity->IsDefined())
     {
-    const std::string& hv_energy = mt_evc_hv_energy->AsUnitString("-", ToUser, 3);
+    const std::string& hv_energy = StdMetrics.ms_v_bat_capacity->AsUnitString("-", ToUser, 3);
     writer->printf("usable Energy: %s\n", hv_energy.c_str());
     }
   
@@ -905,13 +905,13 @@ void OvmsVehicleSmartEQ::xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCom
       return;
       }
 
-    if (!smarteq->mt_evc_LV_DCDC_act_req->AsBool(false)) 
+    if (!StdMetrics.ms_v_env_charging12v->AsBool(false)) 
       {
       writer->puts("Error: vehicle 12V DC-DC converter not active");
       return;
       } 
         
-    float can12V = smarteq->mt_evc_LV_DCDC_volt->AsFloat(0.0f);   // DCDC 12V voltage from CAN bus
+    float can12V = smarteq->mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
     if (can12V <= 13.10f) 
       {
       writer->puts("Error: vehicle 12V is not charging, 12V voltage is not stable for ADC calibration!");
@@ -1059,7 +1059,7 @@ void OvmsVehicleSmartEQ::xsq_ed4scan(int verbosity, OvmsWriter* writer, OvmsComm
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity, OvmsWriter* writer) {
-  writer->puts("=== ED4scan-like BMS/EVC Data Output ===\n");
+  writer->puts("=== ED4scan-like BMS/EVC/OBL Data Output ===\n");
   writer->printf("  HV Batt Serialnumber:    %s\n", mt_bat_serial->AsString().c_str());
   writer->printf("  BMS Serialnumber:        %s\n", mt_bms_prod_data->AsString().c_str());
   writer->printf("  EVC Traceability:        %s\n", mt_evc_traceability->AsString().c_str());
@@ -1068,20 +1068,20 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
 
   writer->puts("--- Battery Health (PID 0x61) ---");
   writer->printf("  State of Health:         %.0f%%\n", mt_bms_soh->AsFloat());
-  writer->printf("  Usable Capacity:         %.2f Ah\n", mt_bms_cap_usable_max->AsFloat());
+  writer->printf("  Usable Capacity:         %.2f Ah\n", mt_bms_cap->GetElemValue(0));
   
   writer->puts("\n--- HV Contactor Cycles (PID 0x02) ---");
   writer->printf("  Max Cycles:              %d\n", mt_bms_contactor_cycles->GetElemValue(0));
   writer->printf("  remaining Cycles:        %d\n", mt_bms_contactor_cycles->GetElemValue(1));
   
   writer->puts("\n--- SOC Kernel Data (PID 0x08) ---");
-  writer->printf("  Open Circuit Voltage:    %.2f V\n", mt_bms_ocv_voltage->AsFloat());
+  writer->printf("  Open Circuit Voltage:    %.2f V\n", mt_bms_voltages->GetElemValue(5));
   writer->printf("  Real SOC (Min):          %.2f%%\n", mt_bms_soc_values->GetElemValue(2));
   writer->printf("  Real SOC (Max):          %.2f%%\n", mt_bms_soc_values->GetElemValue(3));
   writer->printf("  Kernel SOC:              %.2f%%\n", mt_bms_soc_values->GetElemValue(0));
-  writer->printf("  Capacity Loss:           %.2f%%\n", mt_bms_cap_loss_percent->AsFloat());
-  writer->printf("  Initial Capacity:        %.2f Ah\n", mt_bms_cap_init->AsFloat());
-  writer->printf("  Estimated Capacity:      %.2f Ah\n", mt_bms_cap_estimate->AsFloat());
+  writer->printf("  Capacity Loss:           %.2f%%\n", mt_bms_cap->GetElemValue(3));
+  writer->printf("  Initial Capacity:        %.2f Ah\n", mt_bms_cap->GetElemValue(1));
+  writer->printf("  Estimated Capacity:      %.2f Ah\n", mt_bms_cap->GetElemValue(2));
   writer->printf("  Voltage State:           %s\n", mt_bms_voltage_state->AsString().c_str());
   
   writer->puts("\n--- SOC Recalibration (PID 0x25) ---");
@@ -1095,22 +1095,33 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  Link Voltage:            %.2f V\n", mt_bms_voltages->GetElemValue(3));
   writer->printf("  Pack Voltage:            %.2f V\n", mt_bms_voltages->GetElemValue(4));
   writer->printf("  Pack Current:            %.2f A\n", StdMetrics.ms_v_bat_current->AsFloat());
-  writer->printf("  Pack Power:              %.2f kW\n", mt_bms_BattPower_power->AsFloat());
+  writer->printf("  Pack Power:              %.2f kW\n", StdMetrics.ms_v_bat_power->AsFloat());
   writer->printf("  Contactor State:         %s\n", mt_bms_HVcontactStateTXT->AsString().c_str());
   writer->printf("  Vehicle Mode:            %s\n", mt_bms_EVmode_txt->AsString().c_str());
-  writer->printf("  12V BMS System:          %.2f V\n", mt_bms_12v->AsFloat());
+  writer->printf("  BMS 12V Voltage:         %.2f V\n", mt_bms_voltages->GetElemValue(6));
 
   writer->puts("\n--- EVC Data (0x7EC) ---");
-  writer->printf("  HV Energy:               %.3f kWh\n", mt_evc_hv_energy->AsFloat());
-  writer->printf("  DCDC Active Request:     %s\n", mt_evc_LV_DCDC_act_req->AsBool() ? "Yes" : "No");
-  writer->printf("  DCDC Voltage Request:    %.2f V\n", mt_evc_LV_DCDC_volt_req->AsFloat());
-  writer->printf("  DCDC Voltage:            %.2f V\n", mt_evc_LV_DCDC_volt->AsFloat());
-  writer->printf("  DCDC Current:            %.1f A\n", mt_evc_LV_DCDC_amps->AsFloat());
-  writer->printf("  DCDC Power:              %.0f W\n", mt_evc_LV_DCDC_power->AsFloat());
-  writer->printf("  DCDC Load:               %.1f%%\n", mt_evc_LV_DCDC_load->AsFloat());
-  writer->printf("  USM 12V Voltage:         %.2f V\n", mt_evc_LV_USM_volt->AsFloat());
-  writer->printf("  12V Battery (CAN):       %.2f V\n", mt_evc_LV_batt_voltage_can->AsFloat());
-  writer->printf("  12V Battery Req (int):   %.2f V\n", mt_evc_LV_batt_voltage_req->AsFloat());
+  writer->printf("  HV Energy:               %.3f kWh\n", StdMetrics.ms_v_bat_capacity->AsFloat());
+  writer->printf("  DCDC Active Request:     %s\n", StdMetrics.ms_v_env_charging12v->AsBool() ? "Yes" : "No");
+  writer->printf("  DCDC Current:            %.1f A\n", mt_evc_dcdc->GetElemValue(6));
+  writer->printf("  DCDC Power:              %.0f W\n", mt_evc_dcdc->GetElemValue(2));
+  writer->printf("  DCDC Load:               %.1f%%\n", mt_evc_dcdc->GetElemValue(7));
+  writer->printf("  Req (int) 12V Voltage:   %.2f V\n", mt_evc_dcdc->GetElemValue(5));
+  writer->printf("  DCDC Voltage Request:    %.2f V\n", mt_evc_dcdc->GetElemValue(0));
+  writer->printf("  DCDC 12V Voltage:        %.2f V\n", mt_evc_dcdc->GetElemValue(1));
+  writer->printf("  USM 12V Voltage:         %.2f V\n", mt_evc_dcdc->GetElemValue(3));
+  writer->printf("  Batt 12V Voltage:        %.2f V\n", mt_evc_dcdc->GetElemValue(4));
+
+  writer->puts("\n--- OBL Charger Data (0x793) ---");
+  writer->printf("  Fast Charge Active:      %s\n", mt_obl_fastchg->AsBool() ? "Yes" : "No");
+  writer->printf("  Mains Frequency:         %.2f Hz\n", mt_obl_misc->GetElemValue(0));
+  writer->printf("  Ground Resistance:       %.1f Ohm\n", mt_obl_misc->GetElemValue(1));
+  writer->printf("  Max AC Current:          %.1f A\n", mt_obl_misc->GetElemValue(2));
+  writer->printf("  Leakage DC Current:      %.3f mA\n", mt_obl_misc->GetElemValue(3));
+  writer->printf("  Leakage HF10kHz:         %.3f mA\n", mt_obl_misc->GetElemValue(4));
+  writer->printf("  Leakage HF Current:      %.3f mA\n", mt_obl_misc->GetElemValue(5));
+  writer->printf("  Leakage LF Current:      %.3f mA\n", mt_obl_misc->GetElemValue(6));
+  writer->printf("  Leakage Diagnostic:      %s\n", mt_obl_main_leakage_diag->AsString().c_str());
 
   int show = mt_ed4_values->AsInt(10); // number of cells to show
 
@@ -1153,3 +1164,125 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->puts("\n=== End of ED4scan Data ===");
   return Success;
 }
+
+void OvmsVehicleSmartEQ::xsq_tpms_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv) {
+  OvmsVehicleSmartEQ* smarteq = GetInstance(writer);
+  if (!smarteq) return;
+
+  bool data_shown = false;
+  const char* alertname[] = { "OK", "WARN", "ALERT" };  
+  std::vector<std::string> tpms_layout = smarteq->GetTpmsLayout();  
+  
+  writer->printf("TPMS Data       : ");
+  for (auto wheel : tpms_layout)
+    writer->printf(" %8s", wheel.c_str());
+  writer->puts("");
+
+  if (StandardMetrics.ms_v_tpms_alert->IsDefined())
+    {
+    writer->printf("Alert level     : ");
+    for (auto val : StandardMetrics.ms_v_tpms_alert->AsVector())
+      {
+      // Bounds check to prevent array overflow
+      if (val >= 0 && val <= 2)
+        writer->printf(" %8s", alertname[val]);
+      else if (val < 0)
+        writer->printf(" %8s", "UNKNOWN");
+      else
+        writer->printf(" %8s", "INVALID");
+      }
+    writer->puts(StandardMetrics.ms_v_tpms_alert->IsStale() ? "  [stale]" : "");
+    data_shown = true;
+    }
+
+  if (smarteq->mt_tpms_low_batt->IsDefined())
+    {
+    writer->printf("Battery         : ");
+    for (auto val : smarteq->mt_tpms_low_batt->AsVector())
+      {
+      // Bounds check to prevent array overflow
+      if (val >= 0 && val <= 2)
+        writer->printf(" %8s", alertname[val]);
+      else if (val < 0)
+        writer->printf(" %8s", "UNKNOWN");
+      else
+        writer->printf(" %8s", "INVALID");
+      }
+    writer->puts(smarteq->mt_tpms_low_batt->IsStale() ? "  [stale]" : "");
+    data_shown = true;
+    }
+
+  if (smarteq->mt_tpms_missing_tx->IsDefined())
+    {
+    writer->printf("Missing Tx      : ");
+    for (auto val : smarteq->mt_tpms_missing_tx->AsVector())
+      {
+      // Bounds check to prevent array overflow
+      if (val >= 0 && val <= 2)
+        writer->printf(" %8s", alertname[val]);
+      else if (val < 0)
+        writer->printf(" %8s", "UNKNOWN");
+      else
+        writer->printf(" %8s", "INVALID");
+      }
+    writer->puts(smarteq->mt_tpms_missing_tx->IsStale() ? "  [stale]" : "");
+    data_shown = true;
+    }
+
+  if (!smarteq->m_tpms_index.empty())
+    {
+    writer->printf("Sensor mapping  : ");
+    for (auto val : smarteq->m_tpms_index)
+      {
+      if (val >= 0)
+        {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%d", val);
+        writer->printf(" %8s", buf);
+        }
+      else
+        {
+        writer->printf(" %8s", "-");
+        }
+      }
+    writer->puts("");
+    data_shown = true;
+    }
+
+  if (StandardMetrics.ms_v_tpms_pressure->IsDefined())
+    {
+    metric_unit_t user_pressure = OvmsMetricGetUserUnit(GrpPressure, kPa);
+    writer->printf("Pressure...[%s]: ", OvmsMetricUnitLabel(user_pressure));
+    for (auto val : StandardMetrics.ms_v_tpms_pressure->AsVector(user_pressure))
+      {
+      // Validate pressure (typical range 0-500 kPa)
+      if (!std::isnan(val) && val >= 0.0f && val <= 500.0f)
+        writer->printf(" %8.1f", val);
+      else
+        writer->printf(" %8s", "-");
+      }
+    writer->puts(StandardMetrics.ms_v_tpms_pressure->IsStale() ? "  [stale]" : "");
+    data_shown = true;
+    }
+
+  if (StandardMetrics.ms_v_tpms_temp->IsDefined())
+    {
+    metric_unit_t user_temp = OvmsMetricGetUserUnit(GrpTemp, Celcius);
+    writer->printf("Temperature.[%s]: ", OvmsMetricUnitLabel(user_temp));
+    for (auto val : StandardMetrics.ms_v_tpms_temp->AsVector(user_temp))
+      {
+      // Validate temperature (typical range -40 to +150 °C)
+      if (!std::isnan(val) && val >= -50.0f && val <= 200.0f)
+        writer->printf(" %8.1f", val);
+      else
+        writer->printf(" %8s", "-");
+      }
+    writer->puts(StandardMetrics.ms_v_tpms_temp->IsStale() ? "  [stale]" : "");
+    data_shown = true;
+    }
+
+  if (!data_shown)
+    writer->puts("Sorry, no data available. Try switching the vehicle on.");
+
+  writer->puts("");
+  }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -153,18 +153,15 @@ void OvmsVehicleSmartEQ::setTPMSValue() {
     
   // Set the metrics  
   StdMetrics.ms_v_tpms_pressure->SetValue(tpms_pressure);
-  mt_tpms_pressure->SetValue(tpms_pressure);
   
   if (m_tpms_temp_enable)
     {
     StdMetrics.ms_v_tpms_temp->SetValue(tpms_temp);
-    mt_tpms_temp->SetValue(tpms_temp);    
     }
     
   if (m_tpms_alert_enable)
     {
     StdMetrics.ms_v_tpms_alert->SetValue(tpms_alert);
-    mt_tpms_alert->SetValue(tpms_alert);    
     }
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -76,7 +76,7 @@ static const OvmsPoller::poll_pid_t obdii_polls[] =
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {  0,10,10,10 }, 0, ISOTP_STD }, // USM 14V voltage (CAN)
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3433, {  0,60,60,60 }, 0, ISOTP_STD }, // Battery voltage request (internal)
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {  0,60,60,60 }, 0, ISOTP_STD }, // Cabin blower command
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {  0,60,60,60 }, 0, ISOTP_STD }, // Battery voltage 14V request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {  0,60,60,60 }, 0, ISOTP_STD }, // Battery voltage 14V
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {  0,3600,0,0 }, 0, ISOTP_STD }, // Frame Traceability Information 
 };
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -50,26 +50,26 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     HandleEnergy();
     HandleTripcounter();
     }
-    
-  if (ticker % 10 == 0) // Every 10 seconds
-    {
-    // reactivate door lock warning if the car is parked and unlocked
-    if( m_enable_lock_state && 
-          m_warning_unlocked &&
-          (StdMetrics.ms_v_door_fl->AsBool()  || 
-            StdMetrics.ms_v_door_fr->AsBool() ||
-            StdMetrics.ms_v_door_rl->AsBool() ||
-            StdMetrics.ms_v_door_rr->AsBool() ||
-            StdMetrics.ms_v_door_trunk->AsBool() ||
-            StdMetrics.ms_v_door_hood->AsBool())) 
-      {
-      StdMetrics.ms_v_env_parktime->SetValue(0); // reset parking time
-      m_warning_unlocked = false;
-      }
+  }
 
-    if(m_enable_LED_state) 
-      OnlineState();
-    } // end every 10 seconds
+void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker) 
+  {
+  // reactivate door lock warning if the car is parked and unlocked
+  if( m_enable_lock_state && 
+        m_warning_unlocked &&
+        (StdMetrics.ms_v_door_fl->AsBool()  || 
+          StdMetrics.ms_v_door_fr->AsBool() ||
+          StdMetrics.ms_v_door_rl->AsBool() ||
+          StdMetrics.ms_v_door_rr->AsBool() ||
+          StdMetrics.ms_v_door_trunk->AsBool() ||
+          StdMetrics.ms_v_door_hood->AsBool())) 
+    {
+    StdMetrics.ms_v_env_parktime->SetValue(0); // reset parking time
+    m_warning_unlocked = false;
+    }
+
+  if(m_enable_LED_state) 
+    OnlineState();
   }
 
 void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {  
@@ -108,8 +108,8 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
       m_ADCfactor_recalc = false;
       m_ADCfactor_recalc_timer = 4;
       // calculate new ADC factor      
-      float can12V = mt_evc_LV_DCDC_volt->AsFloat(0.0f);
-      if (mt_evc_LV_DCDC_act_req->AsBool(false))
+      float can12V = mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
+      if (StdMetrics.ms_v_env_charging12v->AsBool(false))
         {
         ReCalcADCfactor(can12V, nullptr);  // nullptr = no Log-Output
         ESP_LOGI(TAG, "Auto ADC recalibration started (%.2fV)", can12V);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -491,13 +491,11 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
       // Refresh values from config/metrics to show latest state after command execution
       calcADCfactor = MyConfig.GetParamValueBool("xsq", "calc.adcfactor", calcADCfactor);
       adc_factor  = MyConfig.GetParamValue("system.adc", "factor12v", adc_factor.empty() ? "195.7" : adc_factor);
-      if (sq->mt_evc_LV_USM_volt) {
-        std::string latest = sq->mt_evc_LV_USM_volt->AsString("0.000");
-        if (!latest.empty())
-          onboard_12v = latest;
+      if (sq->mt_evc_dcdc && sq->mt_evc_dcdc->GetElemValue(1) > 10.0f) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%.3f", sq->mt_evc_dcdc->GetElemValue(1));  // DCDC voltage
+        onboard_12v = buf;
       }
-      if (onboard_12v.empty())
-        onboard_12v  = sq->mt_evc_LV_USM_volt->AsString("0.000");
       if (onboard_12v.empty())
         onboard_12v = "12.600";
       if (sq->mt_adc_factor_history)
@@ -527,8 +525,11 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
     // read configuration:
     calcADCfactor = MyConfig.GetParamValueBool("xsq", "calc.adcfactor", false);
     adc_factor  = MyConfig.GetParamValue("system.adc", "factor12v", "195.7");
-    if (sq->mt_evc_LV_USM_volt)
-      onboard_12v  = sq->mt_evc_LV_USM_volt->AsString("0.000");
+    if (sq->mt_evc_dcdc && sq->mt_evc_dcdc->GetElemValue(1) > 10.0f) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%.3f", sq->mt_evc_dcdc->GetElemValue(1));  // DCDC voltage
+        onboard_12v = buf;
+      }
     if (onboard_12v.empty())
       onboard_12v = "12.600";
     if (sq->mt_adc_factor_history)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -114,12 +114,6 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_worst_consumption          = MyMetrics.InitFloat("xsq.v.bat.consumption.worst", SM_STALE_MID, 0, kWhP100K);
   mt_best_consumption           = MyMetrics.InitFloat("xsq.v.bat.consumption.best", SM_STALE_MID, 0, kWhP100K);
   mt_bcb_power_mains            = MyMetrics.InitFloat("xsq.v.charge.bcb.power", SM_STALE_MID, 0, Watts);
-  // 0x634
-  mt_charging_timer_value       = MyMetrics.InitInt("xsq.v.charge.timer.value", SM_STALE_MID, 0, Minutes);
-  mt_charging_timer_status      = MyMetrics.InitInt("xsq.v.charge.timer.status", SM_STALE_MID, 0);
-  mt_charge_prohibited          = MyMetrics.InitInt("xsq.v.charge.prohibited", SM_STALE_MID, 0);
-  mt_charge_authorization       = MyMetrics.InitInt("xsq.v.charge.authorization", SM_STALE_MID, 0);
-  mt_ext_charge_manager         = MyMetrics.InitInt("xsq.v.charge.ext.manager", SM_STALE_MID, 0);
   // 0x763 OBD metrics
   mt_obd_duration               = MyMetrics.InitInt("xsq.obd.charge.duration", SM_STALE_MID, 0, Minutes);
   mt_obd_mt_day_prewarn         = MyMetrics.InitInt("xsq.obd.mt.day.prewarn", SM_STALE_MID, 45, Other);
@@ -132,17 +126,11 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_pos_odometer_trip_total    = MyMetrics.InitFloat("xsq.odometer.trip.total", SM_STALE_MID, 0, Kilometers);
   mt_pos_odometer_trip          = MyMetrics.InitFloat("xsq.odometer.trip", SM_STALE_MID, 0, Kilometers);
 
-  mt_tpms_temp                   = MyMetrics.InitVector<float>("xsq.tpms.temp", SM_STALE_MID, nullptr, Celcius);
-  mt_tpms_pressure               = MyMetrics.InitVector<float>("xsq.tpms.pressure", SM_STALE_MID, nullptr, kPa);
-  mt_tpms_alert                  = MyMetrics.InitVector<short> ("xsq.tpms.alert", SM_STALE_MID, nullptr, Other);
   mt_tpms_low_batt               = MyMetrics.InitVector<short> ("xsq.tpms.lowbatt", SM_STALE_MID, nullptr, Other);
   mt_tpms_missing_tx             = MyMetrics.InitVector<short> ("xsq.tpms.missing", SM_STALE_MID, nullptr, Other);
     // Pre-allocate TPMS vectors for 4 wheels to avoid heap fragmentation
-  mt_tpms_temp->SetElemValue(3, 0.0f);
   StdMetrics.ms_v_tpms_temp->SetElemValue(3, 0.0f);
-  mt_tpms_pressure->SetElemValue(3, 0.0f);
   StdMetrics.ms_v_tpms_pressure->SetElemValue(3, 0.0f);
-  mt_tpms_alert->SetElemValue(3, 0);
   StdMetrics.ms_v_tpms_alert->SetElemValue(3, 0);
   mt_tpms_low_batt->SetElemValue(3, 0);
   mt_tpms_missing_tx->SetElemValue(3, 0);
@@ -152,16 +140,9 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bcm_vehicle_state           = MyMetrics.InitString("xsq.bcm.state", SM_STALE_MIN, "UNKNOWN", Other);
   mt_bcm_gen_mode                = MyMetrics.InitString("xsq.bcm.gen.mode", SM_STALE_MID, "UNKNOWN", Other);
   // 0x7EC EVC metrics
-  mt_evc_hv_energy              = MyMetrics.InitFloat("xsq.evc.hv.energy", SM_STALE_MID, 0, kWh);
-  mt_evc_LV_DCDC_act_req        = MyMetrics.InitBool("xsq.evc.12V.dcdc.act.req", SM_STALE_MID, false);
-  mt_evc_LV_DCDC_amps           = MyMetrics.InitFloat("xsq.evc.12V.dcdc.amps", SM_STALE_MID, 0, Amps);
-  mt_evc_LV_DCDC_load           = MyMetrics.InitFloat("xsq.evc.12V.dcdc.load", SM_STALE_MID, 0, Percentage);
-  mt_evc_LV_DCDC_volt_req       = MyMetrics.InitFloat("xsq.evc.12V.dcdc.volt.req", SM_STALE_MID, 0, Volts);
-  mt_evc_LV_DCDC_volt           = MyMetrics.InitFloat("xsq.evc.12V.dcdc.volt", SM_STALE_MID, 0, Volts);
-  mt_evc_LV_DCDC_power          = MyMetrics.InitFloat("xsq.evc.12V.dcdc.power", SM_STALE_MID, 0, Watts);
-  mt_evc_LV_USM_volt            = MyMetrics.InitFloat("xsq.evc.12V.volt.usm", SM_STALE_MIN, 0, Volts);
-  mt_evc_LV_batt_voltage_can    = MyMetrics.InitFloat("xsq.evc.12V.volt.can", SM_STALE_MIN, 0, Volts);
-  mt_evc_LV_batt_voltage_req    = MyMetrics.InitFloat("xsq.evc.12V.batt.volt.req.int", SM_STALE_MIN, 0, Volts);
+  // EVC 12V values: Index 0=dcdc_volt_req, 1=dcdc_volt, 2=dcdc_power, 3=usm_volt, 4=batt_volt_can, 5=batt_volt_req, 6=dcdc_amps, 7=dcdc_load
+  mt_evc_dcdc                    = MyMetrics.InitVector<float>("xsq.evc.12v.dcdc", SM_STALE_MID, nullptr, Other);
+  mt_evc_dcdc->SetElemValue(7, 0.0f);  // Pre-allocate 8 entries
   mt_evc_traceability           = MyMetrics.InitString("xsq.evc.traceability", SM_STALE_MAX, "");
   // 0x793 OBL charger metrics
   mt_obl_fastchg                = MyMetrics.InitBool("xsq.obl.fastchg", SM_STALE_MIN, false);
@@ -172,13 +153,10 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_obl_main_volts->SetElemValue(2, 0.0f);
   mt_obl_main_amps->SetElemValue(2, 0.0f);
   mt_obl_main_CHGpower->SetElemValue(1, 0.0f);
-    // OBL misc values: Index 0=freq, 1=ground_resistance, 2=max_current
+    // OBL misc values: Index 0=freq, 1=ground_resistance, 2=max_current, 3=dc_current, 4=hf10kHz_current, 5=hf_current, 6=lf_current
   mt_obl_misc                   = MyMetrics.InitVector<float>("xsq.obl.misc", SM_STALE_MID, nullptr, Other);
-  mt_obl_misc->SetElemValue(2, 0.0f);  // Pre-allocate 3 entries
+  mt_obl_misc->SetElemValue(6, 0.0f);  // Pre-allocate 7 entries
   mt_obl_main_leakage_diag      = MyMetrics.InitString("xsq.obl.leakdiag", SM_STALE_MID, "", Other);
-    // Leakage currents as vector: Index 0=dc, 1=hf10kHz, 2=hf, 3=lf
-  mt_obl_leakage_currents       = MyMetrics.InitVector<float>("xsq.obl.current", SM_STALE_MID, nullptr, Amps);
-  mt_obl_leakage_currents->SetElemValue(3, 0.0f);  // Pre-allocate 4 entries
   // 0x7BB BMS metrics
   mt_bms_temps                  = MyMetrics.InitVector<float>("xsq.bms.temps", SM_STALE_HIGH, nullptr, Celcius);
   mt_bms_temps->SetElemValue(30, 0.0f);  // Pre-allocate 31 temp sensors to avoid reallocs
@@ -190,12 +168,10 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_soc_values->SetElemValue(4, 0.0f);  // Pre-allocate: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
   mt_bms_soc_recal_state        = MyMetrics.InitString("xsq.bms.soc.recal.state", SM_STALE_MID, "");
   mt_bms_soh                    = MyMetrics.InitFloat("xsq.bms.soh", SM_STALE_MID, 0, Percentage);
-  mt_bms_cap_usable_max         = MyMetrics.InitFloat("xsq.bms.cap.usable.max", SM_STALE_MID, 0, AmpHours);
-  mt_bms_cap_init               = MyMetrics.InitFloat("xsq.bms.cap.init", SM_STALE_MID, 0, AmpHours);
-  mt_bms_cap_estimate           = MyMetrics.InitFloat("xsq.bms.cap.estimate", SM_STALE_MID, 0, AmpHours);
+  // BMS capacity values: Index 0=usable_max, 1=init, 2=estimate, 3=loss_pct
+  mt_bms_cap                    = MyMetrics.InitVector<float>("xsq.bms.cap", SM_STALE_MID, nullptr, Other);
+  mt_bms_cap->SetElemValue(3, 0.0f);  // Pre-allocate 4 entries
   mt_bms_mileage                = MyMetrics.InitInt("xsq.bms.mileage", SM_STALE_HIGH, 0, Kilometers);
-  mt_bms_ocv_voltage            = MyMetrics.InitFloat("xsq.bms.ocv.voltage", SM_STALE_MID, 0, Volts);
-  mt_bms_cap_loss_percent       = MyMetrics.InitFloat("xsq.bms.cap.loss.pct", SM_STALE_HIGH, 0, Percentage);
   mt_bms_voltage_state          = MyMetrics.InitString("xsq.bms.voltage.state", SM_STALE_MID, "");
   mt_bms_cell_resistance        = MyMetrics.InitVector<float>("xsq.bms.cell.resistance", SM_STALE_HIGH, nullptr, Other);
   mt_bms_cell_resistance->SetElemValue(CELLCOUNT - 1, 0.0f);  // Pre-allocate for all 96 cells
@@ -203,30 +179,37 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_BattPower_power        = MyMetrics.InitFloat("xsq.bms.batt.power", SM_STALE_MID, 0, kW);
   mt_bms_HVcontactStateTXT      = MyMetrics.InitString("xsq.bms.contact", SM_STALE_MID, "", Other);
   mt_bms_EVmode_txt             = MyMetrics.InitString("xsq.bms.ev.mode", SM_STALE_MID, "", Other);
-  mt_bms_12v                    = MyMetrics.InitFloat("xsq.bms.12v", SM_STALE_MID, 0, Volts);
   mt_bms_interlock_hvplug       = MyMetrics.InitBool("xsq.bms.interlock.hvplug",SM_STALE_MID, false);
   mt_bms_interlock_service      = MyMetrics.InitBool("xsq.bms.interlock.service", SM_STALE_MID, false);
   mt_bms_fusi_mode_txt          = MyMetrics.InitString("xsq.bms.fusi",SM_STALE_MID, "", Other);
   mt_bms_mg_rpm                 = MyMetrics.InitFloat("xsq.bms.mg.rpm",SM_STALE_MID, 0, Other);
   mt_bms_safety_mode_txt        = MyMetrics.InitString("xsq.bms.safety",SM_STALE_MID, "", Other);
+  // BMS voltages: Index 0=cell_min, 1=cell_max, 2=cell_mean, 3=link_volt, 4=pack_volt, 5=ocv_volt, 6=12v_system
+  mt_bms_voltages               = MyMetrics.InitVector<float>("xsq.bms.voltages", SM_STALE_MID, nullptr, Volts);
+  mt_bms_voltages->SetElemValue(6, 0.0f);  // Pre-allocate 7 entries
 
   // Start CAN bus in Listen-only mode - will be set according to m_enable_write in ConfigChanged()
   RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
 
   // init commands:
   cmd_xsq = MyCommandApp.RegisterCommand("xsq","smartEQ 453 Gen.4");
-  cmd_xsq->RegisterCommand("start", "Show OBD trip start", xsq_trip_start);
-  cmd_xsq->RegisterCommand("reset", "Show OBD trip total", xsq_trip_reset);
-  cmd_xsq->RegisterCommand("counter", "Show vehicle trip counter", xsq_trip_counters);
-  cmd_xsq->RegisterCommand("total", "Show vehicle trip total", xsq_trip_total);
-  cmd_xsq->RegisterCommand("mtdata", "Show Maintenance data", xsq_maintenance);
-  cmd_xsq->RegisterCommand("tpmsset", "set TPMS dummy value", xsq_tpms_set);
+  cmd_xsq->RegisterCommand("mtdata", "Maintenance data", xsq_maintenance);
   cmd_xsq->RegisterCommand("ddt4all", "DDT4all Command", xsq_ddt4all,"<number>",1,1);
   cmd_xsq->RegisterCommand("ddt4list", "DDT4all Command List", xsq_ddt4list);
   cmd_xsq->RegisterCommand("calcadc", "Recalculate ADC factor (optional: 12V voltage override)", xsq_calc_adc, "[voltage]", 0, 1);
   cmd_xsq->RegisterCommand("wakeup", "Wake up the car", xsq_wakeup);
   cmd_xsq->RegisterCommand("ed4scan", "ED4scan-like BMS Data", xsq_ed4scan);
   cmd_xsq->RegisterCommand("preset", "smart EQ config preset", xsq_preset);
+
+  cmd_tpms = cmd_xsq->RegisterCommand("tpms", "TPMS status");
+  cmd_tpms->RegisterCommand("setdummy", "set TPMS dummy value", xsq_tpms_set);
+  cmd_tpms->RegisterCommand("status", "Show extended TPMS data", xsq_tpms_status);
+
+  cmd_show = cmd_xsq->RegisterCommand("show", "Show smartEQ data");
+  cmd_show->RegisterCommand("start", "Show OBD trip start", xsq_trip_start);
+  cmd_show->RegisterCommand("reset", "Show OBD trip total", xsq_trip_reset);
+  cmd_show->RegisterCommand("counter", "Show vehicle trip counter", xsq_trip_counters);
+  cmd_show->RegisterCommand("total", "Show vehicle trip total", xsq_trip_total);
 
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -428,7 +411,10 @@ void OvmsVehicleSmartEQ::ObdModifyPoll() {
 }
 
 void OvmsVehicleSmartEQ::EventListener(std::string event, void* data) {
-
+  if (!this) {
+    ESP_LOGE(TAG, "EventListener: NULL this pointer!");
+    return;
+  }
   if (event == "vehicle.charge.start") 
     {
     if(m_enable_calcADCfactor && !m_ADCfactor_recalc) 
@@ -437,7 +423,7 @@ void OvmsVehicleSmartEQ::EventListener(std::string event, void* data) {
       m_ADCfactor_recalc = true;      // recalculate ADC factor when HV charging
       }
     }
-  if (event == "vehicle.charge.stop") 
+  else if (event == "vehicle.charge.stop") 
     {
     m_ADCfactor_recalc_timer = 0;
     m_ADCfactor_recalc = false;     // stop recalculation when HV charging stopped
@@ -455,24 +441,31 @@ uint64_t OvmsVehicleSmartEQ::swap_uint64(uint64_t val) {
  * Called once per second from Ticker1
  */
 void OvmsVehicleSmartEQ::HandleEnergy() {
-  float voltage  = StdMetrics.ms_v_bat_voltage->AsFloat(0, Volts);
-  float current  = -StdMetrics.ms_v_bat_current->AsFloat(0, Amps);
+  float voltage  = StdMetrics.ms_v_bat_voltage->AsFloat(0.0f);
+  float current  = -StdMetrics.ms_v_bat_current->AsFloat(0.0f);
 
   // Power (in kw) resulting from voltage and current
-  float power = voltage * current / 1000.0;
-
+  float power = voltage * current / 1000.0f;
   // Are we driving?
-  if (power != 0.0 && StdMetrics.ms_v_env_on->AsBool()) {
+  if (power != 0.0f && StdMetrics.ms_v_env_on->AsBool(false))
+    {
     // Update energy used and recovered   
-    float energy = power / 3600.0;       // 1 second worth of energy in kwh's
-    if (energy < 0.0f){
-      StdMetrics.ms_v_bat_energy_used->SetValue( StdMetrics.ms_v_bat_energy_used->AsFloat() - energy);
-      StdMetrics.ms_v_bat_energy_used_total->SetValue( StdMetrics.ms_v_bat_energy_used_total->AsFloat() - energy);
-    }else{ // (energy > 0.0f)
-      StdMetrics.ms_v_bat_energy_recd->SetValue( StdMetrics.ms_v_bat_energy_recd->AsFloat() + energy);
-      StdMetrics.ms_v_bat_energy_recd_total->SetValue( StdMetrics.ms_v_bat_energy_recd_total->AsFloat() + energy);
+    float energy = power / 3600.0f;       // 1 second worth of energy in kwh's
+    if (energy < 0.0f)
+      {
+      float energy_used = StdMetrics.ms_v_bat_energy_used->AsFloat(0.0f) - energy;
+      float energy_used_total = StdMetrics.ms_v_bat_energy_used_total->AsFloat(0.0f) - energy;
+      StdMetrics.ms_v_bat_energy_used->SetValue(energy_used);
+      StdMetrics.ms_v_bat_energy_used_total->SetValue(energy_used_total);
+      }
+    else if (energy > 0.0f)
+      {
+      float energy_recd = StdMetrics.ms_v_bat_energy_recd->AsFloat(0.0f) + energy;
+      float energy_recd_total = StdMetrics.ms_v_bat_energy_recd_total->AsFloat(0.0f) + energy;
+      StdMetrics.ms_v_bat_energy_recd->SetValue(energy_recd);
+      StdMetrics.ms_v_bat_energy_recd_total->SetValue(energy_recd_total);
+      }
     }
-  }
 }
 
 void OvmsVehicleSmartEQ::HandleTripcounter(){
@@ -624,13 +617,15 @@ void OvmsVehicleSmartEQ::UpdateChargeMetrics() {
   
   StdMetrics.ms_v_charge_current->SetValue(total_current);
   
-  float power_grid = mt_obl_main_CHGpower->GetElemValue(0) + mt_obl_main_CHGpower->GetElemValue(1);
+  // Safe power calculation with default values
+  float power_grid = mt_obl_main_CHGpower->GetElemValue(0) + 
+                     mt_obl_main_CHGpower->GetElemValue(1);
   StdMetrics.ms_v_charge_power->SetValue(power_grid);
   
   // Use absolute value of battery power for efficiency calculation
-  float power_battery = fabs(StdMetrics.ms_v_bat_power->AsFloat());
-  
+  float power_battery = fabs(StdMetrics.ms_v_bat_power->AsFloat(0.0f));  
   float efficiency = 0.0f;
+
   if (power_grid > 0.01f) {  // Avoid division by zero, require at least 10W
     efficiency = (power_battery / power_grid) * 100.0f;
     
@@ -650,13 +645,13 @@ void OvmsVehicleSmartEQ::UpdateChargeMetrics() {
  * TODO: Should be calculated based on actual charge curve. Maybe in a later version?
  */
 int OvmsVehicleSmartEQ::calcMinutesRemaining(float target_soc, float charge_voltage, float charge_current) {
-  float bat_soc = StdMetrics.ms_v_bat_soc->AsFloat(0, Percentage);
+  float bat_soc = StdMetrics.ms_v_bat_soc->AsFloat(0.0f);
   if (bat_soc > target_soc) {
     return 0;   // Done!
   }
-  float remaining_wh    = DEFAULT_BATTERY_CAPACITY * (target_soc - bat_soc) / 100.0;
+  float remaining_wh    = DEFAULT_BATTERY_CAPACITY * (target_soc - bat_soc) / 100.0f;
   float remaining_hours = remaining_wh / (charge_current * charge_voltage);
-  float remaining_mins  = remaining_hours * 60.0;
+  float remaining_mins  = remaining_hours * 60.0f;
 
   return MIN( 1440, (int)remaining_mins );
 }
@@ -694,20 +689,16 @@ void OvmsVehicleSmartEQ::HandlePollState() {
 }
 
 void OvmsVehicleSmartEQ::CalculateEfficiency() {
-  // float consumption = 0;
-  if (StdMetrics.ms_v_pos_speed->AsFloat() >= 5) {
-    float _use_grid = StdMetrics.ms_v_bat_energy_used->AsFloat() - StdMetrics.ms_v_bat_energy_recd->AsFloat();
-    float _use_grid_total = StdMetrics.ms_v_bat_energy_used_total->AsFloat() - StdMetrics.ms_v_bat_energy_recd_total->AsFloat();
-    float _trip_km = StdMetrics.ms_v_pos_trip->AsFloat();
-    float _trip_total_km = mt_pos_odometer_trip_total->AsFloat();
-    if (_use_grid > 0.1f) 
-      {
-      if (_trip_km > 0.1f) StdMetrics.ms_v_charge_kwh_grid->SetValue((_use_grid / _trip_km) * 100.0f);
-      }
-    if (_use_grid_total > 0.1f) 
-      {
-      if (_trip_total_km > 0.1f) StdMetrics.ms_v_charge_kwh_grid_total->SetValue((_use_grid_total / _trip_total_km) * 100.0f);
-      }
+  if (StdMetrics.ms_v_pos_speed->AsFloat(0.0f) >= 5) {
+    float _use_grid = StdMetrics.ms_v_bat_energy_used->AsFloat(0.0f) - StdMetrics.ms_v_bat_energy_recd->AsFloat(0.0f);
+    float _use_grid_total = StdMetrics.ms_v_bat_energy_used_total->AsFloat(0.0f) - StdMetrics.ms_v_bat_energy_recd_total->AsFloat(0.0f);
+    float _trip_km = (_use_grid / StdMetrics.ms_v_pos_trip->AsFloat(0.0f)) * 100.0f;
+    float _trip_total_km = (_use_grid_total / mt_pos_odometer_trip_total->AsFloat(0.0f)) * 100.0f;
+
+    if (_trip_km > 0.1f) 
+      StdMetrics.ms_v_charge_kwh_grid->SetValue(_trip_km);
+    if (_trip_total_km > 0.1f) 
+      StdMetrics.ms_v_charge_kwh_grid_total->SetValue(_trip_total_km);
   }
 }
 


### PR DESCRIPTION
Replaces several individual BMS, EVC, and OBL metrics with vector-based metrics for capacitance, voltage and DC-DC values. Updates all relevant code to use the new vector metrics and removes deprecated metrics. Adds a new EQ TPMS status command, include state of battery and missing sensor, and reorganizes the command registry for better structure. Cleans up legacy code and improves metric premapping. Creates Ticker 10 and moves routines running every 10 seconds from Ticker 1.