### PR TITLE
smartEQ: Refine BMS SOC parsing

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -336,14 +336,14 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
 
 void OvmsVehicleSmartEQ::PollReply_BMS_SOC(const char* data, uint16_t reply_len) {
   REQUIRE_LEN(15);
-  float ocv = (int16_t)CAN_UINT(0) / 100.0f;
-  float real_soc_min = (int16_t)CAN_UINT(2) / 16.0f;
-  float real_soc_max = (int16_t)CAN_UINT(4) / 16.0f;
-  float soc = (int16_t)CAN_UINT(6) / 16.0f;
-  float cap_loss = ((int16_t)CAN_UINT(8)) / 16.0f;
-  float cap_init = ((int16_t)CAN_UINT(10) * 10.0f) / 3600.0f;
-  float cap_estimate = ((int16_t)CAN_UINT(12) * 10.0f) / 3600.0f;
-  int8_t voltage_state = (int8_t)CAN_BYTE(14);
+  float ocv = CAN_UINT(0) / 100.0f;
+  float real_soc_min = CAN_UINT(2) / 16.0f;
+  float real_soc_max = CAN_UINT(4) / 16.0f;
+  float soc = CAN_UINT(6) / 16.0f;
+  float cap_loss = CAN_UINT(8) / 16.0f;
+  float cap_init = (CAN_UINT(10) * 10.0f) / 3600.0f;
+  float cap_estimate = (CAN_UINT(12) * 10.0f) / 3600.0f;
+  int voltage_state = CAN_BYTE(14);
   
   const char* voltage_state_txt;
   switch (voltage_state) {
@@ -354,6 +354,10 @@ void OvmsVehicleSmartEQ::PollReply_BMS_SOC(const char* data, uint16_t reply_len)
     case 4: voltage_state_txt = "value not defined"; break;
     default: voltage_state_txt = "Unknown"; break;
   }
+  if(ocv < 0.0f || ocv > 500.0f)
+    ocv = 0.0f;
+  if(cap_loss < 0.0f || cap_loss > 100.0f)
+    cap_loss = 0.0f;
   mt_bms_voltages->SetElemValue(5, ocv);  // ocv_voltage
   mt_bms_soc_values->SetElemValue(0, soc);                              // kernel SOC
   mt_bms_soc_values->SetElemValue(1, (real_soc_min + real_soc_max) / 2.0f);  // real SOC
@@ -367,7 +371,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_SOC(const char* data, uint16_t reply_len)
 
 void OvmsVehicleSmartEQ::PollReply_BMS_SOCRecal(const char* data, uint16_t reply_len) {
   REQUIRE_LEN(3);
-  int8_t recal_state = (int8_t)CAN_BYTE(0);
+  int recal_state = CAN_BYTE(0);
   const char* recal_state_txt;
   switch (recal_state) {
     case 0: recal_state_txt = "Not Running"; break;
@@ -376,7 +380,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_SOCRecal(const char* data, uint16_t reply
     case 3: recal_state_txt = "Failed"; break;
     default: recal_state_txt = "Unknown"; break;
   }
-  float display_soc = (int16_t)CAN_UINT(1) / 16.0f;
+  float display_soc = CAN_UINT(1) / 16.0f;
   mt_bms_soc_recal_state->SetValue(recal_state_txt);
   
   if (display_soc >= 0 && display_soc <= 100.0f) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -1103,9 +1103,9 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->puts("\n--- EVC Data (0x7EC) ---");
   writer->printf("  HV Energy:               %.3f kWh\n", StdMetrics.ms_v_bat_capacity->AsFloat());
   writer->printf("  DCDC Active Request:     %s\n", StdMetrics.ms_v_env_charging12v->AsBool() ? "Yes" : "No");
-  writer->printf("  DCDC Current:            %.1f A\n", mt_evc_dcdc->GetElemValue(6));
+  writer->printf("  DCDC Current:            %.2f A\n", mt_evc_dcdc->GetElemValue(6));
   writer->printf("  DCDC Power:              %.0f W\n", mt_evc_dcdc->GetElemValue(2));
-  writer->printf("  DCDC Load:               %.1f%%\n", mt_evc_dcdc->GetElemValue(7));
+  writer->printf("  DCDC Load:               %.2f%%\n", mt_evc_dcdc->GetElemValue(7));
   writer->printf("  Req (int) 12V Voltage:   %.2f V\n", mt_evc_dcdc->GetElemValue(5));
   writer->printf("  DCDC Voltage Request:    %.2f V\n", mt_evc_dcdc->GetElemValue(0));
   writer->printf("  DCDC 12V Voltage:        %.2f V\n", mt_evc_dcdc->GetElemValue(1));
@@ -1113,14 +1113,14 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  Batt 12V Voltage:        %.2f V\n", mt_evc_dcdc->GetElemValue(4));
 
   writer->puts("\n--- OBL Charger Data (0x793) ---");
-  writer->printf("  Fast Charge Active:      %s\n", mt_obl_fastchg->AsBool() ? "Yes" : "No");
+  writer->printf("  Fast Charge Active:      %s\n", mt_obl_fastchg->AsBool() ? "Yes" : "No");  
+  writer->printf("  Max AC Current:          %.0f A\n", mt_obl_misc->GetElemValue(2));
   writer->printf("  Mains Frequency:         %.2f Hz\n", mt_obl_misc->GetElemValue(0));
-  writer->printf("  Ground Resistance:       %.1f Ohm\n", mt_obl_misc->GetElemValue(1));
-  writer->printf("  Max AC Current:          %.1f A\n", mt_obl_misc->GetElemValue(2));
-  writer->printf("  Leakage DC Current:      %.3f mA\n", mt_obl_misc->GetElemValue(3));
-  writer->printf("  Leakage HF10kHz:         %.3f mA\n", mt_obl_misc->GetElemValue(4));
-  writer->printf("  Leakage HF Current:      %.3f mA\n", mt_obl_misc->GetElemValue(5));
-  writer->printf("  Leakage LF Current:      %.3f mA\n", mt_obl_misc->GetElemValue(6));
+  writer->printf("  Ground Resistance:       %.4f Ohm\n", mt_obl_misc->GetElemValue(1));
+  writer->printf("  Leakage DC Current:      %.4f mA\n", mt_obl_misc->GetElemValue(3));
+  writer->printf("  Leakage HF10kHz:         %.4f mA\n", mt_obl_misc->GetElemValue(4));
+  writer->printf("  Leakage HF Current:      %.4f mA\n", mt_obl_misc->GetElemValue(5));
+  writer->printf("  Leakage LF Current:      %.4f mA\n", mt_obl_misc->GetElemValue(6));
   writer->printf("  Leakage Diagnostic:      %s\n", mt_obl_main_leakage_diag->AsString().c_str());
 
   int show = mt_ed4_values->AsInt(10); // number of cells to show

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -565,7 +565,7 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
       "<p>This ensures that the 12V battery voltage is always measured correctly.</p>");
   if (!adc_history.empty()) {
     c.input_text("History of calculated ADC factors", "adc_history", adc_history.c_str(), "no historical ADC values",
-      "<p>History of calculated ADC factors.</p><p>Most recent last, max 20 values.</p>");
+      "<p>History of calculated ADC factors.</p><p>Most recent last, max 5 values.</p>");
   }
   c.input_slider("ADC factor", "adc_factor", 5, "", -1, atof(adc_factor.c_str()), 195.7, 160, 230, 0.01,
     "<p>Factor for the 12V battery voltage measurement by ADC.</p>"
@@ -573,7 +573,7 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
     "<p>Default 195.7</p>");
   c.input_slider("12V measured", "onboard_12v", 3, "V",-1, atof(onboard_12v.c_str()), 12.60, 11.00, 15.00, 0.01,
     "<p>Set 12V battery voltage measured for ADC calibration.</p>"
-    "<p>On page load = CAN voltage measured value. (xsq.evc.12V.usm.volt)</p>");
+    "<p>On page load = EVC CAN voltage measured value.</p>");
   c.printf("<input type=\"hidden\" name=\"onboard_12v_submit\" id=\"onboard_12v_submit\" value=\"%s\">\n",
            _attr(onboard_12v.c_str()));
   c.input_button("default", "ADC calculation", "action", "calc");


### PR DESCRIPTION
Removed unnecessary int casts in BMS SOC parsing, added value range checks for OCV and cap_loss, and improved formatting precision for DCDC and charger data in command output. Updated web interface text to clarify ADC history and voltage measurement descriptions.