### PR TITLE
VWEUP: T26: fix/improve handling of faulty profile0

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
@@ -1186,7 +1186,7 @@ void OvmsVehicleVWeUp::ReadProfile0(uint8_t *data)
     {
       if (profile0_cntr[0] >= profile0_retries) {
         ESP_LOGE(TAG, "T26: maximum retries for reading profile0 exceeded! Stopping request.");
-        MyNotify.NotifyString("alert", "Profile0", "Failed to read pfrofile0!");
+        MyNotify.NotifyString("alert", "Profile0", "Failed to read profile0!");
         ESP_LOGD(TAG, "T26: Stopping profile0 timer...");
         int timer_stopped = xTimerStop(profile0_timer, 0);
         ESP_LOGD(TAG, "T26: Timer %s", timer_stopped? "stopped" : "failed to stop!");


### PR DESCRIPTION
OK, hier ein neuer Versuch fehlerhaft gelesene Profile zu behandeln. Diesmal ist es auch getestet, dass es nicht abstürzt wenn das Profil fehlerhaft ist.

(sry für den neuen PR, hatte nicht bedacht dass der alte automatisch geschlossen wird wenn ich den branch lösche :-/)