### PR TITLE
smartEQ: Add usable capacity to BMS metrics and reporting

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -146,7 +146,7 @@ metrics
     xsq.bms.soc.values                    -- SOC values vector [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display [%]
     xsq.bms.soc.recal.state               -- SOC recalibration state
     xsq.bms.soh                           -- State of Health [%]
-    xsq.bms.cap                           -- BMS capacity values vector: [0]=usable_max(Ah), [1]=init(Ah), [2]=estimate(Ah), [3]=loss_pct(%)
+    xsq.bms.cap                           -- BMS capacity values vector: [0]=usable_max(Ah), [1]=init(Ah), [2]=estimate(Ah), [3]=loss_pct(%), [4]=usable_capacity(Ah)
     xsq.bms.mileage                       -- Battery mileage [km]
     xsq.bms.energy.nominal                -- Nominal battery energy [kWh]
     xsq.bms.voltage.state                 -- Voltage state description

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -458,8 +458,10 @@ void OvmsVehicleSmartEQ::PollReply_BMS_BattHealth(const char* data, uint16_t rep
   int32_t mileage_raw = (int32_t)CAN_UINT32(9);
   mt_bms_soh->SetValue(soh);
   //StdMetrics.ms_v_bat_soh->SetValue(soh);
-  mt_bms_cap->SetElemValue(0, cap_full);  // usable_max
-  StdMetrics.ms_v_bat_cac->SetValue(cap_full);
+  mt_bms_cap->SetElemValue(0, cap_full);      // usable_max_capacity
+  float cap_useable = (soh >= 0.0f && soh <= 100.0f && cap_full > 0.0f) ? (cap_full * soh / 100.0f) : 0.0f;
+  mt_bms_cap->SetElemValue(4, cap_useable);   // usable_capacity 
+  StdMetrics.ms_v_bat_cac->SetValue(cap_useable);
   mt_bms_mileage->SetValue(mileage_raw);
 }
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -1129,7 +1129,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
 
   writer->puts("--- Battery Health (PID 0x61) ---");
   writer->printf("  State of Health:         %.0f%%\n", mt_bms_soh->AsFloat());
-  writer->printf("  Usable Capacity:         %.2f Ah\n", mt_bms_cap->GetElemValue(0));
+  writer->printf("  Usable max Capacity:     %.2f Ah\n", mt_bms_cap->GetElemValue(0));
   
   writer->puts("\n--- HV Contactor Cycles (PID 0x02) ---");
   writer->printf("  Max Cycles:              %d\n", mt_bms_contactor_cycles->GetElemValue(0));
@@ -1148,6 +1148,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->puts("\n--- SOC Recalibration (PID 0x25) ---");
   writer->printf("  Recalibration State:     %s\n", mt_bms_soc_recal_state->AsString().c_str());
   writer->printf("  Display SOC:             %.2f%%\n", mt_bms_soc_values->GetElemValue(4));
+  writer->printf("  Usable Capacity:         %.2f Ah\n", mt_bms_cap->GetElemValue(4));
   
   writer->puts("\n--- Battery State (PID 0x07) ---");
   writer->printf("  Cell Voltage Min:        %.3f V\n", mt_bms_voltages->GetElemValue(0));

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -170,7 +170,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_soh                    = MyMetrics.InitFloat("xsq.bms.soh", SM_STALE_MID, 0, Percentage);
   // BMS capacity values: Index 0=usable_max, 1=init, 2=estimate, 3=loss_pct
   mt_bms_cap                    = MyMetrics.InitVector<float>("xsq.bms.cap", SM_STALE_MID, nullptr, Other);
-  mt_bms_cap->SetElemValue(3, 0.0f);  // Pre-allocate 4 entries
+  mt_bms_cap->SetElemValue(4, 0.0f);  // Pre-allocate 5 entries
   mt_bms_mileage                = MyMetrics.InitInt("xsq.bms.mileage", SM_STALE_HIGH, 0, Kilometers);
   mt_bms_voltage_state          = MyMetrics.InitString("xsq.bms.voltage.state", SM_STALE_MID, "");
   mt_bms_cell_resistance        = MyMetrics.InitVector<float>("xsq.bms.cell.resistance", SM_STALE_HIGH, nullptr, Other);


### PR DESCRIPTION
Introduces a fifth element to the BMS capacity vector for usable capacity (Ah), updates documentation, and enhances reporting in command output to display both usable max and current usable capacity. Adjusts metric initialization and calculation logic to support the new value.