### PR TITLE
Ioniq 5 - Fix xhiq range reset

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_hyundai_ioniq5/src/hif_commands.cpp
@@ -641,7 +641,7 @@ void OvmsHyundaiIoniqEv::RangeCalcReset()
 void xiq_range_reset(int verbosity, OvmsWriter *writer, OvmsCommand *cmd, int argc, const char *const *argv)
 {
   OvmsHyundaiIoniqEv *mycar = (OvmsHyundaiIoniqEv *)(MyVehicleFactory.ActiveVehicle());
-  if (mycar) {
+  if (mycar == nullptr) {
     writer->puts("Error: No vehicle module selected");
     return;
   }


### PR DESCRIPTION
Command 'xhiq range reset'  wasn't working due to bad check for vehicle