### PR TITLE
Add timeout PrioritiseAndIndicate

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,10 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Network manager: prevent Task Watchdog crash in PrioritiseAndIndicate()
+    The TCPIP callback semaphore (m_tcpip_callback_done) now uses a 10 second timeout
+    instead of waiting indefinitely. Prevents deadlock when the TCPIP task fails to
+    execute the callback, e.g. during WiFi state transitions.
 - Module: added heap integrity check + alert command for usage in e.g. custom event scripts,
     enables adding checks on specific system events and/or with higher frequency.
     Example: perform heap integrity check when the server V2 gets stopped:

--- a/vehicle/OVMS.V3/main/ovms_netmanager.cpp
+++ b/vehicle/OVMS.V3/main/ovms_netmanager.cpp
@@ -903,7 +903,10 @@ void SafePrioritiseAndIndicate(void* ctx)
 void OvmsNetManager::PrioritiseAndIndicate()
   {
   if (tcpip_callback_with_block(SafePrioritiseAndIndicate, NULL, 1) == ERR_OK)
-    m_tcpip_callback_done.Take();
+    {
+    if (!m_tcpip_callback_done.Take(pdMS_TO_TICKS(10000)))
+      ESP_LOGE(TAG, "PrioritiseAndIndicate: timeout waiting for TCPIP callback");
+    }
   }
 
 void OvmsNetManager::DoSafePrioritiseAndIndicate()


### PR DESCRIPTION
To prevent indefinite blocking if the callback is not executed, a 10-second timeout has been added to the TCP/IP callback semaphore in `PrioriseAndIndicate`. An error is logged upon timeout to facilitate troubleshooting. Previously, a missed callback signal could permanently block the calling task and ultimately trigger the task watchdog. This fix eliminated crashes during OTA updates via cellular data.