### PR TITLE
Fix filter log capture documentation and code comments

### DIFF
--- a/docs/source/crtd/can_logging.rst
+++ b/docs/source/crtd/can_logging.rst
@@ -115,10 +115,10 @@ Value           Example   Description
 <bus>           0         match any bus
 <bus>           2         match a specific bus (1-5)
 <id>            49b       match a specific PID
-<id>-           49b-      match a PID greater than
+<id>-           49b-      match a PID greater than or equal to on any bus
 <id>-<id>       2e2-382   match a range of PIDs
 <bus>:<id>      2:49b     match a specific PID on a specific bus
-<bus>:<id>-     2:49b-    match a PID greater than on a specific bus
+<bus>:<id>-     2:49b-    match a PID greater than or equal to on a specific bus
 <bus>:<id>-<id> 2:2e2-382 match a range of PIDs on a specific bus
 =============== ========= ================
 

--- a/vehicle/OVMS.V3/components/can/src/can.cpp
+++ b/vehicle/OVMS.V3/components/can/src/can.cpp
@@ -556,10 +556,10 @@ bool canfilter::AddFilter(uint8_t bus, uint32_t id_from, uint32_t id_to)
  * and 'from' and 'to' are in hex.
  * <bus>          Matches anything on that bus.
  * <bus>:<value>  Matches 1 address on the specified bus.
- * <bus>:<from>-  Matches adressses greater than the specified value on that bus
+ * <bus>:<from>-  Matches adressses >= the specified value on that bus
  * <bus>:<from>-<to>  Matches addresses  'from' <= adress <= 'to' on that bus
  * <value>        Matches 1 address on any bus.
- * <from>-        Matches adressses greater than the specified value on any bus
+ * <from>-        Matches adressses >= the specified value on any bus
  * <from>-<to>    Matches addresses  'from' <= adress <= 'to' on any bus
  */
 bool canfilter::AddFilter(const char* filterstring)


### PR DESCRIPTION
The code comments said <id>- matched "adressses greater than the specified value" (which seemed wrong). Examination of the code shows it's actually greater than or equal to the specified value.