### PR TITLE
Increase the maximum number of filter arguments for can log commands

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/canlog_monitor.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog_monitor.cpp
@@ -66,7 +66,7 @@ OvmsCanLogMonitorInit::OvmsCanLogMonitorInit()
           "[filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-[<id>]] | <bus>:<id>[-[<id>]]\n"
           "Example: 2:2a0-37f",
-          0, 9);
+          0, _COMMAND_TOKEN_NMB);
         }
       }
     }

--- a/vehicle/OVMS.V3/components/can/src/canlog_tcpclient.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog_tcpclient.cpp
@@ -90,19 +90,19 @@ OvmsCanLogTcpClientInit::OvmsCanLogTcpClientInit()
           "<host:port> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         MyCanFormatFactory.RegisterCommandSet(simulate, "Start CAN logging as TCP client (simulate mode)",
           can_log_tcpclient_start,
           "<host:port> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         MyCanFormatFactory.RegisterCommandSet(transmit, "Start CAN logging as TCP client (transmit mode)",
           can_log_tcpclient_start,
           "<host:port> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         }
       }
     }

--- a/vehicle/OVMS.V3/components/can/src/canlog_tcpserver.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog_tcpserver.cpp
@@ -90,19 +90,19 @@ OvmsCanLogTcpServerInit::OvmsCanLogTcpServerInit()
           "<host[:port]> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         MyCanFormatFactory.RegisterCommandSet(simulate, "Start CAN logging as TCP server (simulate mode)",
           can_log_tcpserver_start,
           "<host[:port]> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         MyCanFormatFactory.RegisterCommandSet(transmit, "Start CAN logging as TCP server (transmit mode)",
           can_log_tcpserver_start,
           "<host[:port]> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         }
       }
     }

--- a/vehicle/OVMS.V3/components/can/src/canlog_udpclient.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog_udpclient.cpp
@@ -88,7 +88,7 @@ OvmsCanLogUdpClientInit::OvmsCanLogUdpClientInit()
           "<host:port> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         }
       }
     }

--- a/vehicle/OVMS.V3/components/can/src/canlog_udpserver.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog_udpserver.cpp
@@ -124,19 +124,19 @@ OvmsCanLogUdpServerInit::OvmsCanLogUdpServerInit()
           "<port> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         MyCanFormatFactory.RegisterCommandSet(simulate, "Start CAN logging as UDP server (simulate mode)",
           can_log_udpserver_start,
           "<port> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         MyCanFormatFactory.RegisterCommandSet(transmit, "Start CAN logging as UDP server (transmit mode)",
           can_log_udpserver_start,
           "<port> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         }
       }
     }

--- a/vehicle/OVMS.V3/components/can/src/canlog_vfs.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canlog_vfs.cpp
@@ -82,7 +82,7 @@ OvmsCanLogVFSInit::OvmsCanLogVFSInit()
           "<path> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9, true, vfs_file_validate);
+          1, _COMMAND_TOKEN_NMB, true, vfs_file_validate);
         }
       }
     }

--- a/vehicle/OVMS.V3/components/can/src/canplay_vfs.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canplay_vfs.cpp
@@ -80,7 +80,7 @@ OvmsCanPlayVFSInit::OvmsCanPlayVFSInit()
           "<path> [filter1] ... [filterN]\n"
           "Filter: <bus> | <id>[-<id>] | <bus>:<id>[-<id>]\n"
           "Example: 2:2a0-37f",
-          1, 9);
+          1, _COMMAND_TOKEN_NMB);
         }
       }
     }


### PR DESCRIPTION
Take advantage of #1373.

(I do not understand why "min" is 0 for can log monitor and 1 for all the others. I guess I would expect them all to use min=0.)