### PR TITLE
 Chademo detectionNissan Leaf ZE1: detect CHAdeMO fast charging from battery voltage/current on 0x1db support

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1065,6 +1065,42 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           }
         }
 
+      // --------- Patch ZE1 : detect CHAdeMO charging via battery voltage/current ---------
+      if (cfg_ze1)
+        {
+        bool car_on = StandardMetrics.ms_v_env_on->AsBool();
+
+        // DC fast charge active if: car off + battery voltage plausible + strong inbound current
+        if (!car_on && battery_voltage > 200.0f && battery_current < -25.0f)
+          {
+          // CHAdeMO detected
+          if (StandardMetrics.ms_v_charge_state->AsString() != "charging"
+              || StandardMetrics.ms_v_charge_type->AsString() != "chademo")
+            {
+            vehicle_nissanleaf_charger_status(CHARGER_STATUS_QUICK_CHARGING);
+            }
+          // Pilot ON (cable connected, station OK)
+          StandardMetrics.ms_v_charge_pilot->SetValue(true);
+          // Keep charge metrics up-to-date
+          StandardMetrics.ms_v_charge_voltage->SetValue(battery_voltage);
+          StandardMetrics.ms_v_charge_current->SetValue(-battery_current);
+          StandardMetrics.ms_v_charge_power  ->SetValue(-battery_power);
+          if (battery_voltage > 0)
+            StandardMetrics.ms_v_charge_climit->SetValue(
+              m_battery_chargerate_max->AsFloat() * 1000.0f / battery_voltage);
+          }
+        else if (!car_on
+                 && StandardMetrics.ms_v_charge_inprogress->AsBool()
+                 && StandardMetrics.ms_v_charge_type->AsString() == "chademo"
+                 && battery_current > -5.0f)
+          {
+          // End of CHAdeMO charging
+          StandardMetrics.ms_v_charge_pilot->SetValue(false);
+          vehicle_nissanleaf_charger_status(CHARGER_STATUS_FINISHED);
+          }
+        }
+      // --------- End patch ZE1 ---------
+
     }
       break;
     case 0x1dc:


### PR DESCRIPTION
## Summary

Adds CHAdeMO (DC fast charging) detection for the **Nissan Leaf ZE1 (2018+)**.

On ZE1 vehicles, the existing charger-status detection (built around `0x5bf` for ZE0 and `0x390` for AZE0) does not trigger, so during a CHAdeMO session the charge state stays idle in OVMS and no charge metrics are reported.

This PR infers the CHAdeMO state from the battery voltage and current already decoded in `case 0x1db`, gated by the existing `xnl.ze1` (`cfg_ze1`) config flag. Zero behavior change for ZE0/AZE0 users.

## Logic

- **Start of session** (ZE1 only): car off + `battery_voltage > 200V` + `battery_current < -25A`  
  → `CHARGER_STATUS_QUICK_CHARGING`, pilot ON, updates `v.c.voltage/current/power/climit`.

- **End of session** (ZE1 only): car off + `charge_inprogress` + `charge_type == "chademo"` + `battery_current > -5A`  
  → pilot OFF, `CHARGER_STATUS_FINISHED`.

Negative `battery_current` = charging (matches the existing sign convention in this file).
The `-25 A` start / `-5 A` stop thresholds prevent false positives from regen (which only occurs with `env.on == true`) and correctly detect end-of-session tapering.

## Scope

- Single file: `vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp`
- Inserted at the end of `case 0x1db:` in `IncomingFrameCan1()`, right after the existing `!cfg_ze1` instrument-SOC block.
- No header change. `cfg_ze1` and `m_battery_chargerate_max` already exist.

## Tested on

- Nissan Leaf **ZE1 (2021)**, with a swapped 62 kWh pack paired to a 40 kWh BMS (seen by OVMS as a 40 kWh battery).
- CHAdeMO session on an EVBox DC station.
- Verified start of session, tapering, and end of session are all correctly reflected on the OVMS app (`v.c.state`, `v.c.type=chademo`, `v.c.voltage`, `v.c.current`, `v.c.power`).