### PR TITLE
Refactor smartEQ class layout and defaults

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -53,16 +53,16 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       REQ_DLC(7);      // logic by vehicle.cpp events
       switch(CAN_BYTE(6)) {
         case 0x00: // Parking
-          m_gear = 0;
+          can_gear = 0;
           break;
         case 0x10: // Rear
-          m_gear = -1;
+          can_gear = -1;
           break;
         case 0x20: // Neutral
-          m_gear = 0;
+          can_gear = 0;
           break;
         case 0x70: // Drive
-          m_gear = 1;
+          can_gear = 1;
           break;
         }
       break;
@@ -70,11 +70,9 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
     case 0x350:
       {
       REQ_DLC(7);
-      bool awake = (CAN_BYTE(0) > 0xc0);
-      bool locked = (CAN_BYTE(6) == 0x96) || (mt_driver_door_locked->AsBool(false) && !DoorOpen());
-      StdMetrics.ms_v_env_locked->SetValue(locked);
-      StdMetrics.ms_v_env_awake->SetValue(awake);
-      if (awake && !mt_bus_awake->AsBool())
+      can_awake = (CAN_BYTE(0) > 0xc0);
+      can_locked = (CAN_BYTE(6) == 0x96) || (mt_driver_door_locked->AsBool(false) && !DoorOpen());
+      if (can_awake && !mt_bus_awake->AsBool())
         {
         ESP_LOGI(TAG,"Car has woken (CAN bus activity)");
         mt_bus_awake->SetValue(true);
@@ -103,11 +101,10 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
     case 0x392:
       {
       REQ_DLC(6);
-      bool hvac_on = (CAN_BYTE(1) & 0x40) > 0;
-      StdMetrics.ms_v_env_hvac->SetValue(hvac_on);
-      if (hvac_on)
+      can_hvac = (CAN_BYTE(1) & 0x40) > 0;
+      if (can_hvac || IsOnEQ())
         {
-        StdMetrics.ms_v_env_cabintemp->SetValue(CAN_BYTE(5) - 40.0f);
+        can_cabintemp = CAN_BYTE(5) - 40.0f;
         }      
       break;
       }
@@ -120,33 +117,33 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       // Ignore invalid sensor reading (0x7F = 127 → 87°C after offset)
       if (raw_temp != 0x7F) 
         {
-        StdMetrics.ms_v_bat_temp->SetValue(_temp);
+        can_bat_temp = _temp;
         }
       
-      StdMetrics.ms_v_bat_voltage->SetValue((float)((CAN_UINT(3) >> 5) & 0x3ff) / 2.0f);
-      StdMetrics.ms_v_charge_climit->SetValue((c >> 20) & 0x3Fu);
+      can_bat_voltage = (float)((CAN_UINT(3) >> 5) & 0x3ff) / 2.0f;
+      can_charge_climit = (c >> 20) & 0x3Fu;
         
       break;
       }
     case 0x4F8:
       REQ_DLC(3);
-      StdMetrics.ms_v_env_handbrake->SetValue((CAN_BYTE(0) & 0x08) > 0);
-      //StdMetrics.ms_v_env_awake->SetValue((CAN_BYTE(0) & 0x40) > 0); // Ignition on
+      can_handbrake = (CAN_BYTE(0) & 0x08) > 0;
+      //can_awake = (CAN_BYTE(0) & 0x40) > 0; // Ignition on
       break;
     case 0x5D7: // Speed, ODO
       REQ_DLC(6);
-      StdMetrics.ms_v_pos_speed->SetValue((float) CAN_UINT(0) / 100.0f);
-      StdMetrics.ms_v_pos_odometer->SetValue((float) (CAN_UINT32(2)>>4) / 100.0f);
+      can_speed = (float) CAN_UINT(0) / 100.0f;
+      can_odometer = (float) (CAN_UINT32(2)>>4) / 100.0f;
       mt_pos_odometer_trip->SetValue((float) (CAN_UINT(4)>>4) / 100.0f);
       break;
     case 0x5de:
       REQ_DLC(8);
-      StdMetrics.ms_v_env_headlights->SetValue((CAN_BYTE(0) & 0x04) > 0);
-      StdMetrics.ms_v_door_fl->SetValue((CAN_BYTE(1) & 0x08) > 0);
-      StdMetrics.ms_v_door_fr->SetValue((CAN_BYTE(1) & 0x02) > 0);
-      StdMetrics.ms_v_door_rl->SetValue((CAN_BYTE(2) & 0x40) > 0);
-      StdMetrics.ms_v_door_rr->SetValue((CAN_BYTE(2) & 0x10) > 0);
-      StdMetrics.ms_v_door_trunk->SetValue((CAN_BYTE(7) & 0x10) > 0);
+      can_headlights = (CAN_BYTE(0) & 0x04) > 0;
+      can_door_fl = (CAN_BYTE(1) & 0x08) > 0;
+      can_door_fr = (CAN_BYTE(1) & 0x02) > 0;
+      can_door_rl = (CAN_BYTE(2) & 0x40) > 0;
+      can_door_rr = (CAN_BYTE(2) & 0x10) > 0;
+      can_door_trunk = (CAN_BYTE(7) & 0x10) > 0;
       break;
     case 0x62d:
       REQ_DLC(3);
@@ -161,7 +158,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       mt_worst_consumption->SetValue(worst_consumption);
       mt_best_consumption->SetValue(best_consumption);
       mt_bcb_power_mains->SetValue(bcb_power_mains);
-      StdMetrics.ms_v_bat_consumption->SetValue(best_consumption * 10.0f); // convert to Wh/km
+      can_bat_consumption = best_consumption * 10.0f; // convert to Wh/km
       break;
       }
     case 0x637:
@@ -193,43 +190,31 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       if(trip_energy < 0x7FFF) 
         mt_reset_energy->SetValue((float)trip_energy * 0.1f);
       mt_reset_speed->SetValue((float)avg_speed * 0.1f);
-      if(m_bcvalue){
-        StdMetrics.ms_v_gen_kwh_grid_total->SetValue((float)rest_consumption); // not the best idea at the moment
-      } else {
-        StdMetrics.ms_v_gen_kwh_grid_total->SetValue(0.0f);
-      }
+      can_kwh_grid_total = m_bcvalue ? (float)rest_consumption : 0.0f;
       break;
       }
     case 0x654:        // SOC / charge port status
       {
       REQ_DLC(4);
       float _soc = (float) CAN_BYTE(3);
-      if (_soc <= 100.0f) StdMetrics.ms_v_bat_soc->SetValue(_soc); // SOC
-      StdMetrics.ms_v_door_chargeport->SetValue((CAN_BYTE(0) & 0x20) != 0); // ChargingPlugConnected
+      if (_soc <= 100.0f) can_soc = _soc; // SOC
+      can_chargeport = (CAN_BYTE(0) & 0x20) != 0; // ChargingPlugConnected
       int _duration_full = (((c >> 22) & 0x3ffu) < 0x3ff) ? (c >> 22) & 0x3ffu : 0;
       mt_obd_duration->SetValue((int)(_duration_full), Minutes);
       float _range_est = ((c >> 12) & 0x3FFu); // VehicleAutonomy
-      float _bat_temp = StdMetrics.ms_v_bat_temp->AsFloat(0) - 20.0;
+      float _bat_temp = can_bat_temp - 20.0;
       float _full_km = m_full_km;
       float _range_cac = _full_km + (_bat_temp); // temperature compensation +/- range
       if (_range_est != 1023.0f) 
         {
-        StdMetrics.ms_v_bat_range_est->SetValue(_range_est);
+        can_range_est = _range_est;
 
         if (_soc > 0.1f)  // prevent div/0
           {
-          StdMetrics.ms_v_bat_range_full->SetValue((_range_est / _soc) * 100.0f);
-          StdMetrics.ms_v_bat_range_ideal->SetValue((_range_cac * _soc) / 100.0f);
+          can_range_full = (_range_est / _soc) * 100.0f;
+          can_range_ideal = (_range_cac * _soc) / 100.0f;
           }
         }
-      break;
-      }
-    case 0x656:
-      {
-      REQ_DLC(7);
-      float _env_temp = (float) CAN_BYTE(6) - 40.0f;
-      if (_env_temp > -40.0f && _env_temp < 85.0f)
-        StdMetrics.ms_v_env_temp->SetValue(_env_temp);
       break;
       }
     case 0x658:
@@ -246,24 +231,24 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
         last_bat_serial = bat_serial;
       }
       float _soh = (float)(CAN_BYTE(4) & 0x7Fu);
-      if (_soh <= 100.0f) StdMetrics.ms_v_bat_soh->SetValue(_soh); // SOH
-      StdMetrics.ms_v_bat_health->SetValue(
+      if (_soh <= 100.0f) can_soh = _soh; // SOH
+      can_bat_health =
         (_soh >= 95.0f) ? "excellent"
       : (_soh >= 85.0f) ? "good"
       : (_soh >= 75.0f) ? "average"
       : (_soh >= 65.0f) ? "poor"
-      : "consider replacement");
-      StdMetrics.ms_v_charge_inprogress->SetValue(CAN_BYTE(5) & 0x20);
+      : "consider replacement";
+      can_charge_inprogress = (CAN_BYTE(5) & 0x20) != 0;
       break;
       }
     case 0x668:
       REQ_DLC(1);
-      StdMetrics.ms_v_env_on->SetValue((CAN_BYTE(0) & 0x40) > 0); // Drive Ready
+      can_env_on = (CAN_BYTE(0) & 0x40) > 0; // Drive Ready
       break;
     case 0x673:
       {
       // TPMS pressure values only used, when CAN write is disabled, otherwise utilize PollReply_TPMS_InputCapt
-      if ((!m_enable_write && !m_enable_write_caron) || !m_obdii_745_tpms)
+      if (!IsCANwrite() || !m_obdii_745_tpms)
         {
         REQ_DLC(6);
         // Read TPMS pressure values:
@@ -275,7 +260,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
             if (m_tpms_temp_enable)
               {
               // Dummy value to indicate valid temp reading, actual temp value is not available in this frame, but can be read via PollReply_TPMS_InputCapt when CAN write is enabled
-              m_tpms_temperature[i] = StdMetrics.ms_v_env_temp->AsFloat(1.1f);
+              m_tpms_temperature[i] = StdMetrics.ms_v_env_temp->AsFloat(0.0f); // use ambient temp as dummy value for valid reading, since actual temp is not available in this frame
               }
             // Prevent warnings when readings are valid if the data is not read via OBDII.
             m_tpms_lowbatt[i] = 0; 
@@ -289,4 +274,37 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       //ESP_LOGI(TAG, "PID:%x DATA: %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
       break;
   }
+}
+
+// Sync CAN datapoints to OVMS metrics, called by Ticker1, because CAN refresh rate is too high
+void OvmsVehicleSmartEQ::smartCAN2Metrics()
+{  
+  StdMetrics.ms_v_env_gear->SetValue(can_gear);
+  StdMetrics.ms_v_env_locked->SetValue(can_locked);
+  StdMetrics.ms_v_env_awake->SetValue(can_awake);
+  StdMetrics.ms_v_env_hvac->SetValue(can_hvac);
+  StdMetrics.ms_v_env_cabintemp->SetValue(can_cabintemp);
+  StdMetrics.ms_v_bat_temp->SetValue(can_bat_temp);
+  StdMetrics.ms_v_bat_voltage->SetValue(can_bat_voltage);
+  StdMetrics.ms_v_charge_climit->SetValue(can_charge_climit);
+  StdMetrics.ms_v_env_handbrake->SetValue(can_handbrake);
+  StdMetrics.ms_v_pos_speed->SetValue(can_speed);
+  StdMetrics.ms_v_pos_odometer->SetValue(can_odometer);
+  StdMetrics.ms_v_env_headlights->SetValue(can_headlights);
+  StdMetrics.ms_v_door_fl->SetValue(can_door_fl);
+  StdMetrics.ms_v_door_fr->SetValue(can_door_fr);
+  StdMetrics.ms_v_door_rl->SetValue(can_door_rl);
+  StdMetrics.ms_v_door_rr->SetValue(can_door_rr);
+  StdMetrics.ms_v_door_trunk->SetValue(can_door_trunk);
+  StdMetrics.ms_v_bat_consumption->SetValue(can_bat_consumption);
+  StdMetrics.ms_v_gen_kwh_grid_total->SetValue(can_kwh_grid_total);
+  StdMetrics.ms_v_bat_soc->SetValue(can_soc);
+  StdMetrics.ms_v_door_chargeport->SetValue(can_chargeport);
+  StdMetrics.ms_v_bat_range_est->SetValue(can_range_est);
+  StdMetrics.ms_v_bat_range_full->SetValue(can_range_full);
+  StdMetrics.ms_v_bat_range_ideal->SetValue(can_range_ideal);
+  StdMetrics.ms_v_bat_soh->SetValue(can_soh);
+  StdMetrics.ms_v_bat_health->SetValue(can_bat_health);
+  StdMetrics.ms_v_charge_inprogress->SetValue(can_charge_inprogress);
+  StdMetrics.ms_v_env_on->SetValue(can_env_on);
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -65,7 +65,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
     return Success;
     }
   // force enable write access for sending the command, even when user has not enabled it (can be required for some vehicles to wake up the car)
-  bool force = !m_enable_write && !m_enable_write_caron ? true : false;
+  bool force = !IsCANwrite() ? true : false;
   if(force)
     {
     m_enable_write_caron = true;
@@ -201,7 +201,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandHomelink(int button, i
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
-  if(!m_enable_write && !m_enable_write_caron)
+  if(!IsCANwrite())
     {
     ESP_LOGE(TAG, "CommandWakeup failed: no write access!");
     return Fail;
@@ -245,7 +245,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup2() {
-  if(!m_enable_write && !m_enable_write_caron)
+  if(!IsCANwrite())
     {
     ESP_LOGE(TAG, "CommandWakeup2 failed: no write access!");
     return Fail;
@@ -289,7 +289,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup2() {
 
 // lock: can can1 tx st 745 04 30 01 00 00
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandLock(const char* pin) {
-  if(!m_enable_write && !m_enable_write_caron) 
+  if(!IsCANwrite()) 
     {
     ESP_LOGE(TAG, "CommandLock failed / no write access");
     return Fail;
@@ -326,7 +326,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandLock(const char* pin) 
 // unlock: can can1 tx st 745 04 30 01 00 01
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandUnlock(const char* pin) {
 
-  if(!m_enable_write && !m_enable_write_caron)
+  if(!IsCANwrite())
     {
     ESP_LOGE(TAG, "CommandUnlock failed / no write access");
     return Fail;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -36,7 +36,7 @@ static const char *TAG = "v-smarteq";
 
 // CommandCanVector(txid, rxid, hexbytes = {"30010000","30082002"}, reset CAN = true/false, CommandWakeup = true/ CommandWakeup2 = false)
 OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCanVector(uint32_t txid,uint32_t rxid, std::vector<std::string> hexbytes,bool reset,bool wakeup) {
-  if(!m_enable_write && !m_enable_write_caron)
+  if(!IsCANwrite())
     {
     ESP_LOGE(TAG, "CommandCanVector failed / no write access");
     return Fail;
@@ -184,7 +184,7 @@ void OvmsVehicleSmartEQ::xsq_canwrite(int verbosity, OvmsWriter* writer, OvmsCom
   if (!smarteq)
     return;
   
-  if(!smarteq->m_ddt4all || !smarteq->m_enable_write) {
+  if(!smarteq->m_ddt4all || !smarteq->IsCANwrite()) {
     ESP_LOGE(TAG, "DDT4all failed / no Canbus write access or DDT4all not enabled");
     writer->puts("DDT4all failed / no Canbus write access or DDT4all not enabled");
     return;
@@ -574,7 +574,8 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandPreset(int verbosity, 
     "obdii_79b",
     "obdii_7e4",
     "obdii_7e4_modify",
-    "basic_tpms"
+    "basic_tpms",
+    "calc.adcfactor.samples"
   };
 
   int removed_count = 0;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
@@ -63,7 +63,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     return Success;
   }
 
-  if((!m_ddt4all || !m_enable_write) && number > 9) {
+  if((!m_ddt4all || !IsCANwrite()) && number > 9) {
     ESP_LOGE(TAG, "DDT4all failed / no Canbus write access or DDT4all not enabled");
     writer->printf("DDT4all failed / no Canbus write access or DDT4all not enabled");
     return Fail;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -380,6 +380,7 @@ void OvmsVehicleSmartEQ::ReCalcADCfactor(float can12V, OvmsWriter* writer) {
       mt_adc_factor_history->SetElemValues(0, n, hist);
     mt_adc_factor->SetValue(adc_factor_new);
     MyConfig.SetParamValueFloat("system.adc", "factor12v", adc_factor_new);
+    MyConfig.SetParamValueBool("xsq", "calc.adcfactor", false);
     if (writer) writer->printf("New ADC factor stored: %.3f (prev %.3f, history size %u)\n", adc_factor_new, adc_factor_prev, (unsigned)n);
   #else
     ESP_LOGD(TAG, "ADC support not enabled");
@@ -470,7 +471,7 @@ void OvmsVehicleSmartEQ::smartOn()
   // reset idle ticker when vehicle turned on to prevent trigger every 60 sec.
   m_idle_ticker = 15 * 60;
   // canwrite enable write access, only when car is on
-  if(m_enable_write || m_enable_write_caron) 
+  if(IsCANwrite()) 
     {
     smartCANmode(true);
     }
@@ -517,11 +518,11 @@ void OvmsVehicleSmartEQ::smartChargeStart()
   // trigger ADC factor recalculation when HV charging started
   if(m_enable_calcADCfactor && !m_ADCfactor_recalc) 
     {
-    m_ADCfactor_recalc_timer = 4;   // wait at least 4 min. before recalculation
+    m_ADCfactor_recalc_timer = 2;   // wait at least 2 min. before recalculation
     m_ADCfactor_recalc = true;      // recalculate ADC factor when HV charging
     }
   // canwrite enable write access, only when car is on
-  if(m_enable_write || m_enable_write_caron) 
+  if(IsCANwrite()) 
     {
     m_poll_on_charge = true;
     smartCANmode(true);
@@ -553,7 +554,7 @@ void OvmsVehicleSmartEQ::smartChargeStop()
     StdMetrics.ms_v_charge_substate->SetValue("onrequest");
   }
   // stop recalculation when HV charging stopped
-  m_ADCfactor_recalc_timer = 0;
+  m_ADCfactor_recalc_timer = 2;
   m_ADCfactor_recalc = false;
   ESP_LOGD(TAG, "smartChargeStop()");
 }
@@ -563,7 +564,7 @@ void OvmsVehicleSmartEQ::smartChargePrepare()
   if (m_charge_finished) ResetChargingValues();
   if (m_resettrip) ResetTripCounters();
   // canwrite enable write access, only when car is on
-  if(m_enable_write || m_enable_write_caron) 
+  if(IsCANwrite()) 
     {
     m_poll_on_charge = true;
     smartCANmode(true);
@@ -581,7 +582,7 @@ void OvmsVehicleSmartEQ::smartChargeFinish()
 
 void OvmsVehicleSmartEQ::smartCANmode(bool activate)
 {
-  if(!m_enable_write && !m_enable_write_caron)
+  if(!IsCANwrite())
     {
     m_can1->Stop();
     vTaskDelay(200 / portTICK_PERIOD_MS);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -39,7 +39,7 @@ void OvmsVehicleSmartEQ::HandlePollState() {
 
   static const char* state_names[] = {"Off", "Awake", "Running", "Charging"};
   static const char* state_disabled = "Pollstate Off (write disabled)";
-  if (!m_enable_write && !m_enable_write_caron) 
+  if (!IsCANwrite()) 
     {
     if (m_poll_state != POLLSTATE_OFF) 
       {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -65,6 +65,15 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
 
   if(m_enable_LED_state) 
     OnlineState();
+
+  // check 12V charging state for powermgmt system
+  bool charge_12v = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) > 13.1f ? true : false;
+  if (charge_12v != StdMetrics.ms_v_env_charging12v->AsBool(false))
+    {
+    StdMetrics.ms_v_env_charging12v->SetValue(charge_12v);    
+    m_ADCfactor_recalc_timer = 2;
+    m_ADCfactor_recalc = charge_12v;
+    }
   }
 
 void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {  
@@ -105,30 +114,44 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
     mt_bus_awake->SetValue(true);
     smartChargeStart();
     }
-  // check 12V charging state for powermgmt system
-  bool charge_12v = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) > 13.1f ? true : false;
-  if (charge_12v != StdMetrics.ms_v_env_charging12v->AsBool())
-    {
-    StdMetrics.ms_v_env_charging12v->SetValue(charge_12v);
-    }
 
   #ifdef CONFIG_OVMS_COMP_ADC
-  if (m_enable_calcADCfactor && m_ADCfactor_recalc) 
+  if(IsOnEQ() || IsChargingEQ())
     {
-    if (--m_ADCfactor_recalc_timer == 0) 
+    // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
+    if(m_check12vadc)
       {
-      m_ADCfactor_recalc = false;
-      m_ADCfactor_recalc_timer = 4;
-      // calculate new ADC factor      
-      float can12V = mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
-      if (StdMetrics.ms_v_env_charging12v->AsBool(false))
+      float can12V = mt_evc_dcdc->GetElemValue(1);
+      float adc12V = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
+      float diff = fabs(can12V - adc12V);
+      bool charging12v = StdMetrics.ms_v_env_charging12v->AsBool(false);
+      if (diff > 0.1f && !m_ADCfactor_recalc && charging12v)      
         {
-        ReCalcADCfactor(can12V, nullptr);  // nullptr = no Log-Output
-        ESP_LOGI(TAG, "Auto ADC recalibration started (%.2fV)", can12V);
-        } 
-      else 
+        ESP_LOGW(TAG, "12V voltage difference detected: CAN=%.2fV, ADC=%.2fV, diff=%.2fV", can12V, adc12V, diff);
+        m_ADCfactor_recalc_timer = 2;   // wait at least 2 min. before recalculation
+        m_enable_calcADCfactor = true;
+        m_ADCfactor_recalc = true;      // recalculate ADC factor when 12V voltage difference detected
+        }
+      m_check12vadc = false;
+      }
+    // if ADC factor recalculation is enabled, then check if it's time to recalculate the factor
+    if (m_enable_calcADCfactor && m_ADCfactor_recalc) 
+      {
+      if (--m_ADCfactor_recalc_timer == 0) 
         {
-        ESP_LOGW(TAG, "Error: Auto ADC recalibration, 12V voltage is not stable for ADC calibration! (%.2fV)", can12V);
+        m_ADCfactor_recalc = false;
+        m_ADCfactor_recalc_timer = 2;
+        // calculate new ADC factor      
+        float can12V = mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
+        if (StdMetrics.ms_v_env_charging12v->AsBool(false))
+          {
+          ReCalcADCfactor(can12V, nullptr);  // nullptr = no Log-Output
+          ESP_LOGI(TAG, "Auto ADC recalibration started (%.2fV)", can12V);
+          } 
+        else 
+          {
+          ESP_LOGW(TAG, "Error: Auto ADC recalibration, 12V voltage is not stable for ADC calibration! (%.2fV)", can12V);
+          }
         }
       }
     }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -44,11 +44,9 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     HandleCharging();
   
   if(IsOnEQ())
-    {
     HandleEnergy();
-    if(StdMetrics.ms_v_env_gear->AsInt(0) != m_gear)
-      StdMetrics.ms_v_env_gear->SetValue(m_gear);
-    }
+    
+  smartCAN2Metrics();
   }
 
 void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker) 
@@ -76,7 +74,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
     DoorLockState();
   if(m_enable_door_state && !m_warning_dooropen && StdMetrics.ms_v_env_parktime->AsInt() > m_park_timeout_secs +10) 
     DoorOpenState();
-  if(IsOnEQ()) 
+  if(IsOnEQ())
     setTPMSValue();   // update TPMS metrics
 
   #if defined(CONFIG_OVMS_COMP_WIFI) || defined(CONFIG_OVMS_COMP_CELLULAR)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -416,7 +416,7 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
       c.alert(alert_type.c_str(), info.c_str());
 
       // Refresh values from config/metrics to show latest state after command execution
-      calcADCfactor = MyConfig.GetParamValueBool("xsq", "calc.adcfactor", calcADCfactor);
+    calcADCfactor = sq->m_enable_calcADCfactor;
       adc_factor  = MyConfig.GetParamValue("system.adc", "factor12v", adc_factor.empty() ? "195.7" : adc_factor);
       if (sq->mt_evc_dcdc && sq->mt_evc_dcdc->GetElemValue(1) > 10.0f) {
         char buf[16];
@@ -450,7 +450,7 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
     }
   } else {
     // read configuration:
-    calcADCfactor = MyConfig.GetParamValueBool("xsq", "calc.adcfactor", false);
+    calcADCfactor = sq->m_enable_calcADCfactor;
     adc_factor  = MyConfig.GetParamValue("system.adc", "factor12v", "195.7");
     if (sq->mt_evc_dcdc && sq->mt_evc_dcdc->GetElemValue(1) > 10.0f) {
         char buf[16];
@@ -487,15 +487,15 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
   // ADC settings
   c.fieldset_start("ADC Settings");
   c.input_checkbox("Auto-recalculate ADC factor", "calcADCfactor", calcADCfactor,
-      "<p>Recalculate ADC factor once per HV charge via CAN 12V measurement</p>");
+      "<p>Recalculate ADC factor once per 12V charge by DC/DC with CAN 12V measurement value</p>");
   if (!adc_history.empty()) {
     c.input_text("ADC factor history", "adc_history", adc_history.c_str(), "no history",
       "<p>Last 5 values, most recent last</p>");
   }
-  c.input_slider("ADC factor", "adc_factor", 5, "", -1, atof(adc_factor.c_str()), 195.7, 160, 230, 0.01,
+  c.input_slider("ADC factor", "adc_factor", 5, "", -1, atof(adc_factor.c_str()), 195.7, 160, 230, 0.1,
     "<p>12V ADC calibration factor (default 195.7)</p>");
   c.input_slider("12V measured", "onboard_12v", 3, "V",-1, atof(onboard_12v.c_str()), 12.60, 11.00, 15.00, 0.01,
-    "<p>Measured 12V for calibration (preset from CAN)</p>");
+    "<p>Your measured 12V for calibration calculation</p>");
   c.printf("<input type=\"hidden\" name=\"onboard_12v_submit\" id=\"onboard_12v_submit\" value=\"%s\">\n",
            _attr(onboard_12v.c_str()));
   c.input_button("default", "ADC calculation", "action", "calc");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -54,32 +54,6 @@ OvmsVehicleSmartEQ* OvmsVehicleSmartEQ::GetInstance(OvmsWriter* writer)
 OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   ESP_LOGI(TAG, "Start smart EQ vehicle module");
 
-  m_12v_ticker = 0;
-  m_ddt4all = false;
-  m_ddt4all_ticker = 0;
-  m_ddt4all_exec = 0;
-  m_warning_unlocked = false;
-  m_warning_dooropen = false;
-  m_modem_restart = false;
-  m_modem_ticker = 0;
-  m_ADCfactor_recalc = false;
-  m_ADCfactor_recalc_timer = 0;
-  m_adc_samples = 5;
-  m_gear = 0;
-
-  m_enable_write = false;
-  m_enable_write_caron = false;
-  m_can_active = false;
-  m_candata_poll = false;
-  m_candata_timer = -1;
-
-  m_charge_finished = true;
-  m_notifySOClimit = false;
-  m_led_state = 4;
-  m_cfg_cell_interval_drv = 60;
-  m_cfg_cell_interval_chg = 60;
-  m_poll_on_charge = false;
-
   // BMS configuration:
   BmsSetCellArrangementVoltage(96, 1);               // 96 cells, 1 series string
   BmsSetCellArrangementTemperature(27, 1);           // 27 temp sensors, 1 series string
@@ -277,10 +251,10 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   bool obdii_79b          = true;
   bool obdii_7e4_dcdc     = true;
   
-  if (map) 
+  if (map)
     {
     m_enable_write         = map->GetValueBool("canwrite", false);
-    m_enable_write_caron   = map->GetValueBool("canwrite.caron", false);
+    m_enable_write_caron   = map->GetValueBool("canwrite.caron", true);
     m_enable_LED_state     = map->GetValueBool("led", false);
     m_bcvalue              = map->GetValueBool("bcvalue", false);
     m_enable_lock_state    = map->GetValueBool("unlock.warning", true);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -34,7 +34,7 @@
 #define __VEHICLE_SMARTEQ_H__
 
 #define VERSION "2.1.2"
-#define PRESET_VERSION 20260326 // Configuration preset version
+#define PRESET_VERSION 20260420 // Configuration preset version
 
 #include "ovms_log.h"
 
@@ -93,17 +93,19 @@ typedef std::initializer_list<const OvmsPoller::poll_pid_t> poll_list_t;
 
 class OvmsVehicleSmartEQ : public OvmsVehicle
 {
+  // =========================================================================
+  // public
+  // =========================================================================
   public:
     OvmsVehicleSmartEQ();
     ~OvmsVehicleSmartEQ();
 
-  private:
-    static OvmsVehicleSmartEQ* GetInstance(OvmsWriter* writer=NULL);
-
-  public:
+    // --- CAN / Poll overrides ---
     void IncomingFrameCan1(CAN_frame_t* p_frame) override;
     void IncomingPollReply(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length) override;
     void IncomingPollError(const OvmsPoller::poll_job_t &job, int32_t code) override;
+
+    // --- Vehicle logic handlers ---
     void HandleCharging();
     void HandleEnergy();
     void HandleTripcounter();
@@ -120,6 +122,9 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void DisablePlugin(const char* plugin);
     bool ExecuteCommand(const std::string& command);
     void setTPMSValue();
+    void ReCalcADCfactor(float can12V, OvmsWriter* writer=nullptr);
+
+    // --- Notification methods ---
     void NotifyClimate();
     void NotifyClimateTimer();
     void NotifyTripReset();
@@ -129,12 +134,17 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void NotifyMaintenance();
     void Notify12Vcharge();
     void NotifySOClimit();
+
+    // --- Door / Lock state ---
     bool DoorOpen();
     void DoorLockState();
     void DoorOpenState();
+
+    // --- Network ---
     void WifiRestart();
     void ModemRestart();
-    void ReCalcADCfactor(float can12V, OvmsWriter* writer=nullptr);
+
+    // --- Vehicle state management ---
     void smartOn();
     void smartOff();
     void smartAwake();
@@ -143,9 +153,10 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void smartChargeStop();
     void smartChargePrepare();
     void smartChargeFinish();
-    void smartCANmode(bool activate);   
+    void smartCANmode(bool activate);
+    void smartCAN2Metrics();
 
-public:
+    // --- Command overrides ---
     vehicle_command_t CommandClimateControl(bool enable) override;
     vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
     vehicle_command_t CommandWakeup() override;
@@ -157,11 +168,11 @@ public:
     vehicle_command_t CommandStartCharge() override;
     vehicle_command_t CommandStopCharge() override;
 
+    // --- Custom vehicle commands ---
     vehicle_command_t CommandCanVector(uint32_t txid, uint32_t rxid, std::vector<std::string> hexbytes, bool reset=false, bool wakeup=false);
     vehicle_command_t CommandWakeup2();
     vehicle_command_t ProcessMsgCommand(std::string &result, int command, const char* args);
     vehicle_command_t MsgCommandCA(std::string &result, int command, const char* args);
-    
     virtual vehicle_command_t CommandTripStart(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandTripReset(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandMaintenance(int verbosity, OvmsWriter* writer);
@@ -176,8 +187,8 @@ public:
     virtual vehicle_command_t CommandED4scan(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandPreset(int verbosity, OvmsWriter* writer);
     virtual vehicle_command_t CommandSetDefault(int verbosity, OvmsWriter* writer);
-    
-public:
+
+    // --- Web interface ---
 #ifdef CONFIG_OVMS_COMP_WEBSERVER
     void WebInit();
     void WebDeInit();
@@ -186,12 +197,14 @@ public:
     static void WebCfgADC(PageEntry_t& p, PageContext_t& c);
     static void WebCfgBattery(PageEntry_t& p, PageContext_t& c);
 #endif
+
+    // --- Config / Features ---
     void ConfigChanged(OvmsConfigParam* param) override;
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
     uint64_t swap_uint64(uint64_t val);
 
-  public:
+    // --- Static shell command handlers ---
     static void xsq_trip_start(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_trip_reset(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_maintenance(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
@@ -208,34 +221,31 @@ public:
     static void xsq_tpms_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_setdefault(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
 
-  private:
-    int m_candata_timer;
-    bool m_candata_poll;
-    bool m_charge_finished;
-    float m_tpms_pressure[4]; // kPa
-    float m_tpms_temperature[4]; // °C
-    bool m_tpms_lowbatt[4]; // 0=ok, 1=low
-    bool m_tpms_missing_tx[4]; // 0=ok, 1=missing
-    bool m_ADCfactor_recalc;       // request recalculation of ADC factor
-    int m_ADCfactor_recalc_timer;  // countdown timer for ADC factor recalculation
-    int m_gear; // <0 = reverse, 0 = park/neutral, >0 = drive -- logic by vehicle.cpp events
-
-  public:
+    // --- Inline state helpers ---
     bool UsesTpmsSensorMapping() override { return true; } // using m_tpms_index[]
     bool IsOffEQ() { return m_poll_state == POLLSTATE_OFF; }
     bool IsAwakeEQ() { return (mt_bus_awake->AsBool(false) || StdMetrics.ms_v_env_awake->AsBool(false)) == true; }
     bool IsOnEQ() { return StdMetrics.ms_v_env_on->AsBool(false) == true; }
     bool IsChargingEQ() { return StdMetrics.ms_v_charge_inprogress->AsBool(false) == true; }
     bool IsOnHVACEQ() { return StdMetrics.ms_v_env_hvac->AsBool(false) == true; }
+    bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
 
+  // =========================================================================
+  // protected
+  // =========================================================================
   protected:
+    // --- Ticker / Poller overrides ---
     void Ticker1(uint32_t ticker) override;
     void Ticker10(uint32_t ticker) override;
     void Ticker60(uint32_t ticker) override;
     void PollerStateTicker(canbus *bus) override;
+
+    // --- Dashboard / Calculations ---
     void GetDashboardConfig(DashboardConfig& cfg);
     virtual void CalculateEfficiency();
-    virtual void CalculateRangeSpeed(); 
+    virtual void CalculateRangeSpeed();
+
+    // --- Vehicle state notification overrides ---
     void NotifyVehicleIdling() override;
     void NotifiedVehicleOn() override;
     void NotifiedVehicleOff() override;
@@ -248,6 +258,7 @@ public:
     void NotifiedVehicleChargePilotOn() override;
     void NotifiedVehicleChargePilotOff() override;
 
+    // --- Poll reply handlers: BMS ---
     void PollReply_BMS_BattVolts(const char* data, uint16_t reply_len, uint16_t start);
     void PollReply_BMS_BattTemps(const char* data, uint16_t reply_len);
     void PollReply_BMS_BattState(const char* data, uint16_t reply_len);
@@ -258,14 +269,17 @@ public:
     void PollReply_BMS_BattHealth(const char* data, uint16_t reply_len);
     void PollReply_BMS_ProductionData(const char* data, uint16_t reply_len);
 
+    // --- Poll reply handlers: TDB ---
     void PollReply_TDB(const char* data, uint16_t reply_len);
 
+    // --- Poll reply handlers: BCM ---
     void PollReply_BCM_VIN(const char* data, uint16_t reply_len);
     void PollReply_BCM_TPMS_InputCapt(const char* data, uint16_t reply_len);
     void PollReply_BCM_TPMS_Status(const char* data, uint16_t reply_len);
     void PollReply_BCM_GenMode(const char* data, uint16_t reply_len);
     void PollReply_BCM_DoorlockEEPROM(const char* data, uint16_t reply_len);
 
+    // --- Poll reply handlers: EVC ---
     void PollReply_EVC_DCDC_ActReq(const char* data, uint16_t reply_len);
     void PollReply_EVC_HV_Energy(const char* data, uint16_t reply_len);
     void PollReply_EVC_PlugDetected(const char* data, uint16_t reply_len);
@@ -280,6 +294,7 @@ public:
     void PollReply_EVC_14VBatteryVoltageReq(const char* data, uint16_t reply_len);
     void PollReply_EVC_CabinBlower(const char* data, uint16_t reply_len);
 
+    // --- Poll reply handlers: OBL ---
     void PollReply_OBL_ChargerAC(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_Ph1_RMS_A(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_Ph2_RMS_A(const char* data, uint16_t reply_len);
@@ -287,7 +302,7 @@ public:
     void PollReply_OBL_JB2AC_Ph12_RMS_V(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_Ph23_RMS_V(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_Ph31_RMS_V(const char* data, uint16_t reply_len);
-    void PollReply_OBL_JB2AC_Power(const char* data, uint16_t reply_len);    
+    void PollReply_OBL_JB2AC_Power(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_GroundResistance(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_LeakageDiag(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_DCCurrent(const char* data, uint16_t reply_len);
@@ -297,6 +312,7 @@ public:
     void PollReply_OBL_JB2AC_MaxCurrent(const char* data, uint16_t reply_len);
     void PollReply_OBL_JB2AC_PhaseFreq(const char* data, uint16_t reply_len);
 
+    // --- Poll reply handlers: OBD ---
     void PollReply_obd_trip(const char* data, uint16_t reply_len);
     void PollReply_obd_time(const char* data, uint16_t reply_len);
     void PollReply_obd_start_trip(const char* data, uint16_t reply_len);
@@ -304,50 +320,24 @@ public:
     void PollReply_obd_mt_day(const char* data, uint16_t reply_len);
     void PollReply_obd_mt_km(const char* data, uint16_t reply_len);
     void PollReply_obd_mt_level(const char* data, uint16_t reply_len);
-    
-  protected:
-    bool m_enable_write;                    // canwrite enable write access
-    bool m_enable_write_caron;              // canwrite enable write access, only when car is on
-    bool m_can_active;                      // true if CAN bus is in active mode, false if in listen-only mode
-    bool m_enable_LED_state;                // Online LED State
-    bool m_enable_lock_state;               // Lock State
-    bool m_enable_door_state;               // Door Open State
-    bool m_tpms_temp_enable;                // TPMS Temperature Display enabled
-    bool m_resettrip;                       // Reset Trip Values when Charging/Driving
-    bool m_resettotal;                      // Reset kWh/100km Values when Driving
-    bool m_tripnotify;                      // Trip Reset Notification on/off
-    bool m_bcvalue;                         // use kWh/100km Value from mt_use_at_reset = true, Calculated = false
-    int m_reboot_ticker;
-    int m_reboot_time;                      // Restart Network time
-    int m_TPMS_FL;                          // TPMS Sensor Front Left
-    int m_TPMS_FR;                          // TPMS Sensor Front Right
-    int m_TPMS_RL;                          // TPMS Sensor Rear Left
-    int m_TPMS_RR;                          // TPMS Sensor Rear Right
-    float m_front_pressure;                 // Front Tire Pressure
-    float m_rear_pressure;                  // Rear Tire Pressure
-    float m_pressure_warning;               // Pressure Warning
-    float m_pressure_alert;                 // Pressure Alert
-    bool m_tpms_alert_enable;               // TPMS Alert enabled
-    bool m_12v_charge;                      //!< 12V charge on/off
-    bool m_12v_charge_state;                //!< 12V charge state
-    std::string m_hl_canbyte;               //!< canbyte variable for unv
-    bool m_extendedStats;                   //!< extended stats for trip and maintenance data
-    std::deque<float> m_adc_factor_history; // ring buffer (max 20) for ADC factors
 
+    // --- Constants ---
     #define DEFAULT_BATTERY_CAPACITY 16700 // <- net 16700 Wh, gross 17600 Wh
     #define MAX_POLL_DATA_LEN 126
     #define CELLCOUNT 96
     #define SQ_CANDATA_TIMEOUT 70 // seconds until car goes to sleep without CAN activity
 
-  protected:
+    // --- Internal buffer ---
     std::string   m_rxbuf;
 
-  protected:
+    // --- Command pointers ---
     OvmsCommand *cmd_xsq;                               // command for xsq
     OvmsCommand *cmd_tpms;                              // command for tpms
     OvmsCommand *cmd_show;                              // command for show
+
+    // --- Custom metrics: general ---
     OvmsMetricBool          *mt_bus_awake;              // Can Bus active
-    OvmsMetricString        *mt_canbyte;                //!< DDT4all canbyte
+    OvmsMetricString        *mt_canbyte;                // DDT4all canbyte
     OvmsMetricFloat         *mt_adc_factor;             // calculated ADC factor for 12V measurement
     OvmsMetricVector<float> *mt_adc_factor_history;     // last 20 calculated ADC factors for 12V measurement
     OvmsMetricString        *mt_poll_state;             // Poller state
@@ -356,109 +346,205 @@ public:
     OvmsMetricString        *mt_start_time;             // Time since start (hh:mm)
     OvmsMetricFloat         *mt_start_distance;         // Trip distance since start (km)
 
-    // 0x646 metrics
+    // --- Custom metrics: 0x646 ---
     OvmsMetricFloat         *mt_reset_consumption;      // Average trip consumption (kWh/100km) reset
     OvmsMetricFloat         *mt_reset_distance;         // Trip distance (km) reset
     OvmsMetricFloat         *mt_reset_energy;           // Trip energy consumption (kWh) reset
     OvmsMetricFloat         *mt_reset_speed;            // Average trip speed (km/h) reset
-    // 0x658 metrics
+
+    // --- Custom metrics: 0x658 ---
     OvmsMetricString        *mt_bat_serial;             // Battery serial number (hex string)
-    // BMS production data (PID 0x90)
+
+    // --- Custom metrics: BMS production data (PID 0x90) ---
     OvmsMetricString        *mt_bms_prod_data;          // BMS production data formatted (serial, MM/YYYY)
-    // 0x637 metrics
+
+    // --- Custom metrics: 0x637 ---
     OvmsMetricFloat         *mt_energy_used;            // Energy used since mission start (kWh)
     OvmsMetricFloat         *mt_energy_recd;            // Energy recovered since mission start (kWh)
-    OvmsMetricFloat         *mt_energy_aux;        // Auxiliary consumption since mission start (kWh)
-    // 0x62d metrics
+    OvmsMetricFloat         *mt_energy_aux;             // Auxiliary consumption since mission start (kWh)
+
+    // --- Custom metrics: 0x62d ---
     OvmsMetricFloat         *mt_worst_consumption;      // Worst average consumption (kWh/100km)
     OvmsMetricFloat         *mt_best_consumption;       // Best average consumption (kWh/100km)
     OvmsMetricFloat         *mt_bcb_power_mains;        // BCB power from mains (W)
 
-    OvmsMetricFloat         *mt_pos_odometer_trip;           // odometer trip in km 
+    // --- Custom metrics: odometer ---
+    OvmsMetricFloat         *mt_pos_odometer_trip;           // odometer trip in km
     OvmsMetricFloat         *mt_pos_odometer_start;          // remind odometer start
     OvmsMetricFloat         *mt_pos_odometer_start_total;    // remind odometer start for kWh/100km
     OvmsMetricFloat         *mt_pos_odometer_trip_total;     // counted km for kWh/100km
-    
-    // EVC 12V values: Index 0=dcdc_volt_req, 1=dcdc_volt, 2=dcdc_power, 3=usm_volt, 4=batt_volt_can, 5=batt_volt_req, 6=dcdc_amps, 7=dcdc_load
-    OvmsMetricVector<float> *mt_evc_dcdc;                    //!< EVC 12V system values vector
-    OvmsMetricString        *mt_evc_traceability;            //!< Frame Traceability: ITG/Factory/Serial
-    OvmsMetricBool          *mt_evc_plug_detected;           //!< Charging plug detected by charger (0x339D)
 
-    OvmsMetricVector<float> *mt_bms_voltages;                //!< Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor
-    OvmsMetricVector<int>   *mt_bms_contactor_cycles;        //!< Max/Total HV contactor cycles
-    OvmsMetricVector<float> *mt_bms_soc_values;              //!< SOC values: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
-    OvmsMetricString        *mt_bms_soc_recal_state;         //!< SOC Recalibration State
-    OvmsMetricFloat         *mt_bms_soh;                     //!< State of Health (%)
+    // --- Custom metrics: EVC 12V ---
+    // Index 0=dcdc_volt_req, 1=dcdc_volt, 2=dcdc_power, 3=usm_volt, 4=batt_volt_can, 5=batt_volt_req, 6=dcdc_amps, 7=dcdc_load
+    OvmsMetricVector<float> *mt_evc_dcdc;                    // EVC 12V system values vector
+    OvmsMetricString        *mt_evc_traceability;            // Frame Traceability: ITG/Factory/Serial
+    OvmsMetricBool          *mt_evc_plug_detected;           // Charging plug detected by charger (0x339D)
+
+    // --- Custom metrics: BMS ---
+    OvmsMetricVector<float> *mt_bms_voltages;                // Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor
+    OvmsMetricVector<int>   *mt_bms_contactor_cycles;        // Max/Total HV contactor cycles
+    OvmsMetricVector<float> *mt_bms_soc_values;              // SOC values: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
+    OvmsMetricString        *mt_bms_soc_recal_state;         // SOC Recalibration State
+    OvmsMetricFloat         *mt_bms_soh;                     // State of Health (%)
     // BMS capacity values: Index 0=usable_max, 1=init, 2=estimate, 3=loss_pct
-    OvmsMetricVector<float> *mt_bms_cap;                     //!< BMS capacity values vector
-    OvmsMetricInt           *mt_bms_mileage;                 //!< Battery mileage (km)
-    OvmsMetricString        *mt_bms_voltage_state;           //!< Voltage State text
-    OvmsMetricVector<float> *mt_bms_cell_resistance;         //!< Cell resistances (mOhm)
-    OvmsMetricFloat         *mt_bms_nominal_energy;          //!< Nominal battery energy (kWh)
-    OvmsMetricInt           *mt_bms_HVcontactStateCode; //!< contactor state: 0 := OFF, 1 := PRECHARGE, 2 := ON
-    OvmsMetricString        *mt_bms_HVcontactStateTXT;  //!< contactor state text
-    OvmsMetricInt           *mt_bms_EVmode;             //!< Mode the EV is actually in: 0 = none, 1 = slow charge, 2 = fast charge, 3 = normal, 4 = Quick Drop, 5 = Cameleon (Non-Isolated Charging)
-    OvmsMetricString        *mt_bms_EVmode_txt;         //!< Mode the EV is actually in text
-    OvmsMetricBool          *mt_bms_interlock_hvplug;       //!< HV plug interlock
-    OvmsMetricBool          *mt_bms_interlock_service;      //!< Service disconnect interlock
-    OvmsMetricInt           *mt_bms_fusi_mode;              //!< FUSI mode code
-    OvmsMetricString        *mt_bms_fusi_mode_txt;          //!< FUSI mode text
-    OvmsMetricInt           *mt_bms_safety_mode;            //!< Safety mode code
-    OvmsMetricString        *mt_bms_safety_mode_txt;        //!< Safety mode text
+    OvmsMetricVector<float> *mt_bms_cap;                     // BMS capacity values vector
+    OvmsMetricInt           *mt_bms_mileage;                 // Battery mileage (km)
+    OvmsMetricString        *mt_bms_voltage_state;           // Voltage State text
+    OvmsMetricVector<float> *mt_bms_cell_resistance;         // Cell resistances (mOhm)
+    OvmsMetricFloat         *mt_bms_nominal_energy;          // Nominal battery energy (kWh)
+    OvmsMetricInt           *mt_bms_HVcontactStateCode;      // contactor state: 0 := OFF, 1 := PRECHARGE, 2 := ON
+    OvmsMetricString        *mt_bms_HVcontactStateTXT;       // contactor state text
+    OvmsMetricInt           *mt_bms_EVmode;                  // Mode the EV is actually in: 0 = none, 1 = slow charge, 2 = fast charge, 3 = normal, 4 = Quick Drop, 5 = Cameleon (Non-Isolated Charging)
+    OvmsMetricString        *mt_bms_EVmode_txt;              // Mode the EV is actually in text
+    OvmsMetricBool          *mt_bms_interlock_hvplug;        // HV plug interlock
+    OvmsMetricBool          *mt_bms_interlock_service;       // Service disconnect interlock
+    OvmsMetricInt           *mt_bms_fusi_mode;               // FUSI mode code
+    OvmsMetricString        *mt_bms_fusi_mode_txt;           // FUSI mode text
+    OvmsMetricInt           *mt_bms_safety_mode;             // Safety mode code
+    OvmsMetricString        *mt_bms_safety_mode_txt;         // Safety mode text
 
-    OvmsMetricVector<float> *mt_obl_main_amps;          //!< AC current of L1, L2, L3
-    OvmsMetricVector<float> *mt_obl_main_volts;         //!< AC voltage of L1, L2, L3
-    OvmsMetricVector<float> *mt_obl_main_CHGpower;      //!< Power of rail1, rail2 W (x/2) & max available kw (x/64)    
+    // --- Custom metrics: OBL (On-Board Loader / Charger) ---
+    OvmsMetricVector<float> *mt_obl_main_amps;          // AC current of L1, L2, L3
+    OvmsMetricVector<float> *mt_obl_main_volts;         // AC voltage of L1, L2, L3
+    OvmsMetricVector<float> *mt_obl_main_CHGpower;      // Power of rail1, rail2 W (x/2) & max available kw (x/64)
     OvmsMetricBool          *mt_obl_fastchg;            // 22kw fast charge enabled
     // OBL misc values: Index 0=freq, 1=ground_resistance, 2=max_current, 3=dc_current, 4=hf10kHz_current, 5=hf_current, 6=lf_current
-    OvmsMetricVector<float> *mt_obl_misc;               //!< OBL misc values vector
-    OvmsMetricString        *mt_obl_main_leakage_diag;                //!< Leakage diagnostic
+    OvmsMetricVector<float> *mt_obl_misc;               // OBL misc values vector
+    OvmsMetricString        *mt_obl_main_leakage_diag;  // Leakage diagnostic
 
-    OvmsMetricInt           *mt_obd_duration;           //!< obd duration
-    OvmsMetricInt           *mt_obd_mt_day_prewarn;     //!< Maintaince pre warning days
-    OvmsMetricInt           *mt_obd_mt_day_usual;       //!< Maintaince usual days
-    OvmsMetricInt           *mt_obd_mt_km_usual;        //!< Maintaince usual km
-    OvmsMetricString        *mt_obd_mt_level;           //!< Maintaince level
- 
+    // --- Custom metrics: OBD maintenance ---
+    OvmsMetricInt           *mt_obd_duration;           // obd duration
+    OvmsMetricInt           *mt_obd_mt_day_prewarn;     // Maintaince pre warning days
+    OvmsMetricInt           *mt_obd_mt_day_usual;       // Maintaince usual days
+    OvmsMetricInt           *mt_obd_mt_km_usual;        // Maintaince usual km
+    OvmsMetricString        *mt_obd_mt_level;           // Maintaince level
+
+    // --- Custom metrics: TPMS ---
     OvmsMetricVector<short> *mt_tpms_low_batt;          // 4 wheel low battery flags (0=ok, 1=low)
-    OvmsMetricVector<short> *mt_tpms_missing_tx;        // 4 wheel missing transmitter flags (0=ok, 1=missing)    
-    OvmsMetricFloat         *mt_dummy_pressure;         //!< Dummy pressure for TPMS
+    OvmsMetricVector<short> *mt_tpms_missing_tx;        // 4 wheel missing transmitter flags (0=ok, 1=missing)
+    OvmsMetricFloat         *mt_dummy_pressure;         // Dummy pressure for TPMS
 
-    OvmsMetricString        *mt_bcm_vehicle_state;      //!< vehicle state
-    OvmsMetricBool          *mt_driver_door_locked;     //!< Driver door locked status
-    
-  protected:
-    bool m_indicator;                       //!< activate indicator e.g. 7 times or whatever
-    bool m_ddt4all;                         //!< DDT4ALL mode
-    bool m_warning_unlocked;                //!< unlocked warning
-    bool m_warning_dooropen;                //!< open doors warning
-    bool m_modem_restart;                   //!< modem restart enabled
-    bool m_notifySOClimit;                  //!< notify SOClimit reached one time
-    bool m_enable_calcADCfactor;            //!< enable calculation of ADC factor
-    int m_adc_samples;                      //!< number of samples for ADC factor calculation
-    int m_ddt4all_ticker;                   //!< DDT4ALL active ticker 
-    int m_ddt4all_exec;                     //!< DDT4ALL ticker for next execution
-    int m_led_state;
-    int m_12v_ticker;
-    int m_modem_ticker;
-    int m_park_timeout_secs;                //!< parking timeout in seconds
-    int m_full_km;                          //!< full battery km value for SoC calculation
-    int m_cfg_preset_version;               //!< config preset version set in CommandPreset by defined PRESET_VERSION in top of this file
-    int m_suffsoc;                          //!< minimum SoC for charging
-    int m_suffrange;                        //!< minimum range for charging
-    bool m_obdii_745_tpms;                  //!< basic TPMS without temperature and low battery status
-    bool m_obdii_79b;                       //!< OBDII 79b mode enabled
-    bool m_obdii_79b_cell;                  //!< OBDII 79b cell V/R/T polling enabled
-    bool m_obdii_743;                       //!< OBDII 743 mode enabled
-    bool m_obdii_745;                       //!< OBDII 745 mode enabled
-    bool m_obdii_7e4;                       //!< OBDII 7e4 mode enabled
-    bool m_obdii_7e4_dcdc;                  //!< OBDII 7e4 dcdc mode enabled
-    bool m_poll_on_charge;                   //!< flag to trigger poll state change actions
+    // --- Custom metrics: BCM ---
+    OvmsMetricString        *mt_bcm_vehicle_state;      // vehicle state
+    OvmsMetricBool          *mt_driver_door_locked;     // Driver door locked status
 
-  protected:
-    poll_vector_t       m_poll_vector;              // List of PIDs to poll
-    int                 m_cfg_cell_interval_drv;    // poll interval while driving, default 60 sec.
-    int                 m_cfg_cell_interval_chg;    // poll interval while while charging, default 60 sec.
+    // --- Config-driven member variables ---
+    bool m_enable_write = false;            // canwrite enable write access
+    bool m_enable_write_caron = false;      // canwrite enable write access, only when car is on
+    bool m_can_active = false;              // true if CAN bus is in active mode, false if in listen-only mode
+    bool m_enable_LED_state;                // Online LED State
+    bool m_enable_lock_state;               // Lock State
+    bool m_enable_door_state;               // Door Open State
+    bool m_tpms_temp_enable;                // TPMS Temperature Display enabled
+    bool m_resettrip;                       // Reset Trip Values when Charging/Driving
+    bool m_resettotal;                      // Reset kWh/100km Values when Driving
+    bool m_tripnotify;                      // Trip Reset Notification on/off
+    bool m_bcvalue;                         // use kWh/100km Value from mt_use_at_reset = true, Calculated = false
+    bool m_tpms_alert_enable;               // TPMS Alert enabled
+    bool m_12v_charge;                      // 12V charge on/off
+    bool m_12v_charge_state;                // 12V charge state
+    bool m_extendedStats;                   // extended stats for trip and maintenance data
+    bool m_enable_calcADCfactor;            // enable calculation of ADC factor
+    int m_reboot_ticker;
+    int m_reboot_time;                      // Restart Network time
+    int m_TPMS_FL;                          // TPMS Sensor Front Left
+    int m_TPMS_FR;                          // TPMS Sensor Front Right
+    int m_TPMS_RL;                          // TPMS Sensor Rear Left
+    int m_TPMS_RR;                          // TPMS Sensor Rear Right
+    int m_park_timeout_secs;                // parking timeout in seconds
+    int m_full_km;                          // full battery km value for SoC calculation
+    int m_cfg_preset_version;               // config preset version set in CommandPreset by defined PRESET_VERSION in top of this file
+    int m_suffsoc;                          // minimum SoC for charging
+    int m_suffrange;                        // minimum range for charging
+    float m_front_pressure;                 // Front Tire Pressure
+    float m_rear_pressure;                  // Rear Tire Pressure
+    float m_pressure_warning;               // Pressure Warning
+    float m_pressure_alert;                 // Pressure Alert
+    std::string m_hl_canbyte;               // canbyte variable for unv
+    std::deque<float> m_adc_factor_history; // ring buffer (max 20) for ADC factors
+
+    // --- Internal state variables ---
+    bool m_indicator;                       // activate indicator e.g. 7 times or whatever
+    bool m_ddt4all = false;                 // DDT4ALL mode
+    bool m_warning_unlocked = false;        // unlocked warning
+    bool m_warning_dooropen = false;        // open doors warning
+    bool m_modem_restart = false;           // modem restart enabled
+    bool m_notifySOClimit = false;          // notify SOClimit reached one time
+    bool m_poll_on_charge = false;          // flag to trigger poll state change actions
+    int m_adc_samples = 5;                  // number of samples for ADC factor calculation
+    int m_ddt4all_ticker = 0;               // DDT4ALL active ticker
+    int m_ddt4all_exec = 0;                 // DDT4ALL ticker for next execution
+    int m_led_state = 4;                    // Online LED State: 0=off, 1=red, 2=green, 3=blue, 4=default (configurable)
+    int m_12v_ticker = 0;                   // ticker for 12V charge state check
+    int m_modem_ticker = 0;                 // ticker for modem restart
+
+    // --- OBDII polling flags ---
+    bool m_obdii_745_tpms;                  // basic TPMS without temperature and low battery status
+    bool m_obdii_79b;                       // OBDII 79b mode enabled
+    bool m_obdii_79b_cell;                  // OBDII 79b cell V/R/T polling enabled
+    bool m_obdii_743;                       // OBDII 743 mode enabled
+    bool m_obdii_745;                       // OBDII 745 mode enabled
+    bool m_obdii_7e4;                       // OBDII 7e4 mode enabled
+    bool m_obdii_7e4_dcdc;                  // OBDII 7e4 dcdc mode enabled
+
+    // --- Poll timing / list ---
+    int m_cfg_cell_interval_drv = 60;       // poll interval while driving, default 60 sec.
+    int m_cfg_cell_interval_chg = 60;       // poll interval while charging, default 60 sec.
+    poll_vector_t m_poll_vector;            // List of PIDs to poll
+
+  // =========================================================================
+  // private
+  // =========================================================================
+  private:
+    static OvmsVehicleSmartEQ* GetInstance(OvmsWriter* writer=NULL);
+    // ADC factor calculation is needed based on 12V reading, only check when car is on or charging to avoid false recalculations based on 12V drop when car is off
+    // activated only after reboot
+    bool m_check12vadc = true;
+
+    // --- Timer / counter variables ---
+    int m_candata_timer = -1;
+    int m_ADCfactor_recalc_timer = 2;     // countdown timer for ADC factor recalculation
+
+    // --- CAN frame intermediate variables (synced to StdMetrics by smartCAN2Metrics in Ticker1) ---
+    int can_gear = 0;                     // <0 = reverse, 0 = park/neutral, >0 = drive -- logic by vehicle.cpp events
+    bool can_awake = false;
+    bool can_locked = false;
+    bool can_hvac = false;
+    bool can_handbrake = false;
+    bool can_headlights = false;
+    bool can_door_fl = false;
+    bool can_door_fr = false;
+    bool can_door_rl = false;
+    bool can_door_rr = false;
+    bool can_door_trunk = false;
+    bool can_chargeport = false;
+    bool can_env_on = false;
+    bool can_charge_inprogress = false;
+    float can_cabintemp = 0.0f;
+    float can_bat_temp = 0.0f;
+    float can_bat_voltage = 0.0f;
+    float can_charge_climit = 0.0f;
+    float can_speed = 0.0f;
+    float can_odometer = 0.0f;
+    float can_bat_consumption = 0.0f;
+    float can_soc = 0.0f;
+    float can_range_est = 0.0f;
+    float can_range_full = 0.0f;
+    float can_range_ideal = 0.0f;
+    float can_soh = 0.0f;
+    float can_kwh_grid_total = 0.0f;
+    const char* can_bat_health = "";
+
+    // --- CAN data state ---
+    bool m_candata_poll = false;
+    bool m_charge_finished = true;
+    bool m_ADCfactor_recalc = false;      // request recalculation of ADC factor
+
+    // --- TPMS internal arrays ---
+    bool m_tpms_lowbatt[4] = {};          // 0=ok, 1=low
+    bool m_tpms_missing_tx[4] = {};       // 0=ok, 1=missing
+    float m_tpms_pressure[4] = {};        // kPa
+    float m_tpms_temperature[4] = {};     // °C
 };
 
-#endif //#ifndef __VEHICLE_SMARTED_H__
+#endif //#ifndef __VEHICLE_SMARTEQ_H__


### PR DESCRIPTION
The declarations and default values ​​of OvmsVehicleSmartEQ have been reorganized and cleaned up. PRESET_VERSION has been updated to 20260420, and the configuration defaults have been changed: canwrite.caron is now set to true. The declarations for metric and query handlers have been extended and reorganized, internal CAN status variables and ADC/TPMS buffers have been added, and the query/ticker-related members have been merged. Overall, minor formatting and comment improvements have been made.