### PR TITLE
vehicle_nissanleaf: ZE1 dashboard SOC and cabin temp parsers

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1443,10 +1443,25 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       break;
     case 0x54f:
       /* Climate control's measurement of temperature inside the car.
-       * Appears to be in Fahrenheit. Unsure why the check for 20?
-       * mjk: seeems like off by 6 celcius on 2013 models, so added cabintempoffset that can be set in GUI.
+       * AZE0 (2013-2017): Fahrenheit, may be off by ~6°C requiring xnl.cabintempoffset.
+       * ZE1 (2018+): half-degree Celsius with 40°C bias, same encoding as ambient temp
+       * on 0x54C byte 6 (which OVMS already parses correctly). Reverse-engineered Apr 2026
+       * by samr037 by comparing ZE1 captures at known cabin temps:
+       *   d[0]=0x72(114) -> 17°C   (matches today's ~18°C cabin)
+       *   d[0]=0x8C(140) -> 30°C   (matches Jul 2024 summer cabin)
+       *   d[0]=0x50(80)  -> 0°C    (sentinel/HVAC off — skipped)
+       * After this patch, xnl.cabintempoffset is unnecessary on ZE1.
        */
-      if (d[0] != 20)
+      if (cfg_ze1)
+        {
+        if (d[0] != 0x50 && d[0] != 20)  // skip sentinels
+          {
+          float cabin_c = d[0] / 2.0f - 40.0f;
+          if (cabin_c > -30.0f && cabin_c < 60.0f)
+            StandardMetrics.ms_v_env_cabintemp->SetValue(cabin_c);
+          }
+        }
+      else if (d[0] != 20)
         {
         StandardMetrics.ms_v_env_cabintemp->SetValue((5.0 / 9.0 * (d[0] - 32)) + MyConfig.GetParamValueFloat("xnl", "cabintempoffset", DEFAULT_CABINTEMP_OFFSET));
         // StandardMetrics.ms_v_env_cabintemp->SetValue(d[0] / 2.0 - 14);
@@ -1475,6 +1490,27 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       break;
     case 0x59e:
       {
+      // ZE1 (40/62 kWh): byte 7 = dashboard SOC (multiplier 0.5).
+      // Reverse-engineered Apr 2026 by samr037 by comparing two CAN captures
+      // taken on a 2018 ZE1 40kWh at known dashboard SOCs:
+      //   real ~59% / dash ~55%  -> byte 7 = 0x6E (110/2 = 55%)
+      //   real ~95% / dash 100%  -> byte 7 = 0xC8 (200/2 = 100%)
+      //   real ~81% / dash  86%  -> byte 7 = 0xAC (172/2 = 86%)
+      // This message previously had no parser for ZE1; xnl.v.b.soc.instrument
+      // was always 0 (Issue #323 long-standing gap).
+      if (cfg_ze1)
+        {
+        float instr_soc = d[7] / 2.0f;
+        if (instr_soc > 0.0f && instr_soc <= 100.0f)
+          {
+          m_soc_instrument->SetValue(instr_soc);
+          // If user opted out of newcar SOC, use dashboard SOC as the main metric:
+          if (!MyConfig.GetParamValueBool("xnl", "soc.newcar", false))
+            {
+            StandardMetrics.ms_v_bat_soc->SetValue(instr_soc);
+            }
+          }
+        }
       switch(m_battery_type->AsInt(BATTERY_TYPE_2_24kWh))
         {
         case BATTERY_TYPE_1_24kWh:


### PR DESCRIPTION
Closes long-standing gaps in Nissan Leaf ZE1 (2018+) support discussed
in Issue #323.

Both metrics existed but were broken on ZE1: instrument SOC was
permanently 0, cabin temp required a brittle `cabintempoffset`
workaround. The fixes below identify the correct CAN frames/encoding
for ZE1 specifically. AZE0 (2013-2017) codepaths are preserved
unchanged behind `if (cfg_ze1) ... else ...`.

1. Dashboard SOC (xnl.v.b.soc.instrument):
   The existing parser reads from frame 0x1DB byte 4, which is always
   0 on ZE1 (different message format than AZE0). The metric stayed
   at 0% and the `xnl.soc.newcar=no` config option had no effect on
   ZE1.

   This patch adds parsing for frame 0x59E byte 7 which carries the
   dashboard SOC * 2 on ZE1 (40/62 kWh batteries). The OVMS code
   already had a `case 0x59e:` branch for 24kWh battery capacity
   (bytes 2-3), but byte 7 was never read and for ZE1
   (BATTERY_TYPE_2_40kWh) the entire branch was effectively unused.

   Reverse-engineered by comparing CAN captures at known dashboard
   SOCs:
     real ~59% / dash ~55%  -> byte 7 = 0x6E (110/2 = 55%)
     real ~95% / dash 100%  -> byte 7 = 0xC8 (200/2 = 100%)
     real ~81% / dash  86%  -> byte 7 = 0xAC (172/2 = 86%)

   When `cfg_ze1==true`, sets `m_soc_instrument` from `d[7]/2.0`. If
   user has `xnl.soc.newcar=false`, also drives main `v.b.soc` so
   reported SOC matches the dashboard.

2. Cabin temperature:
   The existing parser reads 0x54F byte 0 as Fahrenheit, which is
   correct for AZE0 (2013-2017). On ZE1 (2018+) Nissan switched to
   half-degree Celsius with a 40°C bias — the same encoding that
   OVMS already correctly parses for ambient temperature on 0x54C
   byte 6. Without this patch, ZE1 owners need a `cabintempoffset`
   workaround (typically -30°C+) which is brittle across temperature
   ranges and only "looks right" at one operating point.

   Verified from ZE1 captures:
     d[0]=0x72 (114) -> 17°C  (matches today's ~18°C cabin)
     d[0]=0x8C (140) -> 30°C  (matches Jul 2024 summer cabin)
     d[0]=0x50 (80)  -> 0°C   (sentinel/HVAC off — skipped)

   After this patch, ZE1 owners can safely remove
   `xnl.cabintempoffset` (config rm xnl cabintempoffset).

Refs: #323 (40kWh ZE1 support thread, open since 2020)