### PR TITLE
Nissan Leaf: stop OVMS timed climate control

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -1433,7 +1433,13 @@ OvmsVehicle::vehicle_command_t OvmsVehicle::CommandCooldown(bool cooldownon)
   }
 
 OvmsVehicle::vehicle_command_t OvmsVehicle::CommandClimateControl(bool enable)
-  {
+  { 
+  if (!enable)
+    {
+    // stops the scheduled climate restart
+    m_climate_restart = false;
+    m_climate_restart_ticker = 0;
+    }
 #ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE
   if (MyDuktape.DukTapeAvailable())
     {

--- a/vehicle/OVMS.V3/components/vehicle_boltev/src/va_ac_preheat.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_boltev/src/va_ac_preheat.cpp
@@ -408,7 +408,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleBoltEV::CommandClimateControl(bool ena
 {
 #ifdef CONFIG_OVMS_COMP_EXTERNAL_SWCAN
     ESP_LOGW(TAG,"<------ REMOTE CLIMATE CONTROL: %d (Preheat Status: %s) ------>", enable, PreheatStatus() );
-
+    if (!enable)
+        { // stops the scheduled climate restart
+        m_climate_restart = false;
+        m_climate_restart_ticker = 0;
+        }
     if ( ((mt_preheat_status->AsInt()!=VA_PREHEAT_STARTED) && (enable)) ||
             ((mt_preheat_status->AsInt()!=VA_PREHEAT_STOPPED) && (!enable) )  ) {
         if (enable) {

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -2654,8 +2654,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleNissanLeaf::CommandClimateControl(bool
   {
   ESP_LOGI(TAG, "CommandClimateControl");
   if (!climatecontrolon)
-    {
-    // stops the scheduled climate restart
+    { // stops the scheduled climate restart
     m_climate_restart = false;
     m_climate_restart_ticker = 0;
     }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -2655,6 +2655,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleNissanLeaf::CommandClimateControl(bool
   ESP_LOGI(TAG, "CommandClimateControl");
   if (!climatecontrolon)
     {
+    // stops the scheduled climate restart
     m_climate_restart = false;
     m_climate_restart_ticker = 0;
     }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -2653,6 +2653,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleNissanLeaf::CommandHomelink(int button
 OvmsVehicle::vehicle_command_t OvmsVehicleNissanLeaf::CommandClimateControl(bool climatecontrolon)
   {
   ESP_LOGI(TAG, "CommandClimateControl");
+  if (!climatecontrolon)
+    {
+    m_climate_restart = false;
+    m_climate_restart_ticker = 0;
+    }
   return RemoteCommandHandler(climatecontrolon ? ENABLE_CLIMATE_CONTROL : DISABLE_CLIMATE_CONTROL);
   }
 

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/rz_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/rz_commands.cpp
@@ -82,11 +82,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleRenaultZoe::CommandClimateControl(bool
       m_climate_restart_ticker = 0;
       m_climate_restart = false;
       }
-    else
-      {  // There is a equvivalent command to stop pre-conditioning but HVAC wont stop, so probably not coded in the ECUs
-      ESP_LOGW(TAG, "Stop CommandClimateControl not possible, Zoe doesnt support it");
-      MyNotify.NotifyString("error", "climate.control", "Stop CommandClimateControl not possible, Zoe doesnt support it");
-      }
     res = NotImplemented;
   }
   // fallback to default implementation?

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/rz_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/rz_commands.cpp
@@ -76,12 +76,19 @@ OvmsVehicle::vehicle_command_t OvmsVehicleRenaultZoe::CommandClimateControl(bool
     }
     res = Success;
   } else {
-    res = NotImplemented;
-  }
-
-  // fallback to default implementation?
-  if (res == NotImplemented) {
-    res = OvmsVehicle::CommandClimateControl(climatecontrolon);
+    if (m_climate_restart) 
+      {  // stops the scheduled climate restart
+      MyNotify.NotifyString("info", "climatecontrol.schedule", "Climate control restarting stopped!");
+      m_climate_restart_ticker = 0;
+      m_climate_restart = false; 
+      res =  Success;
+      }
+    else
+      {  // There is a equvivalent command to stop pre-conditioning but HVAC wont stop, so probably not coded in the ECUs
+      ESP_LOGW(TAG, "Stop CommandClimateControl not possible, Zoe doesnt support it");
+      MyNotify.NotifyString("error", "climate.control", "Stop CommandClimateControl not possible, Zoe doesnt support it");
+      res = Fail;
+      }
   }
   return res;
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/rz_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/rz_commands.cpp
@@ -80,15 +80,18 @@ OvmsVehicle::vehicle_command_t OvmsVehicleRenaultZoe::CommandClimateControl(bool
       {  // stops the scheduled climate restart
       MyNotify.NotifyString("info", "climatecontrol.schedule", "Climate control restarting stopped!");
       m_climate_restart_ticker = 0;
-      m_climate_restart = false; 
-      res =  Success;
+      m_climate_restart = false;
       }
     else
       {  // There is a equvivalent command to stop pre-conditioning but HVAC wont stop, so probably not coded in the ECUs
       ESP_LOGW(TAG, "Stop CommandClimateControl not possible, Zoe doesnt support it");
       MyNotify.NotifyString("error", "climate.control", "Stop CommandClimateControl not possible, Zoe doesnt support it");
-      res = Fail;
       }
+    res = NotImplemented;
+  }
+  // fallback to default implementation?
+  if (res == NotImplemented) {
+    res = OvmsVehicle::CommandClimateControl(climatecontrolon);
   }
   return res;
 }

--- a/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2/src/rz2_commands_vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_renaultzoe_ph2/src/rz2_commands_vehicle.cpp
@@ -136,10 +136,19 @@ OvmsVehicle::vehicle_command_t OvmsVehicleRenaultZoePh2::CommandClimateControl(b
     }
     else
     {
-        // There is a equvivalent command to stop pre-conditioning but HVAC wont stop, so probably not coded in the ECUs
-        ESP_LOGW(TAG, "Stop CommandClimateControl not possible, Zoe doesnt support it");
-        MyNotify.NotifyString("error", "climate.control", "Stop CommandClimateControl not possible, Zoe doesnt support it");
-        res = Fail;
+        if (m_climate_restart) 
+        {   // stops the scheduled climate restart
+            MyNotify.NotifyString("info", "climatecontrol.schedule", "Climate control restarting stopped!");
+            m_climate_restart_ticker = 0;
+            m_climate_restart = false; 
+            res =  Success;
+        }
+        else
+        {   // There is a equvivalent command to stop pre-conditioning but HVAC wont stop, so probably not coded in the ECUs
+            ESP_LOGW(TAG, "Stop CommandClimateControl not possible, Zoe doesnt support it");
+            MyNotify.NotifyString("error", "climate.control", "Stop CommandClimateControl not possible, Zoe doesnt support it");
+            res = Fail;
+        }
     }
 
     return res;

--- a/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarted/src/ed_commands.cpp
@@ -409,6 +409,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartED::CommandWakeup() {
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartED::CommandClimateControl(bool enable) {
+  if (!enable)
+    { // stops the scheduled climate restart
+    m_climate_restart = false;
+    m_climate_restart_ticker = 0;
+    }
   time_t rawtime;
   time ( &rawtime );
   rawtime += m_preclima_time*60; // add 15 minutes

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -41,9 +41,18 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
 
   if(!enable) // HVAC OFF not implemented by vehicle
     {
-    m_climate_restart_ticker = 0;
-    m_climate_restart = false; 
-    return NotImplemented;
+    if (m_climate_restart) 
+      { // stops the scheduled climate restart
+      MyNotify.NotifyString("info", "climatecontrol.schedule", "Climate control restarting stopped!");
+      m_climate_restart_ticker = 0;
+      m_climate_restart = false; 
+      return Success;
+      }
+    else 
+      {
+      MyNotify.NotifyString("error", "climatecontrol.schedule", "Climate control stop not possible, EQ doesnt support it");
+      return NotImplemented;
+      }
     }
 
   if (StandardMetrics.ms_v_bat_soc->AsInt(0) < 31)

--- a/vehicle/OVMS.V3/components/vehicle_voltampera/src/va_ac_preheat.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_voltampera/src/va_ac_preheat.cpp
@@ -478,7 +478,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVoltAmpera::CommandClimateControl(bool
   {
 #ifdef CONFIG_OVMS_COMP_EXTERNAL_SWCAN
   ESP_LOGW(TAG,"<------ REMOTE CLIMATE CONTROL: %d (Preheat Status: %s) ------>", enable, PreheatStatus() );
-
+  if (!enable)
+    { // stops the scheduled climate restart
+    m_climate_restart = false;
+    m_climate_restart_ticker = 0;
+    }
   if ( ((mt_preheat_status->AsInt()!=VA_PREHEAT_STARTED) && (enable)) || 
        ((mt_preheat_status->AsInt()!=VA_PREHEAT_STOPPED) && (!enable) )  )
     {

--- a/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vweup/src/vweup_t26.cpp
@@ -1579,6 +1579,11 @@ void OvmsVehicleVWeUp::CCTempSet(int temperature)
 OvmsVehicle::vehicle_command_t OvmsVehicleVWeUp::CommandClimateControl(bool climatecontrolon)
 {
   ESP_LOGD(TAG, "T26: CommandClimateControl called");
+  if (!climatecontrolon)
+    { // stops the scheduled climate restart
+    m_climate_restart = false;
+    m_climate_restart_ticker = 0;
+    }
   if (HasNoT26() || !IsT26Ready() || !vweup_enable_write) {
       ESP_LOGE(TAG, "T26: CommandClimateControl failed: T26 not ready / no write access!");
       MyNotify.NotifyString("alert", "Climatecontrol", "Climatecontrol failed: CAN bus not ready / no write access!");


### PR DESCRIPTION
Added variables to CommandClimateControl to terminate time-controlled climate control when the user wishes to stop it manually.

#1394 