### PR TITLE
Kconfig: MAXT90 depends on OVMS_VEHICLE_OBDII

### DIFF
--- a/vehicle/OVMS.V3/main/Kconfig
+++ b/vehicle/OVMS.V3/main/Kconfig
@@ -370,6 +370,7 @@ config OVMS_VEHICLE_NONE
 config OVMS_VEHICLE_MAXT90
     bool "Maxus T90 EV (MT90)"
     default y
+    depends on OVMS_VEHICLE_OBDII
     help
       Enable to include support for Maxus T90 EV.
 


### PR DESCRIPTION
`OvmsVehicleMaxt90` subclasses `OvmsVehicleOBDII` and includes `vehicle_obdii.h`, but the MAXT90 Kconfig didn't declare the dependency. Building with `CONFIG_OVMS_VEHICLE_MAXT90=y` and OBDII unset fails with `fatal error: vehicle_obdii.h: No such file or directory`.

`depends on OVMS_VEHICLE_OBDII` makes MAXT90 only selectable when OBDII is enabled, matching the convention used by the other vehicle Kconfig entries.

Fixes #1397.

## Test plan
- [x] sdkconfig with MAXT90=y and OBDII unset: MAXT90 is dropped on `make oldconfig`; build succeeds.
- [x] Default `sdkconfig.default.hw31`: build still succeeds.
- [x] In `make menuconfig`: MAXT90 only listed when OBDII is enabled.