### PR TITLE
fix(mcp2515): persist acceptance filter across power cycles

### DIFF
--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -273,6 +273,14 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
   // And record that we are powered on
   pcp::SetPowerMode(On);
 
+  // Re-apply acceptance filter if one was configured — Start() resets RXMODE to 3
+  // (receive all), which would bypass the hardware filter on every power cycle.
+  if (m_filter_set)
+    {
+    if (SetAcceptanceFilter(m_filter_cfg) != ESP_OK)
+      ESP_LOGE(TAG, "%s: failed to restore acceptance filter after start", this->GetName());
+    }
+
   return ESP_OK;
   }
 
@@ -381,12 +389,23 @@ esp_err_t mcp2515::SetAcceptanceFilter(const mcp2515_filter_config_t& cfg)
     cfg.mask[0].u8[3], cfg.mask[0].u8[2], cfg.mask[0].u8[1],cfg.mask[0].u8[0],
     cfg.mask[1].u8[3], cfg.mask[1].u8[2], cfg.mask[1].u8[1],cfg.mask[1].u8[0]);
 
+  // Set RXMODE=0 (filter-matched receive) on both RX buffers.
+  // Start() hardcodes RXB0CTRL RXMODE=3 (receive all) for backwards compatibility,
+  // which silently bypasses the acceptance filters.  Switch to filtered mode now that
+  // filters are configured.  BUKT (rollover) bit in RXB0CTRL is preserved via mask.
+  // With mask=0 (all bits don't-care) every frame still matches, so callers that pass
+  // all-zero masks get the same promiscuous behaviour as before.
+  m_spibus->spi_cmd(m_spi, buf, 0, 4, CMD_BITMODIFY, REG_RXB0CTRL, 0b01100000, 0b00000000);
+  m_spibus->spi_cmd(m_spi, buf, 0, 4, CMD_BITMODIFY, REG_RXB1CTRL, 0b01100000, 0b00000000);
+
   // Exit config mode
   if (prev_mode != CANCTRL_MODE_CONFIG && ChangeMode(prev_mode) != ESP_OK)
     {
     return ESP_FAIL;
     }
 
+  m_filter_cfg = cfg;
+  m_filter_set = true;
   return ESP_OK;
   }
 

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
@@ -110,6 +110,8 @@ class mcp2515 : public canbus
     int m_intpin;
     uint8_t m_last_errflag = 0;
     uint8_t m_canctrl_mode;
+    bool m_filter_set = false;
+    mcp2515_filter_config_t m_filter_cfg = {};
     OvmsMutex m_write_mutex;
     OvmsCommand* m_cmd_canx;
   };

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515_regdef.h
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515_regdef.h
@@ -115,6 +115,7 @@
 #define REG_TXB1CTRL            0x40
 #define REG_TXB2CTRL            0x50
 #define REG_RXB0CTRL            0x60
+#define REG_RXB1CTRL            0x70
 
 #define MCP2515_TIMEOUT         100           // Timeout for register verification, in milliseconds
 


### PR DESCRIPTION
## Problem

`SetAcceptanceFilter()` correctly writes filter registers and sets RXMODE, but
the configuration is lost on every power cycle. `Start()` hardcodes RXMODE=3
(receive-all) in RXB0CTRL/RXB1CTRL, silently bypassing any previously
configured hardware filter after `SetPowerMode(On)` or ignition cycles.

This means vehicles that configure an acceptance filter (e.g. to drop
high-frequency frames that would otherwise saturate the ISR and starve the
Events task) get no filtering in practice — the filter only holds until the
next power-mode transition.

Observed symptom on VW e-Golf / J533 harness: CAN2 (FCAN) runs ~860 fps
during OBC charging. Without a working filter, all frames reach the ISR →
Events task starved → TWDT reset loop → module reboots continuously during
charging.

## Fix

Three changes:

1. **Persist filter config**: `SetAcceptanceFilter()` stores the config in
   `m_filter_cfg` / `m_filter_set` after successfully writing registers.

2. **Re-apply on `Start()`**: After init, if a filter was previously
   configured, `SetAcceptanceFilter()` is called again to restore RXMODE.
   A log error is emitted if the restore fails.

3. **Add missing `REG_RXB1CTRL` define** (0x70): was absent from
   `mcp2515_regdef.h`; `SetAcceptanceFilter()` was setting RXMODE only on
   RXB0 as a result.

## Compatibility

Callers that never call `SetAcceptanceFilter()` are unaffected — `m_filter_set`
defaults to false, so `Start()` takes no new action. Callers that pass
all-zero masks continue to receive all frames (RXMODE=0 with an all-pass
mask is equivalent to RXMODE=3).

NIU GTevo has `SetAcceptanceFilter()` commented out — no impact.

## Known limitation (follow-up)

The filter is re-applied **after** `Start()` has already transitioned the
chip out of CONFIG mode and called `pcp::SetPowerMode(On)`. During the brief
window between mode-change and re-apply (typically <20 ms), the chip is in
NORMAL/LISTEN mode with RXMODE=3, so unfiltered frames will reach the ISR.
On a hot bus this can still produce a short ISR burst on every restart.

A cleaner fix would write the filter registers while still in CONFIG mode
during `Start()`, eliminating the window entirely. That refactor (probably
a `_locked` variant of `SetAcceptanceFilter` callable from `Start`) is left
as a follow-up so this PR stays focused on the persistence bug.