### PR TITLE
fix(vwegolf): move FCAN BMS decode to IncomingFrameCan2 + hardware filter

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/CMakeLists.txt
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/CMakeLists.txt
@@ -9,5 +9,5 @@ endif ()
 # requirements can't depend on config
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS ${include_dirs}
-                       PRIV_REQUIRES "main"
+                       PRIV_REQUIRES "main" "mcp2515"
                        WHOLE_ARCHIVE)

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -28,6 +28,7 @@
 
 // #include <stdio.h>
 #include "vehicle_vwegolf.h"
+#include "mcp2515.h"
 
 #undef TAG
 #define TAG "v-vwegolf"
@@ -49,6 +50,41 @@ OvmsVehicleVWeGolf::OvmsVehicleVWeGolf() {
     // even though rxerr/txerr stay at zero. Listen-only eliminates this entirely.
     RegisterCanBus(2, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);  // FCAN — powertrain (read-only)
     RegisterCanBus(3, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);  // KCAN — comfort / clima
+
+    // Hardware acceptance filter on FCAN (CAN2): during OBC charging the bus runs at ~860 fps.
+    // Without filtering all frames reach the ISR, starving the Events task → TWDT resets.
+    // Pass only the 5 frame IDs we decode; everything else is dropped in hardware.
+    //
+    // MCP2515 filter table layout:
+    //   - RXB0 uses mask[0] applied to filter[0..1]   (2 filter slots)
+    //   - RXB1 uses mask[1] applied to filter[2..5]   (4 filter slots)
+    //   The chip has no "disable slot" flag, so unused RXB1 slots must be set to a
+    //   value that matches one of the wanted IDs (slot 5 mirrors slot 4 below).
+    //
+    // Filter ID encoding: SetAcceptanceFilter writes the .u32 field as register bytes
+    // SIDH/SIDL/EID8/EID0. The standard 11-bit ID maps as SID[10:3] → SIDH (bits 24..31),
+    // SID[2:0] → SIDL[7:5] (bits 21..23). Hence the mcp_sid() helper below.
+    if (m_can2 != nullptr) {
+        auto mcp_sid = [](uint16_t sid) -> uint32_t {
+            return (static_cast<uint32_t>(sid >> 3) << 24) |
+                   (static_cast<uint32_t>(sid & 0x7) << 21);
+        };
+        mcp2515_filter_config_t f = {};
+        // RXB0: full 11-bit match on the two slots
+        f.mask[0].u32   = mcp_sid(0x7FF);
+        f.filter[0].u32 = mcp_sid(0x131);   // BMS SoC
+        f.filter[1].u32 = mcp_sid(0x187);   // gear selector
+        // RXB1: full 11-bit match on the four slots
+        f.mask[1].u32   = mcp_sid(0x7FF);
+        f.filter[2].u32 = mcp_sid(0x191);   // BMS current/voltage
+        f.filter[3].u32 = mcp_sid(0x2AF);   // trip energy
+        f.filter[4].u32 = mcp_sid(0x6B4);   // VIN
+        f.filter[5].u32 = mcp_sid(0x6B4);   // duplicate — RXB1 has no unused-slot flag
+        if (static_cast<mcp2515*>(m_can2)->SetAcceptanceFilter(f) != ESP_OK)
+            ESP_LOGE(TAG, "FCAN acceptance filter setup failed — all frames will reach ISR");
+    } else {
+        ESP_LOGE(TAG, "CAN2 not registered — cannot install FCAN acceptance filter");
+    }
 
     OvmsCommand* cmd_vweg = MyCommandApp.RegisterCommand("xvg", "VW e-Golf controls");
     cmd_vweg->RegisterCommand("offline", "Stop sending OCU keepalive", [this](...) {
@@ -75,7 +111,42 @@ OvmsVehicleVWeGolfInit::OvmsVehicleVWeGolfInit() {
 }
 
 void OvmsVehicleVWeGolf::IncomingFrameCan2(CAN_frame_t* p_frame) {
+    const uint8_t* d = p_frame->data.u8;
+
     switch (p_frame->MsgID) {
+        case 0x131: {
+            // State of charge. d[3] * 0.5%. 0xFE is the "not ready" sentinel (127%) — discard it.
+            if (d[3] == 0xFE) break;
+            float soc = d[3] * 0.5f;
+            StandardMetrics.ms_v_bat_soc->SetValue(soc);
+            ESP_LOGV(TAG, "0x0131 soc=%.1f%%", soc);
+            break;
+        }
+        case 0x191: {
+            // BMS current and voltage; power is derived.
+            // d[2]==0xFF is the startup sentinel (all-ones → ~2047A, ~1023V) — discard it.
+            if (d[2] == 0xFF) break;
+            // Current: 12-bit, factor 1 A, offset -2047 A.
+            uint16_t raw_i = ((uint16_t)(d[1] & 0xF0) >> 4) | ((uint16_t)(d[2]) << 4);
+            float current = raw_i * 1.0f - 2047.0f;
+            StandardMetrics.ms_v_bat_current->SetValue(current);
+            // Voltage: 12-bit, factor 0.25 V.
+            uint16_t raw_v = (uint16_t)(d[3]) | ((uint16_t)(d[4] & 0x0F) << 8);
+            float voltage = raw_v * 0.25f;
+            StandardMetrics.ms_v_bat_voltage->SetValue(voltage);
+            // Power: negative = charging, positive = driving.
+            StandardMetrics.ms_v_bat_power->SetValue(-(voltage * current) / 1000.0f);
+            ESP_LOGV(TAG, "0x0191 I=%.1fA V=%.2fV", current, voltage);
+            break;
+        }
+        case 0x2AF: {
+            // Trip energy counters. 15-bit, factor 10 Ws → kWh.
+            uint16_t raw_recd = (uint16_t)(d[4]) | ((uint16_t)(d[5] & 0x7F) << 8);
+            StandardMetrics.ms_v_bat_energy_recd->SetValue(raw_recd * 10.0f / 3600000.0f);
+            uint16_t raw_used = (uint16_t)(d[6]) | ((uint16_t)(d[7] & 0x7F) << 8);
+            StandardMetrics.ms_v_bat_energy_used->SetValue(raw_used * 10.0f / 3600000.0f);
+            break;
+        }
         case 0x187: {
             const uint8_t gear_nibble = p_frame->data.u8[2] & 0x0F;
             ESP_LOGV(TAG, "0x187 gear nibble=%d", gear_nibble);
@@ -132,9 +203,6 @@ void OvmsVehicleVWeGolf::IncomingFrameCan2(CAN_frame_t* p_frame) {
             break;
         }
     }
-    // J533 bridges KCAN traffic onto CAN2; forward every frame so the KCAN
-    // decoder in IncomingFrameCan3 can process it regardless of which bus it arrives on.
-    IncomingFrameCan3(p_frame);
 }
 
 void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
@@ -165,47 +233,13 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
         }
         case 0x131:  // State of charge. d[3] * 0.5%. 0xFE = "not ready" sentinel (127%).
         {
+            // BMS-native frame on FCAN (CAN2) but also bridged by J533 onto KCAN.
+            // Decoded here as well so SoC continues to update on bus paths where
+            // the FCAN-side decode is unavailable (observed on CCS DC sessions).
             if (d[3] == 0xFE) break;
             tmp_f32 = ((float)d[3]) * 0.5F;
             StandardMetrics.ms_v_bat_soc->SetValue(tmp_f32);
             ESP_LOGV(TAG, "0x0131 soc=%.1f%%", tmp_f32);
-            break;
-        }
-        case 0x191:  // BMS current, voltage, power.
-        {
-            // Startup sentinel: d[2]=0xFF decodes to I=2047 A and V=1023.5 V. Discard it.
-            if (d[2] == 0xFF) break;
-
-            // Current: 12-bit, factor 1 A, offset -2047 A.
-            tmp_u16 = ((uint16_t)(d[1] & 0xf0) >> 4) | ((uint16_t)(d[2]) << 4);
-            tmp_f32 = ((float)tmp_u16) * 1.0F - 2047.0F;
-            StandardMetrics.ms_v_bat_current->SetValue(tmp_f32);
-
-            // Voltage: 12-bit, factor 0.25 V.
-            tmp_u16 = ((uint16_t)(d[3])) | ((uint16_t)(d[4] & 0xf) << 8);
-            tmp_f32 = ((float)tmp_u16) * 0.25F;
-            StandardMetrics.ms_v_bat_voltage->SetValue(tmp_f32);
-
-            // Power: negative = charging, positive = driving.
-            tmp_f32 = -1.0F * (StandardMetrics.ms_v_bat_voltage->AsFloat() *
-                               StandardMetrics.ms_v_bat_current->AsFloat()) / 1000.0F;
-            StandardMetrics.ms_v_bat_power->SetValue(tmp_f32);
-            ESP_LOGV(TAG, "0x0191 I=%.1fA V=%.2fV", StandardMetrics.ms_v_bat_current->AsFloat(),
-                     StandardMetrics.ms_v_bat_voltage->AsFloat());
-            break;
-        }
-        case 0x2AF:  // Trip energy counters. 15-bit, factor 10 Ws → kWh.
-        {
-            // Regen energy: d[4] + d[5] bits [6:0]. Max raw 32767 * 10 = 327670 Ws.
-            tmp_f32 = (float)(d[4] | ((uint16_t)(d[5] & 0x7f) << 8)) * 10.0F / 3600000.0F;
-            StandardMetrics.ms_v_bat_energy_recd->SetValue(tmp_f32);
-
-            // Consumed energy: d[6] + d[7] bits [6:0].
-            tmp_f32 = (float)(d[6] | ((uint16_t)(d[7] & 0x7f) << 8)) * 10.0F / 3600000.0F;
-            StandardMetrics.ms_v_bat_energy_used->SetValue(tmp_f32);
-            ESP_LOGV(TAG, "0x02AF recd=%.4f used=%.4f kWh",
-                     StandardMetrics.ms_v_bat_energy_recd->AsFloat(),
-                     StandardMetrics.ms_v_bat_energy_used->AsFloat());
             break;
         }
         // case 0x3D6: //Ladezustand

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mcp2515.h
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mcp2515.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "can.h"
+
+typedef struct {
+    union { struct { unsigned eid:18; unsigned :3; unsigned sid:11; } b; uint32_t u32; uint8_t u8[4]; } mask[2];
+    union { struct { unsigned eid:18; unsigned :1; unsigned exide:1; unsigned :1; unsigned sid:11; } b; uint32_t u32; uint8_t u8[4]; } filter[6];
+} mcp2515_filter_config_t;
+
+class mcp2515 : public canbus {
+public:
+    int SetAcceptanceFilter(const mcp2515_filter_config_t&) { return 0; }
+};


### PR DESCRIPTION
## Depends on

PR #1403 — `fix(mcp2515): persist acceptance filter across power cycles`.
The hardware filter configured here is only effective with that fix present;
without it `Start()` silently reverts RXMODE to receive-all on every power cycle.

## Problem

The initial e-Golf module routed all CAN2 (FCAN) frames into `IncomingFrameCan3`
via a blanket forwarding call at the end of `IncomingFrameCan2`. This caused
two issues:

1. **TWDT crash loop during OBC charging**: CAN2 runs at ~860 fps when the OBC
   is active. Without a hardware filter all frames hit the MCP2515 ISR, starving
   the Events task and triggering a watchdog reset. The module reboots, loads a
   stale persisted SoC, and the cycle repeats for the entire charge session.

2. **False KCAN-idle detection**: The forwarding call made every FCAN frame appear
   to arrive on CAN3, resetting the KCAN idle counter even when the comfort bus
   was genuinely quiet (e.g. during sleep or charging).

## Fix

- **Hardware filter on CAN2**: Configure the MCP2515 acceptance filter to pass
  only the 5 frame IDs decoded from FCAN (`0x131`, `0x187`, `0x191`, `0x2AF`,
  `0x6B4`). All other frames are rejected in hardware before reaching the RX
  buffers. The chip pointer is null-checked before the static_cast; an error
  is logged if CAN2 registration failed.

- **Move BMS decode to `IncomingFrameCan2`**: `0x191` (current/voltage/power)
  and `0x2AF` (trip energy) are FCAN-native and only ever arrive on CAN2.
  Their handlers are moved out of `IncomingFrameCan3` entirely.

- **Keep `0x131` (SoC) on both buses**: The J533 gateway bridges the BMS SoC
  frame onto KCAN. The KCAN-side handler is retained so SoC continues to
  update on bus paths where the FCAN-side decode is unavailable (observed
  on CCS DC fast-charge sessions).

- **Remove blanket forwarding**: The `IncomingFrameCan3(p_frame)` call at the
  end of `IncomingFrameCan2` is removed.

- **CMakeLists**: add `mcp2515` to `PRIV_REQUIRES`.

- **Native test mock**: add `mcp2515.h` stub so the laptop test build compiles.

## Validation

- On-car drive capture: SoC tracks monotonically 99.0 → 95.0 % over 607 s
  with the FCAN filter active; no TWDT resets observed.
- Hardware filter confirmed working: one charge session logged 413,070 OBC
  frames rejected by the MCP2515 before reaching the ISR.
- Native test suite: 28/28 tests pass.