### PR TITLE
Allow setting BMS values with DBC / Duktape Polling

### DIFF
--- a/docs/source/userguide/scripting.rst
+++ b/docs/source/userguide/scripting.rst
@@ -1012,6 +1012,24 @@ The OvmsVehicle object is the most comprehensive, and exposes several methods to
 - ``result = OvmsVehicle.ObdRequest(arguments)``
     Perform OBD/UDS request (synchronous)
 
+- ``OvmsVehicle.BMS.VoltageSetCellArrangement( readings, readingspermodule)``
+    Set the Voltage Cell Arrangement
+
+- ``OvmsVehicle.BMS.VoltageSetCellDefaultThresholds(warn, alert [, max_grad] [, max_std_dev])``
+- ``OvmsVehicle.BMS.VoltageSetCellLimits(float min, float max)``
+- ``OvmsVehicle.BMS.VoltageSetCell(int index, float value)``
+- ``OvmsVehicle.BMS.VoltageResetCells( [full] )``
+- ``OvmsVehicle.BMS.VoltagesRestartCell()``
+
+- ``OvmsVehicle.BMS.TemperatureSetCellArrangement( readings, readingspermodule)``
+    Set the Temperature Cell Arrangement
+
+- ``OvmsVehicle.BMS.TemperatureSetCellDefaultThresholds(warn, alert)``
+- ``OvmsVehicle.BMS.TemperatureSetCellLimits(min, max)``
+- ``OvmsVehicle.BMS.TemperatureSetCell(index, value)``
+- ``OvmsVehicle.BMS.TemperatureResetCells([full])``
+- ``OvmsVehicle.BMS.TemperatureRestartCells()``
+
     Pass the request parameters using the ``arguments`` object:
 
     - ``txid``: the CAN ID to send the request to (or 0x7df for broadcast)

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,7 +1,24 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
-- DukTape: Support for BMS Management and arrays as BMS/Scripted Poller metric pseudo targets.
+- DBC: Support for BMS Management and arrays as DBC (and Scripted Poller) metric pseudo targets.
+    bms.v.r.0   -- Reset voltage BMS metrics and store BMS voltage[0]
+    bms.v.1     -- Store BMS voltage[1]
+    bms.t.1     -- Store BMS temperature[1]
+- DukTape: Support for BMS Management
+  Add OvmsVehicle.BMS methods:
+    VoltageSetCellArrangement
+    VoltageSetCellDefaultThresholds
+    VoltageSetCellLimits
+    VoltageSetCell
+    VoltageResetCells
+    VoltagesRestartCell
+    TemperatureSetCellArrangement
+    TemperatureSetCellDefaultThresholds
+    TemperatureSetCellLimits
+    TemperatureSetCell
+    TemperatureResetCells
+    TemperatureRestartCells
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,7 +1,7 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
-
+- DukTape: Support for BMS Management and arrays as BMS/Scripted Poller metric pseudo targets.
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.cpp
@@ -599,6 +599,87 @@ metric_unit_t dbcOvmsMetric::DefaultUnit() const
   }
 
 ////////////////////////////////////////////////////////////////////////
+// dbcOvmsMetricIndex
+//
+dbcOvmsMetricIndex::dbcOvmsMetricIndex(OvmsMetric *metric, int16_t index)
+  : m_metric(metric), m_index(index)
+  {
+  }
+void dbcOvmsMetricIndex::SetValue(dbcNumber value, metric_unit_t unit)
+  {
+  m_metric->SetValueAt(m_index, value, unit);
+  }
+void dbcOvmsMetricIndex::SetValue(const std::string &value)
+  {
+  m_metric->SetValueAt(m_index, value);
+  }
+
+metric_unit_t dbcOvmsMetricIndex::DefaultUnit() const
+  {
+  return m_metric->GetUnits();
+  }
+
+
+////////////////////////////////////////////////////////////////////////
+// OvmsMetricEvent
+//
+OvmsMetricEvent::OvmsMetricEvent(OvmsMetricEventType type, int index, const std::string &strval)
+  : m_index(index), m_type(type),
+    m_string(strval), m_unit(UnitNotFound), m_value()
+  {
+  }
+OvmsMetricEvent::OvmsMetricEvent(OvmsMetricEventType type, int index, metric_unit_t unit, dbcNumber value)
+  : m_index(index), m_type(type),
+    m_string(), m_unit(UnitNotFound), m_value(value)
+  {
+  }
+void MetricEventDataFree(const char* event, void* data)
+  {
+  delete static_cast<OvmsMetricEvent *>(data);
+  }
+
+bool OvmsMetricEvent::GetValue(double &number) const
+  {
+  if (HasString())
+    {
+    return (sscanf(m_string.c_str(), "%lf", &number) == 1);
+    }
+  number = m_value.GetDouble();
+  return true;
+  }
+bool OvmsMetricEvent::GetValue(uint32_t &number) const
+  {
+  if (HasString())
+    {
+    // Get unsigned value
+    return (sscanf(m_string.c_str(), "%" SCNo32, &number) == 1);
+    }
+  number = m_value.GetUnsignedInteger();
+  return true;
+  }
+
+
+////////////////////////////////////////////////////////////////////////
+// dbcEventMetric
+//
+dbcEventMetric::dbcEventMetric(const std::string event, OvmsMetricEventType type, int index, metric_unit_t unit)
+  : m_event(event), m_index(index), m_type(type), m_unit(unit)
+  {
+  }
+void dbcEventMetric::SetValue(dbcNumber value, metric_unit_t unit)
+  {
+  if (unit == Native)
+    unit = m_unit;
+  OvmsMetricEvent *evt = new OvmsMetricEvent(m_type, m_index, unit, value);
+  MyEvents.SignalEvent(m_event, evt, MetricEventDataFree);
+  }
+void dbcEventMetric::SetValue(const std::string &value)
+  {
+  OvmsMetricEvent *evt = new OvmsMetricEvent(m_type, m_index, value);
+  MyEvents.SignalEvent(m_event, evt, MetricEventDataFree);
+  }
+
+////////////////////////////////////////////////////////////////////////
 // dbcMultiplexor_t
 
 dbcMultiplexor_t::dbcMultiplexor_t()
@@ -704,21 +785,133 @@ const std::string& dbcSignal::GetName() const
   return m_name;
   }
 
+static OvmsMetricEventType get_event_type(char ch, bool hasIndex)
+  {
+  switch (ch)
+    {
+    case 'c':
+    case 'C':
+      if (hasIndex)
+        return OvmsMetricEventType::Value;
+      break;
+    case 'r':
+    case 'R':
+      return hasIndex ? OvmsMetricEventType::ResetWithValue : OvmsMetricEventType::Reset;
+    case 'n':
+    case 'N':
+      if (!hasIndex)
+        return OvmsMetricEventType::SetNumber;
+      break;
+    case 'm':
+    case 'M':
+      if (!hasIndex)
+        return OvmsMetricEventType::SetModuleSize;
+      break;
+    default:
+      ;
+    }
+  return OvmsMetricEventType::Unknown;
+  }
+
 void dbcSignal::SetName(const std::string& name)
   {
   m_name = name;
 
   std::string mappedname(name);
   std::replace( mappedname.begin(), mappedname.end(), '_', '.');
+
+  // Search for metric.
   auto metric = MyMetrics.Find(mappedname.c_str());
   if (metric != nullptr)
     {
     AssignMetric(metric);
     return;
     }
-  // TODO bms.v[] and bms.t[]
 
-  // Not found.
+  // Search for metric vector.index
+  // eg:  v.t.pressure.0
+  std::size_t dot = mappedname.rfind('.');
+  if (dot != std::string::npos)
+    {
+    int16_t num = 0;
+    bool found_number = false;
+    bool all_ok = true;
+    for (auto it = mappedname.begin()+dot+1; it!= mappedname.end();++it)
+      {
+      auto ch = *it;
+      if (ch >= '0' && ch <= '9')
+        {
+        found_number = true;
+        num *= 10;
+        num += (ch - '0');
+        }
+      else
+        {
+        all_ok = false;
+        break;
+        }
+      }
+    if (found_number && all_ok)
+      {
+      // Found the number at the back.
+      // Search for the name without the number at the end.
+      std::string found_name = mappedname.substr(0, dot);
+      auto metric = MyMetrics.Find(mappedname.c_str());
+      if (metric != nullptr)
+        {
+        AttachDbcMetric(new dbcOvmsMetricIndex(metric, num));
+        return;
+        }
+      }
+    }
+
+  // Use internal BMS functions so that averages, min/max etc, as well as alarms
+  // all happen.
+  // bms.v.r    Reset stats for cell voltages (ignore value)
+  // bms.v.n    Set total number of cell voltage readings to value.
+  // bms.v.m    Set cell voltage readings per module (grouping count) to value.
+  // bms.t.n    Set total number of cell temperature readings to value.
+  // bms.t.m    Set cell temperature readings per module (grouping count) to value.
+  // bms.v.r.0  Reset stats, and set Voltage at index 0 to value
+  // bms.v.c.1  Set cell voltage at index 1 to value.
+  // bms.t.c.5  Set cell temperature at index 5 to value.
+
+  char bms_type, bms_extra;
+  uint32_t index;
+
+  auto found = sscanf(mappedname.c_str(), "bms.%c.%c.%" SCNd32, &bms_type, &bms_extra, &index);
+  if (found >= 2)
+    {
+    switch (bms_type)
+      {
+      case 'v':
+      case 't':
+        break;
+      case 'V':
+        bms_type = 'v';
+        break;
+      case 'T':
+        bms_type = 't';
+        break;
+      default:
+        bms_type = '\0';
+      }
+    if (bms_type != '\0')
+      {
+      auto et = get_event_type(bms_extra, found == 3);
+      if (et != OvmsMetricEventType::Unknown)
+        {
+        auto name = string_format("bms.%c",bms_type);
+        if (found == 2)
+          AttachDbcMetric(new dbcEventMetric(name, et, -1, m_metric_unit));
+        else
+          AttachDbcMetric(new dbcEventMetric(name, et, index, m_metric_unit));
+        return;
+        }
+      }
+    }
+
+  // Not found or invalid
   AttachDbcMetric(nullptr);
   }
 

--- a/vehicle/OVMS.V3/components/dbc/src/dbc.h
+++ b/vehicle/OVMS.V3/components/dbc/src/dbc.h
@@ -259,7 +259,6 @@ class dbcValueTableTable
     dbcValueTableTableEntry_t m_entrymap;
   };
 
-
 class dbcMetric
   {
   public:
@@ -268,6 +267,7 @@ class dbcMetric
     virtual void SetValue(const std::string &value) = 0;
     virtual metric_unit_t DefaultUnit() const = 0;
   };
+
 class dbcOvmsMetric : public dbcMetric
   {
   private:
@@ -277,6 +277,63 @@ class dbcOvmsMetric : public dbcMetric
     void SetValue(dbcNumber value, metric_unit_t unit) override;
     void SetValue(const std::string &value) override;
     metric_unit_t DefaultUnit() const override;
+  };
+class dbcOvmsMetricIndex : public dbcMetric
+  {
+  private:
+    OvmsMetric *m_metric;
+    int16_t m_index;
+  public:
+    dbcOvmsMetricIndex(OvmsMetric *metric, int16_t index);
+    void SetValue(dbcNumber value, metric_unit_t unit) override;
+    void SetValue(const std::string &value) override;
+    metric_unit_t DefaultUnit() const override;
+  };
+
+
+enum class OvmsMetricEventType : short {
+  Unknown,
+  Reset,
+  ResetWithValue,
+  Value,
+  SetNumber,
+  SetModuleSize
+};
+
+class OvmsMetricEvent
+  {
+  private:
+    int m_index;
+    OvmsMetricEventType m_type;
+    std::string m_string;
+    metric_unit_t m_unit;
+    dbcNumber m_value;
+
+  public:
+    OvmsMetricEvent(OvmsMetricEventType type, int index, const std::string &strval);
+    OvmsMetricEvent(OvmsMetricEventType type,int index, metric_unit_t unit, dbcNumber value);
+
+    bool HasString() const { return m_unit == UnitNotFound; }
+    const std::string &GetString() const { return m_string; }
+    bool GetValue(double &number) const;
+    bool GetValue(uint32_t &number) const;
+    metric_unit_t GetUnit() const { return HasString() ? Native : m_unit; }
+    OvmsMetricEventType GetType() const { return m_type;}
+    int GetIndex() const { return m_index; }
+  };
+
+class dbcEventMetric : public dbcMetric
+  {
+  private:
+    std::string m_event;
+    int m_index;
+    OvmsMetricEventType m_type;
+    metric_unit_t m_unit;
+  public:
+    dbcEventMetric(const std::string event, OvmsMetricEventType type, int index, metric_unit_t unit);
+    void SetValue(dbcNumber value, metric_unit_t unit) override;
+    void SetValue(const std::string &value) override;
+    metric_unit_t DefaultUnit() const override { return m_unit; }
   };
 
 typedef std::list<std::string> dbcReceiverList_t;

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -32,6 +32,8 @@
 static const char *TAG = "vehicle";
 // static const char *TAGRX = "vehicle-rx";
 static const char *CHECK_SHUTDOWN_TAG = "vehicle-shutdown";
+// static const char *BMS_VOLTAGE_EVENT = "vehicle-bms-v"
+// static const char *BMS_TEMPERATURE_EVENT = "vehicle-bms-t"
 
 #include <stdio.h>
 #include <algorithm>
@@ -67,7 +69,7 @@ OvmsVehicleFactory::OvmsVehicleFactory()
   m_currentvehicletype.clear();
 
   MyEvents.RegisterEvent(TAG,"system.shuttingdown",std::bind(&OvmsVehicleFactory::EventSystemShuttingDown, this, _1, _2));
-  
+
   OvmsCommand* cmd_vehicle = MyCommandApp.RegisterCommand("vehicle","Vehicle framework", vehicle_status, "", 0, 0, false);
   cmd_vehicle->RegisterCommand("module","Set (or clear) vehicle module",vehicle_module,"<type>",0,1,true,vehicle_validate);
   cmd_vehicle->RegisterCommand("list","Show list of available vehicle modules",vehicle_list);
@@ -595,7 +597,11 @@ OvmsVehicle::OvmsVehicle()
 
   MyEvents.RegisterEvent(TAG, "config.changed", std::bind(&OvmsVehicle::VehicleConfigChanged, this, _1, _2));
   MyEvents.RegisterEvent(TAG, "config.mounted", std::bind(&OvmsVehicle::VehicleConfigChanged, this, _1, _2));
+
   VehicleConfigChanged("config.mounted", NULL);
+
+  MyEvents.RegisterEvent(TAG, "bms.v", std::bind(&OvmsVehicle::EventDBCBmsMetricV, this, _1, _2));
+  MyEvents.RegisterEvent(TAG, "bms.t", std::bind(&OvmsVehicle::EventDBCBmsMetricT, this, _1, _2));
 
   MyMetrics.RegisterListener(TAG, "*", std::bind(&OvmsVehicle::MetricModified, this, _1));
 

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.cpp
@@ -173,11 +173,27 @@ OvmsVehicleFactory::OvmsVehicleFactory()
   dto->RegisterDuktapeFunction(DukOvmsVehicleStopCooldown, 0, "StopCooldown");
   dto->RegisterDuktapeFunction(DukOvmsVehicleObdRequest, 1, "ObdRequest");
 
-  DuktapeObjectRegistration* dto_aux= new DuktapeObjectRegistration("OvmsAuxMonitor");;
+  DuktapeObjectRegistration* dto_aux= new DuktapeObjectRegistration("OvmsAuxMonitor");
   dto_aux->RegisterDuktapeFunction(DukOvmsVehicleAuxMonEnable, DUK_VARARGS /*0..2*/, "Enable");
   dto_aux->RegisterDuktapeFunction(DukOvmsVehicleAuxMonDisable, 0, "Disable");
   dto_aux->RegisterDuktapeFunction(DukOvmsVehicleAuxMonStatus, 0, "Status");
   dto->RegisterDuktapeObject(dto_aux, "AuxMon");
+
+  DuktapeObjectRegistration* dto_bms= new DuktapeObjectRegistration("OvmsBms");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsVoltageSetCellArrangement, 2, "VoltageSetCellArrangement");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsVoltageSetCellDefaultThresholds, DUK_VARARGS, "VoltageSetCellDefaultThresholds");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsVoltageSetCellLimits, 2, "VoltageSetCellLimits");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsVoltageSetCell, 2, "VoltageSetCell");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsVoltageResetCells, DUK_VARARGS, "VoltageResetCells");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsVoltagesRestartCell, 0, "VoltagesRestartCell");
+
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsTemperatureSetCellArrangement, 2, "TemperatureSetCellArrangement");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsTemperatureSetCellDefaultThresholds,  2, "TemperatureSetCellDefaultThresholds");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsTemperatureSetCellLimits, 2, "TemperatureSetCellLimits");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsTemperatureSetCell, 2, "TemperatureSetCell");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsTemperatureResetCells, DUK_VARARGS, "TemperatureResetCells");
+  dto_bms->RegisterDuktapeFunction(DukOvmsBmsTemperatureRestartCells, 0, "TemperatureRestartCells");
+  dto->RegisterDuktapeObject(dto_bms, "BMS");
 
   MyDuktape.RegisterDuktapeObject(dto);
 #endif // #ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -259,6 +259,10 @@ class OvmsVehicle : public InternalRamAllocated
     void VehicleConfigChanged(std::string event, void* data);
     void PollRunFinishedNotify(canbus* bus, void *data);
     void PollerStateTickerNotify(canbus* bus, void *data);
+
+    void EventDBCBmsMetricV(std::string event, void* data);
+    void EventDBCBmsMetricT(std::string event, void* data);
+
   protected:
     // Signal poller
     void PausePolling();

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -802,6 +802,22 @@ class OvmsVehicleFactory
     static duk_ret_t DukOvmsVehicleAuxMonEnable(duk_context *ctx);
     static duk_ret_t DukOvmsVehicleAuxMonDisable(duk_context *ctx);
     static duk_ret_t DukOvmsVehicleAuxMonStatus(duk_context *ctx);
+
+    // BMS
+    static duk_ret_t DukOvmsBmsVoltageSetCellArrangement(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsVoltageSetCellDefaultThresholds(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsVoltageSetCellLimits(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsVoltageSetCell(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsVoltageResetCells(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsVoltagesRestartCell(duk_context *ctx);
+
+    static duk_ret_t DukOvmsBmsTemperatureSetCellArrangement(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsTemperatureSetCellDefaultThresholds(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsTemperatureSetCellLimits(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsTemperatureSetCell(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsTemperatureResetCells(duk_context *ctx);
+    static duk_ret_t DukOvmsBmsTemperatureRestartCells(duk_context *ctx);
+
 #endif // CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE
   };
 

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_bms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_bms.cpp
@@ -44,6 +44,7 @@ static const char *TAG = "vehicle";
 #include <ovms_peripherals.h>
 #include <string_writer.h>
 #include "vehicle.h"
+#include <dbc.h>
 
 // Voltage stddev running average sample count:
 #define VSTDDEV_SMOOTHCNT         5
@@ -88,7 +89,18 @@ struct reading_entry_t
 bool OvmsVehicle::BmsCheckChangeCellArrangementVoltage(int readings, int readingspermodule /*=0*/)
   {
   bool res = false;
-  if (readingspermodule <= 0)
+
+  if (readings < 0)
+    {
+    // passing in < 0 will leave readings unchanged.
+    readings = m_bms_readings_v;
+    }
+
+  if (readings == 0)
+    {
+    readingspermodule = 0;
+    }
+  else if (readingspermodule <= 0)
     {
     // Passing in 0 will leave the readings per module unchanged.
     readingspermodule = m_bms_readingspermodule_v;
@@ -882,5 +894,97 @@ void OvmsVehicle::BmsTicker()
       StdMetrics.ms_v_bat_pack_tstddev->AsFloat(),
       StdMetrics.ms_v_bat_pack_tstddev_max->AsFloat(),
       StdMetrics.ms_v_bat_cell_temp->AsString("", Native, 1).c_str());
+    }
+  }
+
+void OvmsVehicle::EventDBCBmsMetricV(std::string event, void* data)
+  {
+  OvmsMetricEvent *evt = static_cast<OvmsMetricEvent*>(data);
+
+  switch (evt->GetType())
+    {
+    case OvmsMetricEventType::Reset:
+      {
+      BmsResetCellVoltages(false);
+      break;
+      }
+    case OvmsMetricEventType::ResetWithValue:
+      BmsResetCellVoltages(false);
+      FALLTHROUGH;
+    case OvmsMetricEventType::Value:
+      {
+      double val;
+      if (evt->GetValue(val))
+        {
+        BmsSetCellVoltage(evt->GetIndex(), val);
+        }
+      break;
+      }
+    case OvmsMetricEventType::SetNumber:
+      {
+      uint32_t n;
+      if (evt->GetValue(n))
+        {
+        BmsCheckChangeCellArrangementVoltage(n, -1);
+        }
+      break;
+      }
+    case OvmsMetricEventType::SetModuleSize:
+      {
+      uint32_t n;
+      if (evt->GetValue(n))
+        {
+        BmsCheckChangeCellArrangementVoltage(-1, n);
+        }
+      break;
+      }
+    case OvmsMetricEventType::Unknown:
+      break;
+    }
+  }
+
+void OvmsVehicle::EventDBCBmsMetricT(std::string event, void* data)
+  {
+  OvmsMetricEvent *evt = static_cast<OvmsMetricEvent*>(data);
+
+  switch (evt->GetType())
+    {
+    case OvmsMetricEventType::Reset:
+      {
+      BmsResetCellTemperatures(false);
+      break;
+      }
+    case OvmsMetricEventType::ResetWithValue:
+      BmsResetCellTemperatures(false);
+      FALLTHROUGH;
+    case OvmsMetricEventType::Value:
+      {
+      double val;
+      if (evt->GetValue(val))
+        {
+        BmsSetCellTemperature(evt->GetIndex(), val);
+        }
+      break;
+      }
+    case OvmsMetricEventType::SetNumber:
+      {
+      uint32_t n;
+      if (evt->GetValue(n))
+        {
+        BmsCheckChangeCellArrangementTemperature(n, -1);
+        }
+      break;
+      }
+    case OvmsMetricEventType::SetModuleSize:
+      {
+      uint32_t n;
+      if (evt->GetValue(n))
+        {
+        BmsCheckChangeCellArrangementTemperature(-1, n);
+        }
+      break;
+      }
+    case OvmsMetricEventType::Unknown:
+      break;
     }
   }

--- a/vehicle/OVMS.V3/components/vehicle/vehicle_duktape.cpp
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle_duktape.cpp
@@ -536,4 +536,167 @@ duk_ret_t OvmsVehicleFactory::DukOvmsVehicleAuxMonStatus(duk_context *ctx)
   dc.PutProp(obj_idx, "state");
   return 1;
   }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsVoltageSetCellArrangement(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // VoltageSetCellArrangement( readings, readingspermodule)
+  int readings = duk_to_int(ctx, 0);
+  int permodule = duk_to_int(ctx, -1);
+  mycar->BmsSetCellArrangementVoltage(readings, permodule);
+  return 0;
+  }
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsVoltageSetCellDefaultThresholds(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // VoltageSetCellDefaultThresholds(warn, alert [, max_grad] [, max_std_dev])``
+  duk_idx_t numArgs = duk_get_top(ctx);
+  if (numArgs < 2)
+    return 0;
+  float warn = duk_to_number(ctx, 0);
+  float alert = duk_to_number(ctx, -1);
+  float maxgrad = -1;
+  float maxsddev = -1;
+  if (numArgs > 2)
+    {
+    maxgrad = duk_to_number(ctx, -2);
+    if (numArgs > 3)
+      maxsddev = duk_to_number(ctx, -3);
+    }
+
+  mycar->BmsSetCellDefaultThresholdsVoltage(warn, alert, maxgrad, maxsddev);
+
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsVoltageSetCellLimits(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  float minv = duk_to_number(ctx, 0);
+  float maxv = duk_to_number(ctx, -1);
+
+  mycar->BmsSetCellLimitsVoltage(minv, maxv);
+  return 0;
+  }
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsVoltageSetCell(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // VoltageSetCell(int index, float value)
+  float index = duk_to_int(ctx, 0);
+  float val = duk_to_number(ctx, -1);
+
+  mycar->BmsSetCellVoltage(index, val);
+  return 0;
+  }
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsVoltageResetCells(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // VoltageResetCells( [full] )
+  //
+
+  duk_idx_t numArgs = duk_get_top(ctx);
+  bool full = false;
+
+  if (numArgs > 0)
+    full = duk_to_boolean(ctx, 0);
+
+  mycar->BmsResetCellVoltages(full);
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsVoltagesRestartCell(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  mycar->BmsRestartCellVoltages();
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsTemperatureSetCellArrangement(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // TemperatureSetCellArrangement( readings, readingspermodule)
+  int readings = duk_to_int(ctx, 0);
+  int permodule = duk_to_int(ctx, -1);
+  mycar->BmsSetCellArrangementTemperature(readings, permodule);
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsTemperatureSetCellDefaultThresholds(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // TemperatureSetCellDefaultThresholds(warn, alert)
+  float warn = duk_to_number(ctx, 0);
+  float alert = duk_to_number(ctx, -1);
+  mycar->BmsSetCellDefaultThresholdsTemperature(warn, alert);
+  return 0;
+  }
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsTemperatureSetCellLimits(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // TemperatureSetCellLimits(min, max)
+  float minv = duk_to_number(ctx, 0);
+  float maxv = duk_to_number(ctx, -1);
+
+  mycar->BmsSetCellLimitsTemperature(minv, maxv);
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsTemperatureSetCell(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // TemperatureSetCell(index, value)
+  float index = duk_to_int(ctx, 0);
+  float val = duk_to_number(ctx, -1);
+
+  mycar->BmsSetCellTemperature(index, val);
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsTemperatureResetCells(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // TemperatureResetCells( [full] )
+
+  duk_idx_t numArgs = duk_get_top(ctx);
+  bool full = false;
+
+  if (numArgs > 0)
+    full = duk_to_boolean(ctx, 0);
+
+  mycar->BmsResetCellTemperatures(full);
+  return 0;
+  }
+
+duk_ret_t OvmsVehicleFactory::DukOvmsBmsTemperatureRestartCells(duk_context *ctx)
+  {
+  OvmsVehicle *mycar = MyVehicleFactory.ActiveVehicle();
+  if (mycar == nullptr)
+    return 0;
+  // TemperatureRestartCells()
+  mycar->BmsRestartCellTemperatures();
+  return 0;
+  }
+
 #endif // #ifdef CONFIG_OVMS_SC_JAVASCRIPT_DUKTAPE

--- a/vehicle/OVMS.V3/components/vehicle_dbc/docs/dbc-primer.rst
+++ b/vehicle/OVMS.V3/components/vehicle_dbc/docs/dbc-primer.rst
@@ -23,6 +23,64 @@ decode the results (instead of doing the decoding in C++ code). So a DBC file ca
 for a real vehicle module. To request OBD2 data during development, you can use the ``re obdii``
 commands.
 
+-----------
+DBC Signals
+-----------
+
+DBC Signal names can be used to store values directly into metrics.  Eg a signal ``v_b_soc`` would be
+sent to the metric ``v.b.soc``.  If the unit name on a signal matches a valid 'unit code' or 'unit label',
+then this will be passed on too.
+
+For signal names, ``_`` will get translated to a ``.`` for looking up metrics (``.`` is still a valid character in a DBC ID).
+
+It is also possible to store into a vector by putting a number at the end of the signal id. Eg the
+signal ``v_t_pressure_0`` would be sent to the first element of the ``v.t.pressure`` vector. 
+
+-----------
+BMS Targets
+-----------
+
+There are also special BMS (battery management) targets that make sure the averages etc are calculated.
+The format is: **bms.**\ *{type}*\ **.**\ *{operation}*\ [\ *.*\ *{index}*\ ].
+
+The *{type}* is either **v** for voltage or **t** for temperature.
+
+.. list-table::
+   :header-rows:  1
+
+   * - Operation
+     - Description
+     - Has Index
+   * - **n**
+     - Total number of cell voltage readings
+     - No
+   * - **m**
+     - Readings per module
+     - No
+   * - **r**
+     - Reset stats
+     - Optional
+   * - **c**
+     - Cell value
+     - Yes
+ 
+.. list-table:: DBC Examples
+   :header-rows: 1
+
+   * - Example
+     - Description
+   * - ``bms.t.n``
+     - Set total number of cell temperature readings to incoming value.
+   * - ``bms.t.m``
+     - Set total number of cells per grouping to incoming value.
+   * - ``bms.v.r``
+     - Reset stats for cell voltages (ignore value)
+   * - ``bms.v.r.0``
+     - Reset stats and set Voltage at index *0* to incoming value
+   * - ``bms.t.c.2``
+     - Set cell temperature at index *2* to incoming value.
+   * - ``bms.v.c.5``
+     - Set cell voltage at index *5* to incoming value.
 
 -------------
 Basic Example
@@ -42,12 +100,11 @@ message if using DBC.
 - Bytes 1+2: momentary battery current [A], big endian, lower 12 bits, scaled by -0.25, offset +500: ``_6 E7`` → **58.25A**
 - Bytes 4+5: SOC [%], big endian, scaled by 0.0025, no offset: ``6D 58`` → **69.98%**
 
-These can be translated to metrics directly:
+These can be translated to metrics directly by specifying these as the name of the element:
 
 - Charge current limit: ``v.c.climit``
 - Momentary battery current: ``v.b.current``
 - Battery SOC: ``v.b.soc``
-
 
 ---------------
 Create DBC File

--- a/vehicle/OVMS.V3/main/ovms_metrics.cpp
+++ b/vehicle/OVMS.V3/main/ovms_metrics.cpp
@@ -1565,6 +1565,20 @@ bool OvmsMetric::SetValue(const dbcNumber& value, metric_unit_t units)
   {
   return false;
   }
+bool OvmsMetric::SetValueAt(size_t n, std::string value, metric_unit_t units)
+  {
+  // This is for non-vectors
+  if (n != 0)
+    return false;
+  return SetValue(value, units);
+  }
+bool OvmsMetric::SetValueAt(size_t n, const dbcNumber& value, metric_unit_t units)
+  {
+  // This is for non-vectors
+  if (n != 0)
+    return false;
+  return SetValue(value, units);
+  }
 
 void OvmsMetric::operator=(std::string value)
   {

--- a/vehicle/OVMS.V3/main/ovms_metrics.h
+++ b/vehicle/OVMS.V3/main/ovms_metrics.h
@@ -239,6 +239,11 @@ class OvmsMetric
 #endif
     virtual bool SetValue(std::string value, metric_unit_t units = Other);
     virtual bool SetValue(const dbcNumber& value, metric_unit_t units = Other);
+    /** Set a value at an index, used by DBC conversions.
+     * Supports n=0 by default.
+     */
+    virtual bool SetValueAt(size_t n, std::string value, metric_unit_t units = Other);
+    virtual bool SetValueAt(size_t n, const dbcNumber& value, metric_unit_t units = Other);
     virtual void operator=(std::string value);
     virtual bool CheckPersist();
     virtual void RefreshPersist();
@@ -457,6 +462,39 @@ class OvmsMetricBitset : public OvmsMetric
       }
     void operator=(std::string value) override { SetValue(value); }
 
+    bool SetValueAt(size_t n, std::string value, metric_unit_t units = Other) override
+      {
+      if (n < 0 || n >= N)
+        return false;
+      bool newval = strtobool(value);
+      bool modified;
+        {
+        OvmsMutexLock lock(&m_mutex);
+        modified = newval != m_value[n];
+        if (modified)
+          m_value[n] = newval;
+        }
+      SetModified(modified);
+      return modified;
+      }
+    bool SetValueAt(size_t n, const dbcNumber& value, metric_unit_t units = Other) override
+      {
+      if (n < 0 || n >= N)
+        return false;
+
+      bool newval = (value.GetSignedInteger() != 0);
+      bool modified;
+        {
+        OvmsMutexLock lock(&m_mutex);
+
+        modified = newval != m_value[n];
+        if (modified)
+          m_value[n] = newval;
+        }
+      SetModified(modified);
+      return modified;
+      }
+
     std::bitset<N> AsBitset(const std::bitset<N> defvalue = std::bitset<N>(0), metric_unit_t units = Other)
       {
       if (!IsDefined())
@@ -619,6 +657,26 @@ class OvmsMetricSet : public OvmsMetric
     std::set<ElemType> m_value;
   };
 
+// Overloaded conversion from a dbcNumber to an integer/float.
+// Add more if vectors use other types.
+inline void OvmsDBCNumberCvt(const dbcNumber &Value, long int &newValue)
+  {
+  newValue = Value.GetSignedInteger();
+  }
+
+inline void OvmsDBCNumberCvt(const dbcNumber &Value, int &newValue)
+  {
+  newValue = Value.GetSignedInteger();
+  }
+inline void OvmsDBCNumberCvt(const dbcNumber &Value, short &newValue)
+  {
+  newValue = Value.GetSignedInteger();
+  }
+
+inline void OvmsDBCNumberCvt(const dbcNumber &Value, float &newValue)
+  {
+  newValue = Value.GetDouble();
+  }
 
 /**
  * OvmsMetricVector<type>: metric wrapper for std::vector<type>
@@ -933,6 +991,20 @@ class OvmsMetricVector : public OvmsMetric
         }
       return modified;
       }
+    bool SetValueAt(size_t n, std::string value, metric_unit_t units = Other) override
+      {
+      ElemType elem;
+      std::istringstream ts(value);
+      ts >> elem;
+      return SetElemValue(n, elem, units);
+      }
+    bool SetValueAt(size_t n, const dbcNumber& value, metric_unit_t units = Other) override
+      {
+      ElemType elem;
+      OvmsDBCNumberCvt(value, elem);
+      return SetElemValue(n, elem, units);
+      }
+
     void operator=(std::vector<ElemType, Allocator> value) { SetValue(value); }
 
     void ClearValue()
@@ -993,7 +1065,7 @@ class OvmsMetricVector : public OvmsMetric
       return UnitConvert(m_units, units, val);
       }
 
-    void SetElemValue(size_t n, const ElemType nvalue, metric_unit_t units = Other)
+    bool SetElemValue(size_t n, const ElemType nvalue, metric_unit_t units = Other)
       {
       ElemType value;
       if (units != Other && units != m_units)
@@ -1020,6 +1092,7 @@ class OvmsMetricVector : public OvmsMetric
         m_mutex.Unlock();
         }
       SetModified(modified);
+      return modified;
       }
 
     void SetElemValues(size_t start, size_t cnt, const ElemType* values, metric_unit_t units = Other)


### PR DESCRIPTION
Support setting BMS configuration in DukTape
Allow setting BMS values with DBC and the Duktape Poller Scripting (that uses the same engine)
Allow specifying array elements as DBC targets