### PR TITLE
smartEQ: removed polling at reboot when CAN bus sleep

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -120,13 +120,6 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
       Handlev2Server();
   #endif
 
-  // start polling to get the first data
-  if(can_init && IsCANwrite())
-    {      
-    can_init = false;
-    mt_bus_awake->SetValue(true);
-    }
-
   // DDT4ALL session timeout on 5 minutes
   if (m_ddt4all) 
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -507,7 +507,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     int can_gear = 0;                     // <0 = reverse, 0 = park/neutral, >0 = drive -- logic by vehicle.cpp events
     int can_duration_full = 0;            // duration until full in minutes
     int can_350_ticker = 0;               // ticker for 0x350 polling, will be reset to SQ_CANDATA_TIMEOUT when 0x350 is received, used to trigger actions on timeout e.g. go to sleep after no CAN activity for some time
-    bool can_init = true;                 // initial CAN data received flag, to set default values for some metrics on first run
     bool can_awake = false;
     bool can_battery_on = false;
     bool can_locked = true;


### PR DESCRIPTION
@dexterbg 
I only just read your comment in #1405 regarding reading in after a reboot. Now I also understand Dimitire's PR for `can_init=false`.