### PR TITLE
smartEQ: refactor awake state for starting polling

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -71,9 +71,9 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       {
       REQ_DLC(7);
       can_350_ticker = SQ_CANDATA_TIMEOUT;
-      can_awake = (CAN_BYTE(0) > 0xC0);
-      can_env_on = (CAN_BYTE(0) > 0xC4);
+      can_awake = (CAN_BYTE(0) > 0xC1);      
       can_battery_on = (CAN_BYTE(0) > 0xC2);
+      can_env_on = (CAN_BYTE(0) > 0xC4);
       can_locked = (CAN_BYTE(6) == 0x96);
       int code = CAN_BYTE(0);
       std::string msgtxt = "";
@@ -121,7 +121,6 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
     case 0x4F8:
       REQ_DLC(3);
       can_handbrake = (CAN_BYTE(0) & 0x08) > 0;
-      //can_awake = (CAN_BYTE(0) & 0x40) > 0; // Ignition on
       break;
     case 0x5D7: // Speed, ODO
       {
@@ -260,13 +259,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
 
 // Sync CAN datapoints to OVMS metrics, called by Ticker1, because CAN refresh rate is too high
 void OvmsVehicleSmartEQ::smartCAN2Metrics()
-{  
-  if (IsAwakeByCanEQ())
-    {
-    mt_bus_awake->SetValue(true);
-    m_candata_poll = true;
-    m_candata_timer = SQ_CANDATA_TIMEOUT;
-    }
+{
   if (m_cmd_locked && !can_locked)
     {
     // prevent desync of command lock and actual lock status    

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -233,7 +233,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
         break;
         }
       }
-    mt_bus_awake->SetValue(true);
     res = Success;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 
@@ -275,8 +274,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup2() {
         res = Success;
         break;
         }
-      }
-    mt_bus_awake->SetValue(true);    
+      }    
     res = Success;
     ESP_LOGI(TAG, "Vehicle is awake");
     } 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -487,7 +487,6 @@ void OvmsVehicleSmartEQ::smartOff()
 void OvmsVehicleSmartEQ::smartAwake()
 {
   // enable active polling when car wakes up (canwrite only)
-  mt_bus_awake->SetValue(true);
   if(m_enable_write) 
     {
     smartCANmode(true);
@@ -517,7 +516,6 @@ void OvmsVehicleSmartEQ::smartChargeStart()
   StdMetrics.ms_v_charge_state->SetValue("charging");
   StdMetrics.ms_v_charge_substate->SetValue("onrequest");
   StdMetrics.ms_v_charge_timestamp->SetValue(StdMetrics.ms_m_timeutc->AsInt());
-  mt_bus_awake->SetValue(true);
   // trigger ADC factor recalculation when HV charging started
   if(m_enable_calcADCfactor && !m_ADCfactor_recalc) 
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -55,12 +55,10 @@ void OvmsVehicleSmartEQ::HandlePollState() {
   if (IsChargingEQ())
     {
     desired_state = POLLSTATE_CHARGING;   //- car is charging
-    mt_bus_awake->SetValue(true);
     }
   else if (IsOnEQ())
     {
     desired_state = POLLSTATE_ON;    //- car is on
-    mt_bus_awake->SetValue(true);
     }
   else if (IsAwakeEQ())
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -46,6 +46,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     can_awake = false;
     can_env_on = false;
     can_battery_on = false;
+    smartCAN2Metrics();
     }
     
   if(IsAwakeEQ())

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -40,19 +40,15 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   if (m_ddt4all_exec >= 1)
     --m_ddt4all_exec;
 
-  if (can_350_ticker > 0)
+  if (can_350_ticker > 0 &&--can_350_ticker == 0) 
     {
-    if (--can_350_ticker == 0) 
-      {
-      ESP_LOGI(TAG, "CAN 0x350 timeout reached");
-      can_awake = false;
-      can_env_on = false;
-      can_battery_on = false;
-      mt_bcm_vehicle_state->SetValue("CAN 0x350 timeout reached");
-      }
+    ESP_LOGD(TAG, "CAN 0x350 timeout reached");
+    can_awake = false;
+    can_env_on = false;
+    can_battery_on = false;
     }
     
-  if(IsAwakeEQ() || IsAwakeByCanEQ())
+  if(IsAwakeEQ())
     smartCAN2Metrics();
 
   if(IsChargingEQ()) 
@@ -100,7 +96,6 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   // if charging is in progress, then modify polling to get the DCDC/Charging data (reboot prevention)
   if (IsChargingEQ() && !m_poll_on_charge)
     {
-    mt_bus_awake->SetValue(true);
     smartChargeStart();
     }
   }
@@ -135,6 +130,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
 
   #ifdef CONFIG_OVMS_COMP_ADC
   if(IsOnEQ() || IsChargingEQ())
+     ReCalcADCfactor(StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f), nullptr);
     {
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
     if(m_check12vadc)
@@ -182,7 +178,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
  */
 void OvmsVehicleSmartEQ::PollerStateTicker(canbus *bus) 
   {
-  if (IsAwakeEQ() && !m_candata_poll) 
+  if (IsAwakeEQ())
     {
     m_candata_poll = true;
     m_candata_timer = SQ_CANDATA_TIMEOUT;
@@ -192,13 +188,12 @@ void OvmsVehicleSmartEQ::PollerStateTicker(canbus *bus)
     {
     // Car has gone to sleep
     ESP_LOGI(TAG,"Car has gone to sleep (CAN bus timeout)");
-    mt_bus_awake->SetValue(false);
     m_candata_poll = false;
     m_candata_timer = -1;
     }
   
   // - base system is awake if we've got a fresh lv_pwrstate:
   // use CAN 0x350 state for 12V aux state, because it seems to be more reliable than the 12V voltage for detecting if the car is in accessory mode or not, which is needed for the powermgmt system
-  StdMetrics.ms_v_env_aux12v->SetValue(can_battery_on); // can_awake
+  StdMetrics.ms_v_env_aux12v->SetValue(IsHVonEQ());
   HandlePollState();
   }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -43,6 +43,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   if (can_350_ticker > 0 &&--can_350_ticker == 0) 
     {
     ESP_LOGD(TAG, "CAN 0x350 timeout reached");
+    can_350_ticker = -1;
     can_awake = false;
     can_env_on = false;
     can_battery_on = false;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -62,7 +62,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   BmsSetCellDefaultThresholdsVoltage(0.040, 0.060);  // Warn: 40mV, Alert: 60mV
   BmsSetCellDefaultThresholdsTemperature(4.0, 5.5);  // Warn: 4,0°C, Alert: 5,5°C
 
-  mt_bus_awake                  = MyMetrics.InitBool("xsq.v.bus.awake", SM_STALE_MIN, false);
+  //mt_bus_awake                  = MyMetrics.InitBool("xsq.v.bus.awake", SM_STALE_MIN, false);
   mt_canbyte                    = MyMetrics.InitString("xsq.ddt4all.canbyte", SM_STALE_MAX, "", Other);
   mt_adc_factor                 = MyMetrics.InitFloat("xsq.adc.factor", SM_STALE_MAX, 0, Other);
   mt_adc_factor_history         = MyMetrics.InitVector<float>("xsq.adc.factor.history", SM_STALE_MAX, nullptr, Other);
@@ -313,7 +313,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     MyConfig.SetParamValueBool("xsq", "canwrite.caron", false);
     }
   // start in listen-only mode if sleep write is enabled and bus is not awake
-  if (m_enable_write_sleep && !mt_bus_awake->AsBool(false))
+  if (m_enable_write_sleep && !IsAwakeEQ())
     {
     smartCANmode(false);
     }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -227,8 +227,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // --- Inline state helpers ---
     bool UsesTpmsSensorMapping() override { return true; } // using m_tpms_index[]
     bool IsOffEQ() { return m_poll_state == POLLSTATE_OFF; }
-    bool IsAwakeByCanEQ() { return can_awake || can_charge_inprogress || can_env_on || can_hvac; }
-    bool IsAwakeEQ() { return mt_bus_awake->AsBool(false) || IsAwakeByCanEQ(); }
+    bool IsAwakeEQ() { return can_awake || can_charge_inprogress || can_env_on || can_hvac; }
+    bool IsHVonEQ() { return can_battery_on && IsAwakeEQ(); }
     bool IsOnEQ() { return can_env_on; }
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }


### PR DESCRIPTION
renamed IsAwakeByCanEQ to IsAwakeEQ
removed xsq metric awake
rised can bus awake level from 0xC0 > 0 to 0xC1 >0