### PR TITLE
SmartEQ: improve CAN, polling and contactor handling

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -270,7 +270,7 @@ void OvmsVehicleSmartEQ::smartCAN2Metrics()
     StdMetrics.ms_v_env_locked->SetValue(can_locked);
     }
   StdMetrics.ms_v_env_on->SetValue(can_env_on);
-  StdMetrics.ms_v_env_awake->SetValue(can_awake);
+  StdMetrics.ms_v_env_awake->SetValue(IsAwakeEQ());
   StdMetrics.ms_v_env_hvac->SetValue(can_hvac);
   StdMetrics.ms_v_env_handbrake->SetValue(can_handbrake);
   StdMetrics.ms_v_env_headlights->SetValue(can_headlights);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -337,45 +337,47 @@ void OvmsVehicleSmartEQ::PollReply_BMS_BattVolts(const char* data, uint16_t repl
 void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint16_t reply_len) {
   REQUIRE_LEN(8);
   int32_t cycles_remain = (int32_t)CAN_UINT32(0);
+  // use current remain value if no valid remain value in reply, to prevent false positive jump alert
+  int32_t cycles_now = cycles_remain > 0 ? cycles_remain : (int32_t)mt_bms_contactor_cycles->GetElemValue(1);
   int32_t cycles_max = (int32_t)CAN_UINT32(4);
   // use previous remain value if available, otherwise current remain value, to calculate diff
-  int32_t cycles_prev = (int32_t)mt_bms_contactor_cycles->GetElemValue(1) > 0 ? (int32_t)mt_bms_contactor_cycles->GetElemValue(1) : cycles_remain;
-  int32_t cycles_diff = cycles_prev - cycles_remain;
-  int32_t cycles_consumed = cycles_max - cycles_remain;
+  int32_t cycles_prev = (int32_t)mt_bms_contactor_cycles->GetElemValue(1) > 0 ? (int32_t)mt_bms_contactor_cycles->GetElemValue(1) : cycles_now;
+  int32_t cycles_diff = cycles_prev - cycles_now;
+  int32_t cycles_consumed = cycles_max - cycles_now;
   float odometer = can_odometer; // in km
   mt_bms_contactor_cycles->SetElemValue(0, cycles_max);
-  mt_bms_contactor_cycles->SetElemValue(1, cycles_remain);
+  mt_bms_contactor_cycles->SetElemValue(1, cycles_now);
   mt_bms_contactor_cycles->SetElemValue(2, cycles_consumed);
-  mt_bms_contactor_cycles->SetElemValue(3, cycles_diff);  
-  if (cycles_remain != cycles_prev) 
+  mt_bms_contactor_cycles->SetElemValue(3, cycles_diff);
+  if (cycles_now != cycles_prev) 
     {
-    ESP_LOGD(TAG,"HV contactor cycles (%u / %u / %u)", cycles_max, cycles_remain, cycles_diff);
+    ESP_LOGD(TAG,"HV contactor cycles (%u / %u / %u)", cycles_max, cycles_now, cycles_diff);
     // Send data log XSQ-BMS-ContactorLog V1:
     //  <cycles_max>,<cycles_prev>,<cycles_now>,<cycles_diff>,<odometer>
     MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,1,%d,%d,%d,%d,%d,%0.0f",
       86400 * 30, // hold time 30 days
-      cycles_max, cycles_prev, cycles_remain, cycles_diff, odometer);
+      cycles_max, cycles_prev, cycles_now, cycles_diff, odometer);
 
     // Send alert?
     // Note: excluding sending an alert on cycle count 0 for now, because possibly a false positive
     //  caused by some secondary/CAN error/bug -- to be verified    
-    if (cycles_prev > cycles_remain && cycles_diff > 100) 
+    if (cycles_prev > cycles_now && cycles_diff > 100) 
       {
       MyNotify.NotifyStringf("alert", "bms.contactorjump",
         "ATT: HV contactor cycle count stepped down by %d counts (now at %d)\n"
         "Possible issue #1405 condition (BMS glitch), check ASAP!\n"
         "CAN write is now disabled and switched to listen mode!\n",
-        cycles_diff, cycles_remain);
+        cycles_diff, cycles_now);
       // In case of a large unexpected jump, disable CAN write to prevent possible damage to the contactor
-      ESP_LOGW(TAG, "HV contactor cycles alert: last: %d, now: %d, consumed: %d odo: %0.0f, counted more than expected!", cycles_prev, cycles_remain, cycles_consumed, odometer);
+      ESP_LOGW(TAG, "HV contactor cycles alert: last: %d, now: %d, consumed: %d odo: %0.0f, counted more than expected!", cycles_prev, cycles_now, cycles_consumed, odometer);
       MyConfig.SetParamValueBool("xsq", "canwrite", false);
       MyConfig.SetParamValueBool("xsq", "canwrite.caron", false);
       smartCANmode(false);
       }
     // Alert if consumed cycles are above expected for a healthy contactor (e.g. above 50000 cycles consumed)
-    if(cycles_remain > 0 && cycles_consumed > m_above_cycles)
+    if(cycles_now > 0 && cycles_consumed > m_above_cycles)
       {
-      ESP_LOGW(TAG, "HV contactor cycles counted > %d: last: %d, now: %d, consumed: %d odo: %0.0f!", m_above_cycles, cycles_prev, cycles_remain, cycles_consumed, odometer);
+      ESP_LOGW(TAG, "HV contactor cycles counted > %d: last: %d, now: %d, consumed: %d odo: %0.0f!", m_above_cycles, cycles_prev, cycles_now, cycles_consumed, odometer);
       NotifyHVCycles(true);
       m_above_cycles = m_above_cycles * 1.25; // next alert at 25% more cycles counted
       }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -372,7 +372,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
       ESP_LOGW(TAG, "HV contactor cycles alert: last: %d, now: %d, consumed: %d odo: %0.0f, counted more than expected!", cycles_prev, cycles_now, cycles_consumed, odometer);
       MyConfig.SetParamValueBool("xsq", "canwrite", false);
       MyConfig.SetParamValueBool("xsq", "canwrite.caron", false);
-      smartCANmode(false);
+      smartOBDpolling(false);
       }
     // Alert if consumed cycles are above expected for a healthy contactor (e.g. above 50000 cycles consumed)
     if(cycles_now > 0 && cycles_consumed > m_above_cycles)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -85,33 +85,24 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
     smartCANmode(true);
     }
 
-  OvmsVehicle::vehicle_command_t res;
+  OvmsVehicle::vehicle_command_t res = Fail;
 
-  if (enable) 
+  if (enable && !IsOnHVACEQ()) 
     {
     uint8_t data[4] = {0x40, 0x01, 0x00, 0x00};
     canbus *obd;
     obd = m_can1;
-
-    res = CommandWakeup();
-    if (res == Success) 
+    res = Fail;
+    for (int i = 0; i < 10; i++) 
       {
-      vTaskDelay(2000 / portTICK_PERIOD_MS);
-      for (int i = 0; i < 10; i++) 
+      obd->WriteStandard(0x634, 4, data);
+      vTaskDelay(500 / portTICK_PERIOD_MS);
+      if (IsOnHVACEQ())
         {
-        obd->WriteStandard(0x634, 4, data);
-        vTaskDelay(500 / portTICK_PERIOD_MS);
-        if (IsOnHVACEQ()) 
-          {
-          ESP_LOGI(TAG, "Climate control started");
-          break;
-          }
-        }     
-      res = Success;
-      }
-    else
-      {
-      res = Fail;
+        ESP_LOGI(TAG, "Climate control started");
+        res = Success;
+        break;
+        }
       }
     }
   else
@@ -223,10 +214,10 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
     canbus *obd;
     obd = m_can1;
 
-    for (int i = 0; i < 10; i++) 
+    for (int i = 0; i < 15; i++) 
       {
       obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(500 / portTICK_PERIOD_MS);
+      vTaskDelay(200 / portTICK_PERIOD_MS);
       if (IsAwakeEQ()) 
         {
         res = Success;
@@ -234,54 +225,13 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
         }
       }
     res = Success;
+    can_awake = true;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 
   else 
     {
     res = Success;
     ESP_LOGI(TAG, "Vehicle is awake");
-    }
-  return res;
-}
-
-OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup2() {
-  if(!IsCANwrite())
-    {
-    ESP_LOGE(TAG, "CommandWakeup2 failed: no write access!");
-    return Fail;
-    }
-  // if write access is not enabled, then switch CAN bus to active mode for sending the command
-  if (!m_can_active)
-    {
-    smartCANmode(true);
-    }
-  ESP_LOGI(TAG, "Send Wakeup Command 2");  
-
-  OvmsVehicle::vehicle_command_t res = Fail;
-
-  if(!IsAwakeEQ()) 
-    {
-    ESP_LOGI(TAG, "Send Wakeup CommandWakeup2");
-    uint8_t data[8] = {0xc3, 0x11, 0x96, 0xef, 0x14, 0x10, 0x96, 0x85};
-    canbus *obd;
-    obd = m_can1;
-    for (int i = 0; i < 10; i++) 
-      {
-      obd->WriteStandard(0x350, 8, data);
-      vTaskDelay(500 / portTICK_PERIOD_MS);
-      if (IsAwakeEQ()) 
-        {
-        res = Success;
-        break;
-        }
-      }    
-    res = Success;
-    ESP_LOGI(TAG, "Vehicle is awake");
-    } 
-  else 
-    {
-    ESP_LOGI(TAG, "Vehicle is awake");
-    res = Success;
     }
   return res;
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -82,7 +82,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
   // if write access is not enabled, then switch CAN bus to active mode for sending the command
   if (!m_can_active)
     {
-    smartCANmode(true);
+    smartOBDpolling(true);
     }
 
   OvmsVehicle::vehicle_command_t res = Fail;
@@ -201,7 +201,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
   // if write access is not enabled, then switch CAN bus to active mode for sending the command
   if (!m_can_active)
     {
-    smartCANmode(true);
+    smartOBDpolling(true);
     }
 
   ESP_LOGI(TAG, "Send Wakeup Command");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -100,7 +100,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
       for (int i = 0; i < 10; i++) 
         {
         obd->WriteStandard(0x634, 4, data);
-        vTaskDelay(200 / portTICK_PERIOD_MS);
+        vTaskDelay(500 / portTICK_PERIOD_MS);
         if (IsOnHVACEQ()) 
           {
           ESP_LOGI(TAG, "Climate control started");
@@ -223,10 +223,10 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
     canbus *obd;
     obd = m_can1;
 
-    for (int i = 0; i < 15; i++) 
+    for (int i = 0; i < 10; i++) 
       {
       obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(200 / portTICK_PERIOD_MS);
+      vTaskDelay(500 / portTICK_PERIOD_MS);
       if (IsAwakeEQ()) 
         {
         res = Success;
@@ -268,7 +268,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup2() {
     for (int i = 0; i < 10; i++) 
       {
       obd->WriteStandard(0x350, 8, data);
-      vTaskDelay(200 / portTICK_PERIOD_MS);
+      vTaskDelay(500 / portTICK_PERIOD_MS);
       if (IsAwakeEQ()) 
         {
         res = Success;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -34,7 +34,7 @@ static const char *TAG = "v-smarteq";
 
 #include "vehicle_smarteq.h"
 
-// CommandCanVector(txid, rxid, hexbytes = {"30010000","30082002"}, reset CAN = true/false, CommandWakeup = true/ CommandWakeup2 = false)
+// CommandCanVector(txid, rxid, hexbytes = {"30010000","30082002"}, reset CAN = true/false, CommandWakeup = true/false)
 OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCanVector(uint32_t txid,uint32_t rxid, std::vector<std::string> hexbytes,bool reset,bool wakeup) {
   if(!IsCANwrite())
     {
@@ -82,12 +82,11 @@ OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCanVector(uint32_t tx
   mt_canbyte->SetValue(hexbytes[0].c_str());
 
   OvmsVehicle::vehicle_command_t res = Fail;
-  res = wakeup ? CommandWakeup() : CommandWakeup2();
+  res = wakeup ? CommandWakeup() : Success;
   
   if (res == Success)
     {
-    PollSetState(POLLSTATE_AWAKE);
-    vTaskDelay(2000 / portTICK_PERIOD_MS);
+    vTaskDelay(1500 / portTICK_PERIOD_MS);
     if (!IsAwakeEQ()) 
       {
       ESP_LOGE(TAG, "vehicle not awake");
@@ -346,13 +345,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandCanWrite(const std::st
 /**
  * writer for command line interface
  */
-void OvmsVehicleSmartEQ::xsq_wakeup(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv) {
-  OvmsVehicleSmartEQ* smarteq = GetInstance(writer);
-  if (!smarteq)
-    return;
-
-  smarteq->CommandWakeup2();
-}
 
 void OvmsVehicleSmartEQ::xsq_tpms_set(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv) {
   OvmsVehicleSmartEQ* smarteq = GetInstance(writer);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -51,7 +51,7 @@ OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCanVector(uint32_t tx
   // if write access is not enabled, then switch CAN bus to active mode for sending the command
   if (!m_can_active)
     {
-    smartCANmode(true);
+    smartOBDpolling(true);
     }
 
   m_ddt4all_exec = 10; // 10 seconds delay for next DDT4ALL command execution

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
@@ -134,7 +134,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
       #endif
       break;
     }
-    // CommandCanVector(txid, rxid, hexbytes = {"30010000","30082002"}, reset CAN = true/false, CommandWakeup = true/ CommandWakeup2 = false)
+    // CommandCanVector(txid, rxid, hexbytes = {"30010000","30082002"}, reset CAN = true/false, CommandWakeup = true/ false)
     case 6:
     {
       // BIPBIP_Lock false

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -507,8 +507,14 @@ void OvmsVehicleSmartEQ::smartSleep()
 
 void OvmsVehicleSmartEQ::smartChargeStart()
 {
-  if (m_charge_finished) ResetChargingValues();
-  if (m_resettrip) ResetTripCounters();
+  if (m_charge_finished)
+    {
+    m_poll_on_charge = true;
+    ResetChargingValues();
+    if (m_resettrip)
+      ResetTripCounters();
+    }
+  
   // Set charging metrics
   StdMetrics.ms_v_charge_pilot->SetValue(true);
   StdMetrics.ms_v_charge_mode->SetValue("standard");
@@ -523,9 +529,8 @@ void OvmsVehicleSmartEQ::smartChargeStart()
     m_ADCfactor_recalc = true;      // recalculate ADC factor when HV charging
     }
   // canwrite enable write access, only when car is on
-  if(IsCANwrite()) 
+  if(IsCANwrite() && !m_can_active) 
     {
-    m_poll_on_charge = true;
     smartCANmode(true);
     }
   ESP_LOGD(TAG, "smartChargeStart()");
@@ -543,17 +548,20 @@ void OvmsVehicleSmartEQ::smartChargeStop()
   StdMetrics.ms_v_charge_current->SetValue(0);
   StdMetrics.ms_v_charge_timestamp->SetValue(StdMetrics.ms_m_timeutc->AsInt());
 
-  if (StdMetrics.ms_v_bat_soc->AsInt() < 95) {
+  if (StdMetrics.ms_v_bat_soc->AsInt() < 95)
+    {
     // Assume the charge was interrupted
     ESP_LOGI(TAG,"charge session was interrupted");
     StdMetrics.ms_v_charge_state->SetValue("stopped");
     StdMetrics.ms_v_charge_substate->SetValue("interrupted");
-  } else {
+    }
+  else 
+    {
     // Assume the charge completed normally
     ESP_LOGI(TAG,"charge session completed");
     StdMetrics.ms_v_charge_state->SetValue("done");
     StdMetrics.ms_v_charge_substate->SetValue("onrequest");
-  }
+    }
   // stop recalculation when HV charging stopped
   m_ADCfactor_recalc_timer = 2;
   m_ADCfactor_recalc = false;
@@ -577,10 +585,10 @@ void OvmsVehicleSmartEQ::smartCANmode(bool activate)
 {
   if(!IsCANwrite())
     {
-    m_can1->Stop();
+    m_can1->Stop();    
+    PollSetPidList(m_can1, NULL);
     vTaskDelay(200 / portTICK_PERIOD_MS);
     m_can1->Start(CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
-    PollSetPidList(m_can1, NULL);
     m_can_active = false;
     m_poll_on_charge = false;
     ESP_LOGD(TAG, "smartCANmode(): CAN bus switched to listen mode");
@@ -591,7 +599,7 @@ void OvmsVehicleSmartEQ::smartCANmode(bool activate)
   m_can1->Stop();
   vTaskDelay(200 / portTICK_PERIOD_MS);
   CAN_mode_t mode = activate ? CAN_MODE_ACTIVE : CAN_MODE_LISTEN;
-  RegisterCanBus(1, mode, CAN_SPEED_500KBPS);
+  m_can1->Start(mode, CAN_SPEED_500KBPS);
   m_can_active = activate;
   m_poll_on_charge = m_poll_state == POLLSTATE_CHARGING ? true : false;
   if (activate)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -473,7 +473,7 @@ void OvmsVehicleSmartEQ::smartOn()
   // canwrite enable write access, only when car is on
   if(IsCANwrite()) 
     {
-    smartCANmode(true);
+    smartOBDpolling(true);
     }
   ESP_LOGD(TAG, "smartOn()");
 }
@@ -489,11 +489,11 @@ void OvmsVehicleSmartEQ::smartAwake()
   // enable active polling when car wakes up (canwrite only)
   if(m_enable_write) 
     {
-    smartCANmode(true);
+    smartOBDpolling(true);
     }
   else if (m_enable_write_caron && m_can_active)
     {
-    smartCANmode(false);
+    smartOBDpolling(false);
     }
 }
 
@@ -501,7 +501,7 @@ void OvmsVehicleSmartEQ::smartSleep()
 {
   // disable active polling when car goes to sleep
   if((m_enable_write_caron && m_can_active) || m_enable_write_sleep)
-    smartCANmode(false);
+    smartOBDpolling(false);
   ESP_LOGD(TAG, "smartSleep()");
 }
 
@@ -531,7 +531,7 @@ void OvmsVehicleSmartEQ::smartChargeStart()
   // canwrite enable write access, only when car is on
   if(IsCANwrite() && !m_can_active) 
     {
-    smartCANmode(true);
+    smartOBDpolling(true);
     }
   ESP_LOGD(TAG, "smartChargeStart()");
 }
@@ -581,7 +581,7 @@ void OvmsVehicleSmartEQ::smartChargeFinish()
   ESP_LOGD(TAG, "smartChargeFinish()");
 }
 
-void OvmsVehicleSmartEQ::smartCANmode(bool activate)
+void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
 {
   if(!IsCANwrite())
     {
@@ -589,7 +589,7 @@ void OvmsVehicleSmartEQ::smartCANmode(bool activate)
     vTaskDelay(200 / portTICK_PERIOD_MS);
     m_can_active = false;
     m_poll_on_charge = false;
-    ESP_LOGD(TAG, "smartCANmode(): CAN bus polling list cleared (write access disabled)");
+    ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared (write access disabled)");
     return;
     }
     
@@ -597,11 +597,11 @@ void OvmsVehicleSmartEQ::smartCANmode(bool activate)
   m_poll_on_charge = m_poll_state == POLLSTATE_CHARGING ? true : false;
   if (activate)
     {
-    ESP_LOGD(TAG, "smartCANmode(): CAN bus polling list will be updated");
+    ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list will be updated");
     }
   if (!activate)
     {
-    ESP_LOGD(TAG, "smartCANmode(): CAN bus polling list cleared");
+    ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared");
     }
   HandleOBDpolling();
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -585,30 +585,23 @@ void OvmsVehicleSmartEQ::smartCANmode(bool activate)
 {
   if(!IsCANwrite())
     {
-    m_can1->Stop();    
     PollSetPidList(m_can1, NULL);
     vTaskDelay(200 / portTICK_PERIOD_MS);
-    m_can1->Start(CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
     m_can_active = false;
     m_poll_on_charge = false;
-    ESP_LOGD(TAG, "smartCANmode(): CAN bus switched to listen mode");
+    ESP_LOGD(TAG, "smartCANmode(): CAN bus polling list cleared (write access disabled)");
     return;
     }
-  
-  // switch CAN bus to active/listen mode
-  m_can1->Stop();
-  vTaskDelay(200 / portTICK_PERIOD_MS);
-  CAN_mode_t mode = activate ? CAN_MODE_ACTIVE : CAN_MODE_LISTEN;
-  m_can1->Start(mode, CAN_SPEED_500KBPS);
+    
   m_can_active = activate;
   m_poll_on_charge = m_poll_state == POLLSTATE_CHARGING ? true : false;
   if (activate)
     {
-    ESP_LOGD(TAG, "smartCANmode(): CAN bus switched to active mode for write access");
+    ESP_LOGD(TAG, "smartCANmode(): CAN bus polling list will be updated");
     }
   if (!activate)
     {
-    ESP_LOGD(TAG, "smartCANmode(): CAN bus switched to listen mode");
+    ESP_LOGD(TAG, "smartCANmode(): CAN bus polling list cleared");
     }
   HandleOBDpolling();
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -58,11 +58,11 @@ void OvmsVehicleSmartEQ::HandlePollState() {
     }
   else if (IsOnEQ())
     {
-    desired_state = POLLSTATE_ON;    //- car is on
+    desired_state = POLLSTATE_ON;         //- car is on
     }
   else if (IsAwakeEQ())
     {
-    desired_state = POLLSTATE_AWAKE;         //- car is awake (but not on)
+    desired_state = POLLSTATE_AWAKE;      //- car is awake (but not on)
     }    
   else if (!IsAwakeEQ())
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -39,7 +39,7 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,300,10,4 }, 0, ISOTP_STD },     // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,10,10,10 }, 0, ISOTP_STD },     // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,60,10,10 }, 0, ISOTP_STD },     // HV Contactor Cycles
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,300,60,60 }, 0, ISOTP_STD },    // SOC
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,300,60,60 }, 0, ISOTP_STD },    // SOC Recalibration
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,300,60,60 }, 0, ISOTP_STD },    // Battery Health (SOH)
@@ -59,7 +59,7 @@ static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] =
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
   { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,3600,0,0 }, 0, ISOTP_STD },      // req.VIN
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,5,5,5 }, 0, ISOTP_STD },         // Doorlock EEPROM
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,8,8,8 }, 0, ISOTP_STD },         // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
@@ -73,20 +73,20 @@ static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,3600,0,0 }, 0, ISOTP_STD },      // Frame Traceability Information
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,16,0,16 }, 0, ISOTP_STD },  // Charging plug detected (B_PlugConnected_bcb_status_S)  
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,60,60,16 }, 0, ISOTP_STD }, // rqHV_Energy
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,14,14,14 }, 0, ISOTP_STD }, // Cabin blower command
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,60,60,60 }, 0, ISOTP_STD }, // Cabin blower command
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,14,14,14 }, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,14,14,14 }, 0, ISOTP_STD }, // DCDC activation request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,14,14,14 }, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,14,14,14 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,14,14,14 }, 0, ISOTP_STD }, // 14V DCDC current measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,14,14,14 }, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,14,14,14 }, 0, ISOTP_STD }, // USM 14V voltage (CAN)
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,14,14,14 }, 0, ISOTP_STD }, // Battery voltage 14V
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,60,14,14 }, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,60,14,14 }, 0, ISOTP_STD }, // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,60,14,14 }, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,60,14,14 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,60,14,14 }, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,60,14,14 }, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,60,14,14 }, 0, ISOTP_STD }, // USM 14V voltage (CAN)
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,60,14,14 }, 0, ISOTP_STD }, // Battery voltage 14V
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, { 0,300,0,300 }, 0, ISOTP_STD },  // Vehicle Speed
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, { 0,300,0,300 }, 0, ISOTP_STD },  // Total vehicle distance
 };

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -132,7 +132,6 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
 
   #ifdef CONFIG_OVMS_COMP_ADC
   if(IsOnEQ() || IsChargingEQ())
-     ReCalcADCfactor(StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f), nullptr);
     {
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
     if(m_check12vadc)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -93,7 +93,7 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   // if HVAC is on, then modify polling to get the DCDC data (reboot prevention)
   if (IsOnHVACEQ() && IsAwakeEQ() && m_enable_write_caron && !m_can_active)
     {
-    smartCANmode(true);
+    smartOBDpolling(true);
     }
   // if charging is in progress, then modify polling to get the DCDC/Charging data (reboot prevention)
   if (IsChargingEQ() && !m_poll_on_charge)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -159,7 +159,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_safety_mode_txt        = MyMetrics.InitString("xsq.bms.safety",SM_STALE_MID, "", Other);
 
   // Start CAN bus in Listen-only mode - will be set according to m_enable_write in ConfigChanged()
-  RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);  
+  RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
   PollSetState(POLLSTATE_OFF);
 
   // register config container for smart EQ module, with callback to ConfigChanged() on changes

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -303,7 +303,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // set CAN bus transceiver to active or listen-only depending on user selection
   if ( stateWrite != m_enable_write )
     {
-    smartCANmode(m_enable_write);
+    smartOBDpolling(m_enable_write);
     }
   // disable caron write mode if normal write mode is enabled to avoid conflicts
   if(m_enable_write_caron && m_enable_write) 
@@ -314,7 +314,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // start in listen-only mode if sleep write is enabled and bus is not awake
   if (m_enable_write_sleep && !IsAwakeEQ())
     {
-    smartCANmode(false);
+    smartOBDpolling(false);
     }
 
   bool do_modify_poll = (

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -158,8 +158,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_fusi_mode_txt          = MyMetrics.InitString("xsq.bms.fusi",SM_STALE_MID, "", Other);
   mt_bms_safety_mode_txt        = MyMetrics.InitString("xsq.bms.safety",SM_STALE_MID, "", Other);
 
-  // Start CAN bus in Listen-only mode - will be set according to m_enable_write in ConfigChanged()
-  RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
+  // Start CAN bus in CAN_MODE_ACTIVE mode
+  RegisterCanBus(1, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);
   PollSetState(POLLSTATE_OFF);
 
   // register config container for smart EQ module, with callback to ConfigChanged() on changes
@@ -174,7 +174,6 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   cmd_xsq->RegisterCommand("ddt4list", "DDT4all Command List", xsq_ddt4list);
   cmd_xsq->RegisterCommand("canwrite", "Send CAN command", xsq_canwrite,"<txid,rxid,hexbytes[,reset,wakeup]>",1,1);
   cmd_xsq->RegisterCommand("calcadc", "Recalculate ADC factor (optional: 12V voltage override)", xsq_calc_adc, "[voltage]", 0, 1);
-  cmd_xsq->RegisterCommand("wakeup", "Wake up the car", xsq_wakeup);
   cmd_xsq->RegisterCommand("ed4scan", "ED4scan-like BMS Data", xsq_ed4scan);
   cmd_xsq->RegisterCommand("preset", "smart EQ config preset", xsq_preset);
   cmd_xsq->RegisterCommand("default", "smart EQ config set default", xsq_setdefault);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -154,7 +154,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void smartChargeStop();
     void smartChargePrepare();
     void smartChargeFinish();
-    void smartCANmode(bool activate);
+    void smartOBDpolling(bool activate);
     void smartCAN2Metrics();
 
     // --- Command overrides ---

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -171,7 +171,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
 
     // --- Custom vehicle commands ---
     vehicle_command_t CommandCanVector(uint32_t txid, uint32_t rxid, std::vector<std::string> hexbytes, bool reset=false, bool wakeup=false);
-    vehicle_command_t CommandWakeup2();
     vehicle_command_t ProcessMsgCommand(std::string &result, int command, const char* args);
     vehicle_command_t MsgCommandCA(std::string &result, int command, const char* args);
     virtual vehicle_command_t CommandTripStart(int verbosity, OvmsWriter* writer);
@@ -218,7 +217,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     static void xsq_ddt4list(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_canwrite(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
-    static void xsq_wakeup(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_ed4scan(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_preset(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);
     static void xsq_tpms_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, const char* const* argv);


### PR DESCRIPTION
Multiple SmartEQ fixes and tweaks: use IsAwakeEQ() for awake metric, make HV contactor cycle processing robust (avoid false positives by using current/previous 'now' values, update logging and alerts), increase command delays (200ms -> 500ms) and reduce wakeup retries, adjust charge start/stop logic (set m_poll_on_charge, conditionally reset trip counters and gate CAN write when m_can_active), refine smartCANmode to properly stop/start bus and clear poll lists, fix Ticker60 ADC recalculation block, and update several poll intervals for various PIDs. Also includes minor formatting/logging improvements.