### PR TITLE
smartEQ: Refine CAN write/polling logic and web UI text

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -79,11 +79,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
     ESP_LOGI(TAG, "CommandClimateControl already on");
     return Success;
     }
-  // if write access is not enabled, then switch CAN bus to active mode for sending the command
-  if (!m_can_active)
-    {
-    smartOBDpolling(true);
-    }
 
   OvmsVehicle::vehicle_command_t res = Fail;
 
@@ -93,16 +88,16 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
     canbus *obd;
     obd = m_can1;
     res = Fail;
-    for (int i = 0; i < 10; i++) 
+    for (int i = 0; i < 15; i++) 
       {
-      obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(500 / portTICK_PERIOD_MS);
       if (IsOnHVACEQ())
         {
         ESP_LOGI(TAG, "Climate control started");
         res = Success;
         break;
         }
+      obd->WriteStandard(0x634, 4, data);
+      vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     }
   else
@@ -198,11 +193,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
     ESP_LOGE(TAG, "CommandWakeup failed: no write access!");
     return Fail;
     }
-  // if write access is not enabled, then switch CAN bus to active mode for sending the command
-  if (!m_can_active)
-    {
-    smartOBDpolling(true);
-    }
 
   ESP_LOGI(TAG, "Send Wakeup Command");
 
@@ -216,13 +206,13 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
 
     for (int i = 0; i < 15; i++) 
       {
-      obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(200 / portTICK_PERIOD_MS);
       if (IsAwakeEQ()) 
         {
         res = Success;
         break;
-        }
+        }      
+      obd->WriteStandard(0x634, 4, data);
+      vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
     can_awake = true;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -48,12 +48,6 @@ OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCanVector(uint32_t tx
     return Fail;
     }
 
-  // if write access is not enabled, then switch CAN bus to active mode for sending the command
-  if (!m_can_active)
-    {
-    smartOBDpolling(true);
-    }
-
   m_ddt4all_exec = 10; // 10 seconds delay for next DDT4ALL command execution
 
   ESP_LOGI(TAG, "CommandCanVector");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -487,7 +487,7 @@ void OvmsVehicleSmartEQ::smartOff()
 void OvmsVehicleSmartEQ::smartAwake()
 {
   // enable active polling when car wakes up (canwrite only)
-  if(m_enable_write && !m_can_active) 
+  if(m_enable_write) 
     {
     smartOBDpolling(true);
     }
@@ -509,12 +509,11 @@ void OvmsVehicleSmartEQ::smartChargeStart()
 {
   if (m_charge_finished)
     {
-    m_poll_on_charge = true;
     ResetChargingValues();
     if (m_resettrip)
       ResetTripCounters();
     }
-  
+  m_poll_on_charge = true;
   // Set charging metrics
   StdMetrics.ms_v_charge_pilot->SetValue(true);
   StdMetrics.ms_v_charge_mode->SetValue("standard");
@@ -528,11 +527,7 @@ void OvmsVehicleSmartEQ::smartChargeStart()
     m_ADCfactor_recalc_timer = 2;   // wait at least 2 min. before recalculation
     m_ADCfactor_recalc = true;      // recalculate ADC factor when HV charging
     }
-  // canwrite enable write access, only when car is on
-  if(IsCANwrite() && !m_can_active) 
-    {
-    smartOBDpolling(true);
-    }
+  smartOBDpolling(true);
   ESP_LOGD(TAG, "smartChargeStart()");
 }
 
@@ -594,12 +589,11 @@ void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
     }
     
   m_can_active = activate;
-  m_poll_on_charge = m_poll_state == POLLSTATE_CHARGING ? true : false;
   if (activate)
     {
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list will be updated");
     }
-  if (!activate)
+  else
     {
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared");
     }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -487,7 +487,7 @@ void OvmsVehicleSmartEQ::smartOff()
 void OvmsVehicleSmartEQ::smartAwake()
 {
   // enable active polling when car wakes up (canwrite only)
-  if(m_enable_write) 
+  if(m_enable_write && !m_can_active) 
     {
     smartOBDpolling(true);
     }
@@ -500,7 +500,7 @@ void OvmsVehicleSmartEQ::smartAwake()
 void OvmsVehicleSmartEQ::smartSleep()
 {
   // disable active polling when car goes to sleep
-  if((m_enable_write_caron && m_can_active) || m_enable_write_sleep)
+  if((m_enable_write_caron && m_can_active) || (m_enable_write_sleep && m_can_active))
     smartOBDpolling(false);
   ESP_LOGD(TAG, "smartSleep()");
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -118,7 +118,7 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
   if (m_obdii_745) // 745 PIDs Doorlock and VIN
     m_poll_vector.insert(m_poll_vector.end(), obdii_745_polls, endof_array(obdii_745_polls));
        
-  if (m_obdii_745_tpms) // full TPMS mode with individual pressure/temp/alert status for each wheel
+  if (m_obdii_745_tpms && IsOnEQ()) // full TPMS mode with individual pressure/temp/alert status for each wheel
     m_poll_vector.insert(m_poll_vector.end(), obdii_745_tpms_polls, endof_array(obdii_745_tpms_polls));
   
   if (m_obdii_79b_cell) // 79b PIDs cell V/R/T values with configurable intervals
@@ -141,7 +141,7 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
   if (m_obdii_743) // 743 PIDs Maintenance data, OBD trip counters
     m_poll_vector.insert(m_poll_vector.end(), obdii_743_polls, endof_array(obdii_743_polls));
   
-  if (m_poll_on_charge)
+  if (m_poll_on_charge && IsChargingEQ()) // additional PIDs to poll when charging, depending on fast/slow charger detected
     { 
     if (mt_obl_fastchg->AsBool(false)) 
       {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -141,7 +141,7 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
   if (m_obdii_743) // 743 PIDs Maintenance data, OBD trip counters
     m_poll_vector.insert(m_poll_vector.end(), obdii_743_polls, endof_array(obdii_743_polls));
   
-  if (m_poll_on_charge && IsChargingEQ()) // additional PIDs to poll when charging, depending on fast/slow charger detected
+  if (m_poll_on_charge) // additional PIDs to poll when charging, depending on fast/slow charger detected
     { 
     if (mt_obl_fastchg->AsBool(false)) 
       {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -204,12 +204,15 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.form_start(p.uri);
   
   c.fieldset_start("Remote Control");
-  c.input_checkbox("Enable CAN write access", "canwrite", canwrite,
-    "<p>Controls CAN write access (OBDII polling etc.)</p>");
-  c.input_checkbox("Enable CAN write only when car on/charging", "canwrite_caron", canwrite_caron,
-    "<p>Alternative to Canwrite; select one or neither!</p>");
+  c.input_checkbox("Enable CAN write access #1", "canwrite", canwrite,
+    "<p>Controls CAN write access all time (OBDII polling, start Preconditioning etc.)</p>");
+  c.input_checkbox("Enable CAN write access #2", "canwrite_caron", canwrite_caron,
+    "<p>Write access when car: on/charging and starting Preconditioning or trickle 12V charging is allowed</p>"
+    "<p>Clears polling list when vehicle is in awake/sleep mode</p>"
+    "<p>Alternative to CAN write access #1; select one or neither!</p>");
   c.input_checkbox("Disable CAN write during sleep", "canwrite_sleep", canwrite_sleep,
-    "<p>Switch CAN Bus to listen Mode when car is sleeping</p>");
+    "<p>Clears polling list when vehicle is in sleep mode</p>"
+    "<p>This option affects to CAN write access #1</p>");
   c.fieldset_end();
   
   // trip reset or OBD activation
@@ -223,14 +226,15 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input_checkbox("OBD kWh/100km value", "bcvalue", bcvalue,
     "<p>Show OBD kWh/100km</p>");
   c.input_slider("WLTP km", "full_km", 3, "km",-1, atof(full_km.c_str()), 126, 100, 180, 1,
-  "<p>Max range at full HV (126 WLTP, 155 NFEZ) for ideal range calc</p>");
+    "<p>Max range at full HV (126 WLTP, 155 NFEZ) for ideal range calc</p>");
   c.fieldset_end();
 
   c.fieldset_start("Diff Settings");
   c.input_checkbox("Online state LED", "led", led,
     "<p>RED=no inet, BLUE=inet, GREEN=v2 connected. EGPIO 7,8,9</p>");
-  c.input_checkbox("Enable 12V charging", "charge12v", charge12v,
-    "<p>Charge 12V on low-voltage alert</p>"); 
+  c.input_checkbox("Enable trickle 12V charging", "charge12v", charge12v,
+    "<p>Charge 12V battery on low-voltage alert</p>"
+    "<p>Trickle charging for the 12V battery is performed via pre-conditioning.</p>"); 
   c.input_checkbox("Door unlocked warning", "unlocked", unlocked,
     "<p>Warn if parked &gt;10min and unlocked</p>");
   c.input_checkbox("Door open warning", "opendoors", opendoors,

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -209,7 +209,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input_checkbox("Enable CAN write access #2", "canwrite_caron", canwrite_caron,
     "<p>CAN write access all time!</p>"
     "<p>Clears polling list when vehicle is in awake/sleep mode</p>"
-    "<p>This will stop polling (CAN access) when the vehicle is in awake/sleep mode</p>"
+    "<p>This will stop CAN polling when the vehicle is in awake/sleep mode</p>"
     "<p>Alternative to CAN write access #1; select one or neither!</p>");
   c.input_checkbox("Disable CAN polling during sleep", "canwrite_sleep", canwrite_sleep,
     "<p>Clears polling list when vehicle is in sleep mode</p>");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -205,14 +205,14 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   
   c.fieldset_start("Remote Control");
   c.input_checkbox("Enable CAN write access #1", "canwrite", canwrite,
-    "<p>Controls CAN write access all time (OBDII polling, start Preconditioning etc.)</p>");
+    "<p>CAN write access all time! (OBDII polling, start Preconditioning etc.)</p>");
   c.input_checkbox("Enable CAN write access #2", "canwrite_caron", canwrite_caron,
-    "<p>Write access when car: on/charging and starting Preconditioning or trickle 12V charging is allowed</p>"
+    "<p>CAN write access all time!</p>"
     "<p>Clears polling list when vehicle is in awake/sleep mode</p>"
+    "<p>This will stop polling (CAN access) when the vehicle is in awake/sleep mode</p>"
     "<p>Alternative to CAN write access #1; select one or neither!</p>");
-  c.input_checkbox("Disable CAN write during sleep", "canwrite_sleep", canwrite_sleep,
-    "<p>Clears polling list when vehicle is in sleep mode</p>"
-    "<p>This option affects to CAN write access #1</p>");
+  c.input_checkbox("Disable CAN polling during sleep", "canwrite_sleep", canwrite_sleep,
+    "<p>Clears polling list when vehicle is in sleep mode</p>");
   c.fieldset_end();
   
   // trip reset or OBD activation


### PR DESCRIPTION
Adjust smartEQ CAN write/polling behavior and related UI copy. Key changes:

- Remove automatic smartOBDpolling(true) invocations from several command paths to avoid switching the CAN bus active unnecessarily.
- Increase retry attempts for climate control/wakeup sequences (loops -> 15) and reduce inter-send delay from 500ms to 200ms; reorder send/check in loops so state is checked before/after writes to improve responsiveness.
- Update smartAwake/smartSleep guards to consider m_can_active and m_enable_write_sleep correctly to prevent unwanted polling toggles.
- Restrict certain polling vectors: only poll full TPMS when vehicle is on (IsOnEQ()), and only add charge-related polls when actually charging (IsChargingEQ()).
- Remove redundant polling activation in CommandCanVector.
- Update web configuration labels and helper text: clarify two CAN write options, refine descriptions for sleep behavior and 12V trickle charging.