### PR TITLE
smartEQ: Add CommandClimateControlEQ and 12V trickle support

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -34,8 +34,12 @@ static const char *TAG = "v-smarteq";
 
 #include "vehicle_smarteq.h"
 
-// can can1 tx st 634 40 01 72 00
+// can can1 tx st 634 40 01 00 00
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool enable) {
+  return CommandClimateControlEQ(enable, false, 0, false);
+}
+
+OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool enable, bool restart, int minutes, bool trickle) {
   
   if(!IsCANwrite())
     {
@@ -61,12 +65,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
       }
     }  
 
-  if (StandardMetrics.ms_v_bat_soc->AsInt(0) < 31)
+  if (StdMetrics.ms_v_bat_soc->AsInt(can_soc) < 31)
     {    
     char msg[100];
-    snprintf(msg, sizeof(msg), "Scheduled precondition skipped: Battery SOC too low (%d%%)",
-             StandardMetrics.ms_v_bat_soc->AsInt(0));
-    ESP_LOGW(TAG, "%s", msg);
+    snprintf(msg, sizeof(msg), "Scheduled precondition skipped: HV SOC too low (%d%%)", StdMetrics.ms_v_bat_soc->AsInt(can_soc));
+    ESP_LOGI(TAG, "%s", msg);
     MyNotify.NotifyString("alert", "climatecontrol.schedule", msg);
     m_climate_restart_ticker = 0;
     m_climate_restart = false; 
@@ -80,111 +83,94 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControl(bool en
     return Success;
     }
 
-  OvmsVehicle::vehicle_command_t res = Fail;
-
   if (enable && !IsOnHVACEQ()) 
     {
+    CommandWakeup();
     uint8_t data[4] = {0x40, 0x01, 0x00, 0x00};
     canbus *obd;
     obd = m_can1;
-    res = Fail;
     for (int i = 0; i < 15; i++) 
       {
       if (IsOnHVACEQ())
         {
-        ESP_LOGI(TAG, "Climate control started");
-        res = Success;
+        StdMetrics.ms_v_env_awake->SetValue(true);
+        ESP_LOGD(TAG, "Climate control is now on");
         break;
         }
       obd->WriteStandard(0x634, 4, data);
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
+
+    if (IsOnHVACEQ())
+      {
+      // if true, climate will be restarted after 5 minutes by Ticker1, if false, climate will not be restarted after 5 minutes
+      m_climate_restart = restart;
+      m_climate_restart_ticker = minutes;      
+      if (trickle) 
+        {
+        ESP_LOGI(TAG, "activated 12V trickle charging successfully");
+        Notify12Vcharge();
+        }
+      else
+        {
+        // add 2 minutes to display time if restart is true, because climate will be restarted after 5/10 minutes
+        int minutes_display = restart ? minutes + 2 : 5;
+        char msg[100];
+        snprintf(msg, sizeof(msg), "%d minutes precondition started, HV SOC is %d%%", minutes_display, StdMetrics.ms_v_bat_soc->AsInt(can_soc));
+        ESP_LOGI(TAG, "%s", msg);
+        MyNotify.NotifyString("info", "climatecontrol.schedule", msg);
+        }
+      return Success;
+      }
+    else
+      {
+      if (trickle) 
+        {
+        ESP_LOGI(TAG, "Failed to activate 12V trickle charging");
+        MyNotify.NotifyString("info", "12v.trickle.charge", "Failed to activate 12V trickle charging!");
+        }
+      else
+        {
+        ESP_LOGI(TAG, "Failed to activate precondition");
+        MyNotify.NotifyString("info", "climatecontrol.schedule","Failed to activate precondition!");
+        }
+      return Fail;
+      }
     }
   else
     {
-    res = NotImplemented;
+    // fallback to default implementation?
+    return OvmsVehicle::CommandClimateControl(enable);
     }
-  // fallback to default implementation?
-  if (res == NotImplemented) 
-    {
-    res = OvmsVehicle::CommandClimateControl(enable);
-    }
-  return res;
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandHomelink(int button, int durationms) {
-  // This is needed to enable climate control via Homelink for the iOS app
+  // This is needed to enable climate control via Homelink
   ESP_LOGI(TAG, "CommandHomelink button=%d durationms=%d", button, durationms);
-  OvmsVehicle::vehicle_command_t res = NotImplemented;
 
   switch (button)
   {
     case 0:
     {
-      res = CommandClimateControl(true);
-
-      if (res == Success)
-        {
-          m_climate_restart = false;
-          m_climate_restart_ticker = 0; // 5 minutes default runtime, no ticker required
-          ESP_LOGI(TAG, "Precondition activated successfully");
-          MyNotify.NotifyString("info", "climatecontrol.schedule",
-                                "5 minutes precondition started");
-        }
-      else
-        {
-          ESP_LOGE(TAG, "Failed to activate precondition (result=%d)", res);
-          MyNotify.NotifyString("error", "climatecontrol.schedule",
-                                "precondition failed to start");
-        }
-      break;
+      // 5 minutes default runtime, no ticker required
+      CommandClimateControlEQ(true,false,0,false);
+      return Success;
     }
     case 1:
     {
-      res = CommandClimateControl(true);
-
-      if (res == Success)
-        {
-          m_climate_restart = true;
-          m_climate_restart_ticker = 8; // 10 minutes
-          ESP_LOGI(TAG, "Precondition activated successfully");
-          MyNotify.NotifyString("info", "climatecontrol.schedule",
-                                "10 minutes precondition started");
-        }
-      else
-        {
-          ESP_LOGE(TAG, "Failed to activate precondition (result=%d)", res);
-          MyNotify.NotifyString("error", "climatecontrol.schedule",
-                                "precondition failed to start");
-        }
-      break;
+      // 10 minutes runtime, will be restarted after 5 minutes by Ticker60, so total runtime will be 10 minutes
+      CommandClimateControlEQ(true,true,8,false);
+      return Success;
     }
     case 2:
     { 
-      res = CommandClimateControl(true);
-
-      if (res == Success)
-        {
-          m_climate_restart = true;
-          m_climate_restart_ticker = 12; // 15 minutes
-          ESP_LOGI(TAG, "Precondition activated successfully");
-          MyNotify.NotifyString("info", "climatecontrol.schedule",
-                                "15 minutes precondition started");
-        }
-      else
-        {
-          ESP_LOGE(TAG, "Failed to activate precondition (result=%d)", res);
-          MyNotify.NotifyString("error", "climatecontrol.schedule",
-                                "precondition failed to start");
-        }
-      break;
+      // 15 minutes runtime, will be restarted after 5 and 10 minutes by Ticker60, so total runtime will be 15 minutes
+      CommandClimateControlEQ(true,true,13,false);
+      return Success;
     }
     default:
-      res = OvmsVehicle::CommandHomelink(button, durationms);
-      break;
+      return OvmsVehicle::CommandHomelink(button, durationms);
   }
-
-  return res;
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
@@ -215,7 +201,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
-    can_awake = true;
+    StdMetrics.ms_v_env_awake->SetValue(true);
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 
   else 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -390,9 +390,9 @@ void OvmsVehicleSmartEQ::xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCom
       writer->puts("Error: invalid number");
       return;
       }
-    if (val < 12.0 || val > 15.0) 
+    if (val < 11.0 || val > 16.0) 
       {
-      writer->puts("Error: voltage out of plausible range (12.0–15.0)");
+      writer->puts("Error: voltage out of plausible range (11.0–16.0)");
       return;
       }
     writer->printf("Recalculating ADC factor using override voltage %.2fV\n", val);
@@ -401,7 +401,7 @@ void OvmsVehicleSmartEQ::xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCom
     } 
   else if (argc == 0) 
     {
-    if (!StdMetrics.ms_v_env_charging12v->AsBool(false)) 
+    if (!smarteq->Is12VchargeEQ()) 
       {
       writer->puts("Error: vehicle 12V DC-DC converter not active");
       return;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -235,7 +235,6 @@ void OvmsVehicleSmartEQ::ResetTotalCounters() {
 
 // check the 12V alert periodically and charge the 12V battery if needed
 void OvmsVehicleSmartEQ::Check12vState() {
-  OvmsVehicle::vehicle_command_t res = NotImplemented;
   static const float MIN_VOLTAGE = 10.0f;
   static const int ALERT_THRESHOLD_TICKS = 10;
   
@@ -261,19 +260,7 @@ void OvmsVehicleSmartEQ::Check12vState() {
       {
         m_12v_ticker = 0;
         ESP_LOGI(TAG, "Initiating climate control due to 12V alert");
-        res = CommandClimateControl(true);
-
-      if (res == Success)
-        {
-        m_climate_restart = true;
-        m_climate_restart_ticker = 12; // 15 minutes
-        ESP_LOGI(TAG, "activated 12V charging successfully");
-        Notify12Vcharge();
-        }
-      else 
-        {
-        ESP_LOGE(TAG, "Failed to activate 12V charging");
-        }
+        CommandClimateControlEQ(true,true,8,true); // Start climate control with restart and 10 minutes duration
       }
     } 
   else if (m_12v_ticker > 0) 
@@ -285,7 +272,7 @@ void OvmsVehicleSmartEQ::Check12vState() {
 
 void OvmsVehicleSmartEQ::ReCalcADCfactor(float can12V, OvmsWriter* writer) {
   #ifdef CONFIG_OVMS_COMP_ADC
-    if (can12V < 12.0f || can12V > 15.0f) 
+    if (can12V < 11.0f || can12V > 16.0f) 
       {
       ESP_LOGW(TAG, "Skip ADC factor recalculation (invalid 12V input %.2f)", can12V);
       if (writer) writer->printf("Skip ADC factor recalculation (invalid 12V input %.2f)\n", can12V);
@@ -300,7 +287,7 @@ void OvmsVehicleSmartEQ::ReCalcADCfactor(float can12V, OvmsWriter* writer) {
     // Collect samples
     for (int i = 0; i < m_adc_samples; i++) 
       {
-      vTaskDelay(2 / portTICK_PERIOD_MS);
+      vTaskDelay(5 / portTICK_PERIOD_MS);
       samples_adc[i] = adc1_get_raw(ADC1_CHANNEL_0);
       }
 
@@ -346,9 +333,9 @@ void OvmsVehicleSmartEQ::ReCalcADCfactor(float can12V, OvmsWriter* writer) {
     // Calculate average of USM voltage samples
     float V_batt = can12V;
 
-    float adc_factor_median = (V_batt > 12.0f) ? (median_raw / V_batt) : 0.0f;
-    float adc_factor_avg = (V_batt > 12.0f) ? (avg_raw / V_batt) : 0.0f;
-    float adc_factor_trimmed = (V_batt > 12.0f) ? (trimmed_avg / V_batt) : 0.0f;
+    float adc_factor_median = (V_batt > 11.0f) ? (median_raw / V_batt) : 0.0f;
+    float adc_factor_avg = (V_batt > 11.0f) ? (avg_raw / V_batt) : 0.0f;
+    float adc_factor_trimmed = (V_batt > 11.0f) ? (trimmed_avg / V_batt) : 0.0f;
 
     float adc_factor_new = adc_factor_median;
     float adc_factor_prev = MyConfig.GetParamValueFloat("system.adc", "factor12v", 195.7f);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
@@ -165,7 +165,7 @@ void OvmsVehicleSmartEQ::NotifySOClimit() {
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::Command12Vcharge(int verbosity, OvmsWriter* writer) {
-  writer->puts("12V charge on:"); 
+  writer->puts("12V trickle charge on:"); 
   writer->printf("  12V: %s\n", (char*) StdMetrics.ms_v_bat_12v_voltage->AsUnitString("-", Native, 1).c_str());
   writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
   writer->printf("  CAP: %s\n", (char*) StdMetrics.ms_v_bat_capacity->AsUnitString("-", Native, 1).c_str());

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -83,12 +83,11 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
     OnlineState();
 
   // check 12V charging state for powermgmt system
-  bool charge_12v = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) > 13.1f ? true : false;
-  if (charge_12v != StdMetrics.ms_v_env_charging12v->AsBool(false))
+  if (Is12VchargeEQ() != StdMetrics.ms_v_env_charging12v->AsBool(false))
     {
-    StdMetrics.ms_v_env_charging12v->SetValue(charge_12v);    
+    StdMetrics.ms_v_env_charging12v->SetValue(Is12VchargeEQ());    
     m_ADCfactor_recalc_timer = 2;
-    m_ADCfactor_recalc = charge_12v;
+    m_ADCfactor_recalc = Is12VchargeEQ();
     }  
   // if HVAC is on, then modify polling to get the DCDC data (reboot prevention)
   if (IsOnHVACEQ() && IsAwakeEQ() && m_enable_write_caron && !m_can_active)
@@ -99,6 +98,11 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   if (IsChargingEQ() && !m_poll_on_charge)
     {
     smartChargeStart();
+    }
+  if (IsAwakeEQ() != StdMetrics.ms_v_env_awake->AsBool(false))
+    {
+    // if car is not awake but metric is, then set metric to false to prevent desync
+    StdMetrics.ms_v_env_awake->SetValue(IsAwakeEQ());
     }
   }
 
@@ -185,7 +189,7 @@ void OvmsVehicleSmartEQ::PollerStateTicker(canbus *bus)
     m_candata_timer = SQ_CANDATA_TIMEOUT;
     }
   
-  if (m_candata_timer > 0 && --m_candata_timer == 0 && m_candata_poll) 
+  if ((!IsAwakeEQ()) || (m_candata_timer > 0 && --m_candata_timer == 0 && m_candata_poll))
     {
     // Car has gone to sleep
     ESP_LOGI(TAG,"Car has gone to sleep (CAN bus timeout)");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -158,7 +158,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void smartCAN2Metrics();
 
     // --- Command overrides ---
-    vehicle_command_t CommandClimateControl(bool enable) override;
+    vehicle_command_t CommandClimateControl(bool enable) override; // Override to add support for preconditioning and 12V trickle charge -> CommandClimateControlEQ
     vehicle_command_t CommandHomelink(int button, int durationms=1000) override;
     vehicle_command_t CommandWakeup() override;
     vehicle_command_t CommandStat(int verbosity, OvmsWriter* writer) override;
@@ -170,6 +170,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     vehicle_command_t CommandStopCharge() override;
 
     // --- Custom vehicle commands ---
+    
+    vehicle_command_t CommandClimateControlEQ(bool enable, bool restart = false, int minutes = 0, bool trickle = false);
     vehicle_command_t CommandCanVector(uint32_t txid, uint32_t rxid, std::vector<std::string> hexbytes, bool reset=false, bool wakeup=false);
     vehicle_command_t ProcessMsgCommand(std::string &result, int command, const char* args);
     vehicle_command_t MsgCommandCA(std::string &result, int command, const char* args);
@@ -231,6 +233,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
     bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
+    bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) > 13.1f || StdMetrics.ms_v_env_charging12v->AsBool(false); }
 
   // =========================================================================
   // protected


### PR DESCRIPTION
Refactor climate control into a new CommandClimateControlEQ API to support preconditioning duration, restart behavior and 12V trickle charging. CommandClimateControl now delegates to the new function; Homelink commands simplified to call it directly. Add Is12VchargeEQ helper and use StdMetrics updates for awake/charging state to avoid metric desyncs. Broaden ADC recalculation acceptance range (12–15 -> 11–16), increase sampling delay, and adjust recalculation logic accordingly. Ticker/Poller logic and various logs/notifications updated to reflect the new flow and improve reporting on failures/successes.