### PR TITLE
smartEQ: Add 12V trickle-charge count and alert

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,7 +1,12 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
-
+- smart EQ:
+    As soon as the 12V trickle charge begins, a timestamp is generated and stored in `m_12v_trickle_charge_times`.
+    The counted value is set in `xsq.12v.trickle.count`.
+    Within `Ticker3600`, a routine removes all timestamps older than 24 hours and updates `xsq.12v.trickle.count` by -1.
+    New metric:
+      xsq.12v.trickle.count             -- Count of 12V trickle-charge cycles in 24h
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -228,6 +228,7 @@ xsq.bms.interlock.hvplug               HV plug interlock status [bool]
 xsq.bms.interlock.service              Service interlock status [bool]
 xsq.bms.fusi                           FUSI mode text
 xsq.bms.safety                         Safety mode text
+xsq.12v.trickle.count                  12V trickle charge counted in 24h, reset to 0 after 24h. Alert if count == 3 in 24h [count]
 =========================== ==============
 
 -------------------------

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -267,6 +267,7 @@ void OvmsVehicleSmartEQ::smartCAN2Metrics()
   StdMetrics.ms_v_env_headlights->SetValue(can_headlights);
   StdMetrics.ms_v_env_gear->SetValue(can_gear);
   StdMetrics.ms_v_env_cabintemp->SetValue(can_cabintemp);
+  StdMetrics.ms_v_env_charging12v->SetValue(Is12VchargeEQ());
 
   StdMetrics.ms_v_door_fl->SetValue(can_door_fl);
   StdMetrics.ms_v_door_fr->SetValue(can_door_fr);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -357,11 +357,14 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
     //  <cycles_max>,<cycles_prev>,<cycles_now>,<cycles_diff>,<odometer>
     //V2:
     //  ,<bms_mileage>,<can_soc>,<can_soh>,<USM_12V>,<contactor_state>,<bms_prod_data>,<bat_serial>,<evc_traceability>
-    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,2,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s",
+    //V3:
+    //  ,<12V_trickle_charge_count within 24h>
+    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,3,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s,%d",
       86400 * 30, // hold time 30 days
       cycles_max, cycles_prev, cycles_now, cycles_diff, odometer, 
       mt_bms_mileage->AsFloat(), can_soc, can_soh, mt_evc_dcdc->GetElemValue(3), mt_bms_HVcontactStateTXT->AsString().c_str(),
-        mp_encode(mt_bms_prod_data->AsString()).c_str(), mt_bat_serial->AsString().c_str(), mp_encode(mt_evc_traceability->AsString()).c_str());
+      mp_encode(mt_bms_prod_data->AsString()).c_str(), mt_bat_serial->AsString().c_str(), mp_encode(mt_evc_traceability->AsString()).c_str(),
+      mt_12v_trickle_charge_count->AsInt(0));
     // Send alert in case of a large unexpected jump
     if (cycles_prev > cycles_now && cycles_diff > 100) 
       {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -775,8 +775,7 @@ void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_ActReq(const char* data, uint16_t re
   // Spec: bitoffset 7, bitscount 1 (MSB of byte 0 in payload)
   REQUIRE_LEN(1);
   uint8_t raw = CAN_BYTE(0);
-  bool active = raw != 0;  // Bit 7
-  StdMetrics.ms_v_env_charging12v->SetValue(active);
+  can_charging12v = raw != 0;  // Bit 7  
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_VoltReq(const char* data, uint16_t reply_len) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -119,7 +119,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
         m_12v_trickle_charge_times.push_back((uint32_t)now);
         mt_12v_trickle_charge_count->SetValue((int)m_12v_trickle_charge_times.size());
 
-        if (m_12v_trickle_charge_times.size() == 3)
+        if (mt_12v_trickle_charge_count->AsInt(0) == 3)
           {
           ESP_LOGW(TAG, "12V trickle charging activated 3 times within 24h");
           MyNotify.NotifyString("alert", "xsq.12v.charge.alert",

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -109,7 +109,31 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
       if (trickle) 
         {
         ESP_LOGI(TAG, "activated 12V trickle charging successfully");
-        Notify12Vcharge();
+        // Check the 12V ADC factors based on the 12V readings, as long as trickle charging is active.
+        m_check12vadc = true;
+
+        time_t now = time(NULL);
+        while (!m_12v_trickle_charge_times.empty() && (now - m_12v_trickle_charge_times.front()) > 24 * 3600)
+          m_12v_trickle_charge_times.pop_front();
+
+        m_12v_trickle_charge_times.push_back((uint32_t)now);
+        mt_12v_trickle_charge_count->SetValue((int)m_12v_trickle_charge_times.size());
+
+        if (m_12v_trickle_charge_times.size() == 3)
+          {
+          ESP_LOGW(TAG, "12V trickle charging activated 3 times within 24h");
+          MyNotify.NotifyString("alert", "xsq.12v.charge.alert",
+                            "12V trickle charging was activated 3 times within 24 hours.\n"
+                            "Check the 12V battery condition.\n"
+                            "If the alert appears frequently, consider replacing the 12V battery preventively."
+                            "The trickle charging will be deactivated now to next reboot to prevent further stress on the 12V battery!");
+          m_12v_charge = false; // deactivate trickle charging to prevent further stress on the 12V battery
+          }
+        else
+          {
+          ESP_LOGI(TAG, "12V trickle charging activation count within 24h: %u", (unsigned)m_12v_trickle_charge_times.size());          
+          Notify12Vcharge();
+          }
         }
       else
         {
@@ -128,6 +152,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
         {
         ESP_LOGI(TAG, "Failed to activate 12V trickle charging");
         MyNotify.NotifyString("info", "12v.trickle.charge", "Failed to activate 12V trickle charging!");
+
         }
       else
         {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -38,22 +38,22 @@
 static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,300,10,4 }, 0, ISOTP_STD },     // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,60,10,10 }, 0, ISOTP_STD },     // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,300,60,60 }, 0, ISOTP_STD },    // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,300,60,60 }, 0, ISOTP_STD },    // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,300,60,60 }, 0, ISOTP_STD },    // Battery Health (SOH)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,3600,0,0 }, 0, ISOTP_STD },     // BMS Production Number Supplier Read
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,60,10,4 }, 0, ISOTP_STD },     // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,60,10,10 }, 0, ISOTP_STD },    // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,60,60,60 }, 0, ISOTP_STD },    // SOC
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,60,60,60 }, 0, ISOTP_STD },    // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Health (SOH)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,3600,0,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
 };
 
 //   -> HandleOBDpolling() will add the following PIDs with modified intervals m_cfg_cell_interval_drv/m_cfg_cell_interval_chg
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,600,60,60 }, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,600,60,60 }, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,600,60,60 }, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,600,60,60 }, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,600,60,60 }, 0, ISOTP_STD },    // Battery Temperatures (27 sensors)    
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,60,60,60 }, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,60,60,60 }, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Temperatures (27 sensors)    
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
@@ -87,16 +87,16 @@ static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,60,14,14 }, 0, ISOTP_STD }, // rqDCDC_Power
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,60,14,14 }, 0, ISOTP_STD }, // USM 14V voltage (CAN)
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,60,14,14 }, 0, ISOTP_STD }, // Battery voltage 14V
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, { 0,300,0,300 }, 0, ISOTP_STD },  // Vehicle Speed
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, { 0,300,0,300 }, 0, ISOTP_STD },  // Total vehicle distance
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, { 0,60,0,60 }, 0, ISOTP_STD },  // Vehicle Speed
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, { 0,60,0,60 }, 0, ISOTP_STD },  // Total vehicle distance
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,600,600,600 }, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,600,60,0 }, 0, ISOTP_STD }, // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,600,60,0 }, 0, ISOTP_STD }, // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,600,60,0 }, 0, ISOTP_STD }, // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,60,60,60 }, 0, ISOTP_STD }, // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,60,60,0 }, 0, ISOTP_STD }, // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,60,60,0 }, 0, ISOTP_STD }, // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,60,60,0 }, 0, ISOTP_STD }, // OBD start Trip time s
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,3600,0,0 }, 0, ISOTP_STD }, // maintenance data days
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,3600,0,0 }, 0, ISOTP_STD }, // maintenance data usual km
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,3600,0,0 }, 0, ISOTP_STD }, // maintenance level

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -67,6 +67,16 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
 
 void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker) 
   {
+  // if awake state has changed, then update metric to prevent desync
+  if (IsAwakeEQ() != StdMetrics.ms_v_env_awake->AsBool(false))
+    {
+    StdMetrics.ms_v_env_awake->SetValue(IsAwakeEQ());
+    }
+  // if 12V charging state has changed, then update metric to prevent desync
+  if (Is12VchargeEQ() != StdMetrics.ms_v_env_charging12v->AsBool(false))
+    {
+    StdMetrics.ms_v_env_charging12v->SetValue(Is12VchargeEQ());
+    } 
   // reactivate door lock warning if the car is parked and unlocked
   if( m_enable_lock_state && 
         m_warning_unlocked &&
@@ -82,13 +92,6 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   if(m_enable_LED_state) 
     OnlineState();
 
-  // check 12V charging state for powermgmt system
-  if (Is12VchargeEQ() != StdMetrics.ms_v_env_charging12v->AsBool(false))
-    {
-    StdMetrics.ms_v_env_charging12v->SetValue(Is12VchargeEQ());    
-    m_ADCfactor_recalc_timer = 2;
-    m_ADCfactor_recalc = Is12VchargeEQ();
-    }  
   // if HVAC is on, then modify polling to get the DCDC data (reboot prevention)
   if (IsOnHVACEQ() && IsAwakeEQ() && IsCANwrite() && !m_can_active)
     {
@@ -98,11 +101,6 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   if (IsChargingEQ() && !m_poll_on_charge)
     {
     smartChargeStart();
-    }
-  if (IsAwakeEQ() != StdMetrics.ms_v_env_awake->AsBool(false))
-    {
-    // if car is not awake but metric is, then set metric to false to prevent desync
-    StdMetrics.ms_v_env_awake->SetValue(IsAwakeEQ());
     }
   } // Ticker 10
 
@@ -201,7 +199,7 @@ void OvmsVehicleSmartEQ::PollerStateTicker(canbus *bus)
     m_candata_timer = SQ_CANDATA_TIMEOUT;
     }
   
-  if ((!IsAwakeEQ()) || (m_candata_timer > 0 && --m_candata_timer == 0 && m_candata_poll))
+  if (m_candata_timer > 0 && --m_candata_timer == 0 && m_candata_poll)
     {
     // Car has gone to sleep
     ESP_LOGI(TAG,"Car has gone to sleep (CAN bus timeout)");
@@ -211,6 +209,6 @@ void OvmsVehicleSmartEQ::PollerStateTicker(canbus *bus)
   
   // - base system is awake if we've got a fresh lv_pwrstate:
   // use CAN 0x350 state for 12V aux state, because it seems to be more reliable than the 12V voltage for detecting if the car is in accessory mode or not, which is needed for the powermgmt system
-  StdMetrics.ms_v_env_aux12v->SetValue(IsHVonEQ());
+  StdMetrics.ms_v_env_aux12v->SetValue(Is12VchargeEQ());
   HandlePollState();
   }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -90,7 +90,7 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
     m_ADCfactor_recalc = Is12VchargeEQ();
     }  
   // if HVAC is on, then modify polling to get the DCDC data (reboot prevention)
-  if (IsOnHVACEQ() && IsAwakeEQ() && m_enable_write_caron && !m_can_active)
+  if (IsOnHVACEQ() && IsAwakeEQ() && IsCANwrite() && !m_can_active)
     {
     smartOBDpolling(true);
     }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -63,7 +63,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     {
     m_cmd_locked = false; // reset command lock when car is opened
     }
-  }
+  } // Ticker 1
 
 void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker) 
   {
@@ -104,11 +104,12 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
     // if car is not awake but metric is, then set metric to false to prevent desync
     StdMetrics.ms_v_env_awake->SetValue(IsAwakeEQ());
     }
-  }
+  } // Ticker 10
 
-void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {  
+void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) 
+  {  
   if(m_12v_charge && !IsOnEQ()) 
-    Check12vState();
+    Check12vState();  
   if(m_enable_lock_state && !m_warning_unlocked && StdMetrics.ms_v_env_parktime->AsInt() > m_park_timeout_secs +10) 
     DoorLockState();
   if(m_enable_door_state && !m_warning_dooropen && StdMetrics.ms_v_env_parktime->AsInt() > m_park_timeout_secs +10) 
@@ -135,17 +136,16 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
     }
 
   #ifdef CONFIG_OVMS_COMP_ADC
-  bool charging12v = StdMetrics.ms_v_env_charging12v->AsBool(false);
-  float can12V = mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
-  if((IsOnEQ() || IsChargingEQ()) && (charging12v && can12V > 13.3f && can12V < 15.1f))
+  if((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ())
     {
+    float can12V = mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
     if(m_check12vadc)
       {
       float can12V = mt_evc_dcdc->GetElemValue(1);
       float adc12V = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
       float diff = fabs(can12V - adc12V);      
-      if (diff > 0.1f && !m_ADCfactor_recalc && charging12v)      
+      if (diff > 0.1f && !m_ADCfactor_recalc && Is12VchargeEQ())      
         {
         ESP_LOGW(TAG, "12V voltage difference detected: CAN=%.2fV, ADC=%.2fV, diff=%.2fV", can12V, adc12V, diff);
         m_ADCfactor_recalc_timer = 2;   // wait at least 2 min. before recalculation
@@ -162,7 +162,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
         m_ADCfactor_recalc = false;
         m_ADCfactor_recalc_timer = 2;
         // calculate new ADC factor         
-        if (charging12v)
+        if (Is12VchargeEQ())
           {
           ReCalcADCfactor(can12V, nullptr);  // nullptr = no Log-Output
           ESP_LOGI(TAG, "Auto ADC recalibration started (%.2fV)", can12V);
@@ -175,7 +175,19 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker) {
       }
     }
   #endif
-}
+  } // Ticker 60
+
+void OvmsVehicleSmartEQ::Ticker3600(uint32_t ticker) 
+  { 
+  if (mt_12v_trickle_charge_count->AsInt(0) > 0)
+    {
+    // remove timestamps older than 24h
+    time_t now = time(NULL);
+    while (!m_12v_trickle_charge_times.empty() && (now - m_12v_trickle_charge_times.front()) > 24 * 3600)
+      m_12v_trickle_charge_times.pop_front();
+    mt_12v_trickle_charge_count->SetValue((int)m_12v_trickle_charge_times.size());
+    }
+  } // Ticker 3600
 
 /**
  * PollerStateTicker: check for state changes

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -253,44 +253,44 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   
   if (map)
     {
-    m_enable_write         = map->GetValueBool("canwrite", m_enable_write);
-    m_enable_write_caron   = map->GetValueBool("canwrite.caron", m_enable_write_caron);
-    m_enable_write_sleep   = map->GetValueBool("canwrite.sleep", m_enable_write_sleep);
-    m_enable_LED_state     = map->GetValueBool("led", m_enable_LED_state);
-    m_bcvalue              = map->GetValueBool("bcvalue", m_bcvalue);
-    m_enable_lock_state    = map->GetValueBool("unlock.warning", m_enable_lock_state);
-    m_enable_door_state    = map->GetValueBool("door.warning", m_enable_door_state);
-    m_resettrip            = map->GetValueBool("resettrip", m_resettrip);
-    m_resettotal           = map->GetValueBool("resettotal", m_resettotal);
-    m_tripnotify           = map->GetValueBool("reset.notify", m_tripnotify);
-    m_tpms_alert_enable    = map->GetValueBool("tpms.alert.enable", m_tpms_alert_enable);
-    m_tpms_temp_enable     = map->GetValueBool("tpms.temp", m_tpms_temp_enable);
-    m_12v_charge           = map->GetValueBool("12v.charge", m_12v_charge);
-    m_enable_calcADCfactor = map->GetValueBool("calc.adcfactor", m_enable_calcADCfactor);
-    m_indicator            = map->GetValueBool("indicator", m_indicator);
-    m_extendedStats        = map->GetValueBool("extended.stats", m_extendedStats);
-    obdii_79b              = map->GetValueBool("obdii.79b", m_obdii_79b);
-    obdii_79b_cell         = map->GetValueBool("obdii.79b.cell", m_obdii_79b_cell);
-    obdii_743              = map->GetValueBool("obdii.743", m_obdii_743);
-    obdii_745              = map->GetValueBool("obdii.745", m_obdii_745);
-    obdii_745_tpms         = map->GetValueBool("obdii.745.tpms", m_obdii_745_tpms);
-    obdii_7e4              = map->GetValueBool("obdii.7e4", m_obdii_7e4);
-    obdii_7e4_dcdc         = map->GetValueBool("obdii.7e4.dcdc", m_obdii_7e4_dcdc);
+    m_enable_write         = map->GetValueBool("canwrite", false);
+    m_enable_write_caron   = map->GetValueBool("canwrite.caron", false);
+    m_enable_write_sleep   = map->GetValueBool("canwrite.sleep", false);
+    m_enable_LED_state     = map->GetValueBool("led", false);
+    m_bcvalue              = map->GetValueBool("bcvalue", false);
+    m_enable_lock_state    = map->GetValueBool("unlock.warning", true);
+    m_enable_door_state    = map->GetValueBool("door.warning", true);
+    m_resettrip            = map->GetValueBool("resettrip", true);
+    m_resettotal           = map->GetValueBool("resettotal", false);
+    m_tripnotify           = map->GetValueBool("reset.notify", false);
+    m_tpms_alert_enable    = map->GetValueBool("tpms.alert.enable", true);
+    m_tpms_temp_enable     = map->GetValueBool("tpms.temp", true);
+    m_12v_charge           = map->GetValueBool("12v.charge", true);
+    m_enable_calcADCfactor = map->GetValueBool("calc.adcfactor", false);
+    m_indicator            = map->GetValueBool("indicator", false);
+    m_extendedStats        = map->GetValueBool("extended.stats", false);
+    obdii_79b              = map->GetValueBool("obdii.79b", true);
+    obdii_79b_cell         = map->GetValueBool("obdii.79b.cell", true);
+    obdii_743              = map->GetValueBool("obdii.743", true);
+    obdii_745              = map->GetValueBool("obdii.745", true);
+    obdii_745_tpms         = map->GetValueBool("obdii.745.tpms", true);
+    obdii_7e4              = map->GetValueBool("obdii.7e4", true);
+    obdii_7e4_dcdc         = map->GetValueBool("obdii.7e4.dcdc", true);
 
-    m_reboot_time          = map->GetValueInt("rebootnw", m_reboot_time);
-    m_park_timeout_secs    = map->GetValueInt("park.timeout", m_park_timeout_secs);
-    m_full_km              = map->GetValueInt("full.km", m_full_km);
-    m_cfg_preset_version   = map->GetValueInt("cfg.preset.ver", m_cfg_preset_version);
-    m_suffsoc              = map->GetValueInt("suffsoc", m_suffsoc);
-    m_suffrange            = map->GetValueInt("suffrange", m_suffrange);
-    cell_interval_drv      = map->GetValueInt("cell_interval_drv", cell_interval_drv);
-    cell_interval_chg      = map->GetValueInt("cell_interval_chg", cell_interval_chg);
-    m_above_cycles         = map->GetValueInt("bms.alert.above.cycles", m_above_cycles);
+    m_reboot_time          = map->GetValueInt("rebootnw", 30);
+    m_park_timeout_secs    = map->GetValueInt("park.timeout", 600);
+    m_full_km              = map->GetValueInt("full.km", 126);
+    m_cfg_preset_version   = map->GetValueInt("cfg.preset.ver", 0);
+    m_suffsoc              = map->GetValueInt("suffsoc", 0);
+    m_suffrange            = map->GetValueInt("suffrange", 0);
+    cell_interval_drv      = map->GetValueInt("cell_interval_drv", 60);
+    cell_interval_chg      = map->GetValueInt("cell_interval_chg", 60);
+    m_above_cycles         = map->GetValueInt("bms.alert.above.cycles", 50000);
     
-    m_front_pressure       = map->GetValueFloat("tpms.front.pressure", m_front_pressure);
-    m_rear_pressure        = map->GetValueFloat("tpms.rear.pressure", m_rear_pressure);
-    m_pressure_warning     = map->GetValueFloat("tpms.value.warn", m_pressure_warning);
-    m_pressure_alert       = map->GetValueFloat("tpms.value.alert", m_pressure_alert);
+    m_front_pressure       = map->GetValueFloat("tpms.front.pressure", 225.0f);
+    m_rear_pressure        = map->GetValueFloat("tpms.rear.pressure", 255.0f);
+    m_pressure_warning     = map->GetValueFloat("tpms.value.warn", 40.0f);
+    m_pressure_alert       = map->GetValueFloat("tpms.value.alert", 70.0f);
     }
 
 #ifdef CONFIG_OVMS_COMP_MAX7317

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -121,6 +121,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_evc_dcdc->SetElemValue(7, 0.0f);           // Pre-allocate 8 entries
   mt_evc_traceability           = MyMetrics.InitString("xsq.evc.traceability", SM_STALE_MAX, "");
   mt_evc_plug_detected          = MyMetrics.InitBool("xsq.evc.plug.detected", SM_STALE_MIN, false);
+  mt_12v_trickle_charge_count   = MyMetrics.InitInt("xsq.12v.trickle.count", SM_STALE_MAX, 0, Other);
   // 0x793 OBL charger metrics
   mt_obl_fastchg                = MyMetrics.InitBool("xsq.obl.fastchg", SM_STALE_MIN, false);
   mt_obl_main_volts             = MyMetrics.InitVector<float>("xsq.obl.volts", SM_STALE_HIGH, nullptr, Volts);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -253,44 +253,44 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   
   if (map)
     {
-    m_enable_write         = map->GetValueBool("canwrite", false);
-    m_enable_write_caron   = map->GetValueBool("canwrite.caron", false);
-    m_enable_write_sleep   = map->GetValueBool("canwrite.sleep", false);
-    m_enable_LED_state     = map->GetValueBool("led", false);
-    m_bcvalue              = map->GetValueBool("bcvalue", false);
-    m_enable_lock_state    = map->GetValueBool("unlock.warning", true);
-    m_enable_door_state    = map->GetValueBool("door.warning", true);
-    m_resettrip            = map->GetValueBool("resettrip", true);
-    m_resettotal           = map->GetValueBool("resettotal", false);
-    m_tripnotify           = map->GetValueBool("reset.notify", false);
-    m_tpms_alert_enable    = map->GetValueBool("tpms.alert.enable", true);
-    m_tpms_temp_enable     = map->GetValueBool("tpms.temp", true);
-    m_12v_charge           = map->GetValueBool("12v.charge", true);
-    m_enable_calcADCfactor = map->GetValueBool("calc.adcfactor", false);
-    m_indicator            = map->GetValueBool("indicator", false);
-    m_extendedStats        = map->GetValueBool("extended.stats", false);
-    obdii_79b              = map->GetValueBool("obdii.79b", true);
-    obdii_79b_cell         = map->GetValueBool("obdii.79b.cell", true);
-    obdii_743              = map->GetValueBool("obdii.743", true);
-    obdii_745              = map->GetValueBool("obdii.745", true);
-    obdii_745_tpms         = map->GetValueBool("obdii.745.tpms", true);
-    obdii_7e4              = map->GetValueBool("obdii.7e4", true);
-    obdii_7e4_dcdc         = map->GetValueBool("obdii.7e4.dcdc", true);
+    m_enable_write         = map->GetValueBool("canwrite", m_enable_write);
+    m_enable_write_caron   = map->GetValueBool("canwrite.caron", m_enable_write_caron);
+    m_enable_write_sleep   = map->GetValueBool("canwrite.sleep", m_enable_write_sleep);
+    m_enable_LED_state     = map->GetValueBool("led", m_enable_LED_state);
+    m_bcvalue              = map->GetValueBool("bcvalue", m_bcvalue);
+    m_enable_lock_state    = map->GetValueBool("unlock.warning", m_enable_lock_state);
+    m_enable_door_state    = map->GetValueBool("door.warning", m_enable_door_state);
+    m_resettrip            = map->GetValueBool("resettrip", m_resettrip);
+    m_resettotal           = map->GetValueBool("resettotal", m_resettotal);
+    m_tripnotify           = map->GetValueBool("reset.notify", m_tripnotify);
+    m_tpms_alert_enable    = map->GetValueBool("tpms.alert.enable", m_tpms_alert_enable);
+    m_tpms_temp_enable     = map->GetValueBool("tpms.temp", m_tpms_temp_enable);
+    m_12v_charge           = map->GetValueBool("12v.charge", m_12v_charge);
+    m_enable_calcADCfactor = map->GetValueBool("calc.adcfactor", m_enable_calcADCfactor);
+    m_indicator            = map->GetValueBool("indicator", m_indicator);
+    m_extendedStats        = map->GetValueBool("extended.stats", m_extendedStats);
+    obdii_79b              = map->GetValueBool("obdii.79b", m_obdii_79b);
+    obdii_79b_cell         = map->GetValueBool("obdii.79b.cell", m_obdii_79b_cell);
+    obdii_743              = map->GetValueBool("obdii.743", m_obdii_743);
+    obdii_745              = map->GetValueBool("obdii.745", m_obdii_745);
+    obdii_745_tpms         = map->GetValueBool("obdii.745.tpms", m_obdii_745_tpms);
+    obdii_7e4              = map->GetValueBool("obdii.7e4", m_obdii_7e4);
+    obdii_7e4_dcdc         = map->GetValueBool("obdii.7e4.dcdc", m_obdii_7e4_dcdc);
 
-    m_reboot_time          = map->GetValueInt("rebootnw", 30);
-    m_park_timeout_secs    = map->GetValueInt("park.timeout", 600);
-    m_full_km              = map->GetValueInt("full.km", 126);
-    m_cfg_preset_version   = map->GetValueInt("cfg.preset.ver", 0);
-    m_suffsoc              = map->GetValueInt("suffsoc", 0);
-    m_suffrange            = map->GetValueInt("suffrange", 0);
-    cell_interval_drv      = map->GetValueInt("cell_interval_drv", 60);
-    cell_interval_chg      = map->GetValueInt("cell_interval_chg", 60);
-    m_above_cycles         = map->GetValueInt("bms.alert.above.cycles", 50000);
+    m_reboot_time          = map->GetValueInt("rebootnw", m_reboot_time);
+    m_park_timeout_secs    = map->GetValueInt("park.timeout", m_park_timeout_secs);
+    m_full_km              = map->GetValueInt("full.km", m_full_km);
+    m_cfg_preset_version   = map->GetValueInt("cfg.preset.ver", m_cfg_preset_version);
+    m_suffsoc              = map->GetValueInt("suffsoc", m_suffsoc);
+    m_suffrange            = map->GetValueInt("suffrange", m_suffrange);
+    cell_interval_drv      = map->GetValueInt("cell_interval_drv", cell_interval_drv);
+    cell_interval_chg      = map->GetValueInt("cell_interval_chg", cell_interval_chg);
+    m_above_cycles         = map->GetValueInt("bms.alert.above.cycles", m_above_cycles);
     
-    m_front_pressure       = map->GetValueFloat("tpms.front.pressure", 225.0f);
-    m_rear_pressure        = map->GetValueFloat("tpms.rear.pressure", 255.0f);
-    m_pressure_warning     = map->GetValueFloat("tpms.value.warn", 40.0f);
-    m_pressure_alert       = map->GetValueFloat("tpms.value.alert", 70.0f);
+    m_front_pressure       = map->GetValueFloat("tpms.front.pressure", m_front_pressure);
+    m_rear_pressure        = map->GetValueFloat("tpms.rear.pressure", m_rear_pressure);
+    m_pressure_warning     = map->GetValueFloat("tpms.value.warn", m_pressure_warning);
+    m_pressure_alert       = map->GetValueFloat("tpms.value.alert", m_pressure_alert);
     }
 
 #ifdef CONFIG_OVMS_COMP_MAX7317

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -432,39 +432,39 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_enable_write_caron = false;      // canwrite enable write access, only when car is on
     bool m_enable_write_sleep = false;      // canwrite disable write access, only when car is asleep
     bool m_can_active = false;              // true if CAN bus is in active mode, false if in listen-only mode
-    bool m_enable_LED_state;                // Online LED State
-    bool m_enable_lock_state;               // Lock State
-    bool m_enable_door_state;               // Door Open State
-    bool m_tpms_temp_enable;                // TPMS Temperature Display enabled
-    bool m_resettrip;                       // Reset Trip Values when Charging/Driving
-    bool m_resettotal;                      // Reset kWh/100km Values when Driving
-    bool m_tripnotify;                      // Trip Reset Notification on/off
-    bool m_bcvalue;                         // use kWh/100km Value from mt_use_at_reset = true, Calculated = false
-    bool m_tpms_alert_enable;               // TPMS Alert enabled
-    bool m_12v_charge;                      // 12V charge on/off
-    bool m_12v_charge_state;                // 12V charge state
-    bool m_extendedStats;                   // extended stats for trip and maintenance data
-    bool m_enable_calcADCfactor;            // enable calculation of ADC factor
-    int m_reboot_ticker;
-    int m_reboot_time;                      // Restart Network time
-    int m_TPMS_FL;                          // TPMS Sensor Front Left
-    int m_TPMS_FR;                          // TPMS Sensor Front Right
-    int m_TPMS_RL;                          // TPMS Sensor Rear Left
-    int m_TPMS_RR;                          // TPMS Sensor Rear Right
-    int m_park_timeout_secs;                // parking timeout in seconds
-    int m_full_km;                          // full battery km value for SoC calculation
-    int m_cfg_preset_version;               // config preset version set in CommandPreset by defined PRESET_VERSION in top of this file
-    int m_suffsoc;                          // minimum SoC for charging
-    int m_suffrange;                        // minimum range for charging
-    float m_front_pressure;                 // Front Tire Pressure
-    float m_rear_pressure;                  // Rear Tire Pressure
-    float m_pressure_warning;               // Pressure Warning
-    float m_pressure_alert;                 // Pressure Alert
-    std::string m_hl_canbyte;               // canbyte variable for unv
+    bool m_enable_LED_state = false;        // Online LED State
+    bool m_enable_lock_state = true;        // Lock State
+    bool m_enable_door_state = true;        // Door Open State
+    bool m_tpms_alert_enable = true;        // TPMS Alert enabled
+    bool m_tpms_temp_enable = false;        // TPMS Temperature Display enabled
+    bool m_resettrip = true;                // Reset Trip Values when true/false = Charging/Driving
+    bool m_resettotal = false;              // Reset kWh/100km Values when Driving
+    bool m_tripnotify = false;              // Trip Reset Notification on/off
+    bool m_bcvalue = false;                 // use kWh/100km Value from mt_use_at_reset = true, Calculated = false
+    bool m_12v_charge = true;               // 12V charge on/off
+    bool m_12v_charge_state = false;        // 12V charge state
+    bool m_extendedStats = false;           // extended stats for trip and maintenance data
+    bool m_enable_calcADCfactor = false;    // enable calculation of ADC factor
+    int m_reboot_ticker = 0;                // ticker for network restart
+    int m_reboot_time = 30;                 // Restart Network time
+    int m_TPMS_FL = 0;                      // TPMS Sensor Front Left
+    int m_TPMS_FR = 0;                      // TPMS Sensor Front Right
+    int m_TPMS_RL = 0;                      // TPMS Sensor Rear Left
+    int m_TPMS_RR = 0;                      // TPMS Sensor Rear Right
+    int m_park_timeout_secs = 600;          // parking timeout in seconds
+    int m_full_km = 126;                    // full battery km value for SoC calculation
+    int m_cfg_preset_version = 0;           // config preset version set in CommandPreset by defined PRESET_VERSION in top of this file
+    int m_suffsoc = 0;                      // minimum SoC for charging
+    int m_suffrange = 0;                    // minimum range for charging
+    float m_front_pressure = 225.0f;        // Front Tire Pressure
+    float m_rear_pressure = 255.0f;         // Rear Tire Pressure
+    float m_pressure_warning = 40.0f;       // Pressure Warning
+    float m_pressure_alert = 70.0f;         // Pressure Alert
+    std::string m_hl_canbyte = "";          // canbyte variable for unv
     std::deque<float> m_adc_factor_history; // ring buffer (max 20) for ADC factors
 
     // --- Internal state variables ---
-    bool m_indicator;                       // activate indicator e.g. 7 times or whatever
+    bool m_indicator = false;               // activate indicator e.g. 7 times or whatever
     bool m_ddt4all = false;                 // DDT4ALL mode
     bool m_warning_unlocked = false;        // unlocked warning
     bool m_warning_dooropen = false;        // open doors warning

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -233,7 +233,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
     bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
-    bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) > 13.1f || StdMetrics.ms_v_env_charging12v->AsBool(false); }
+    bool Is12VchargeEQ() { return mt_evc_dcdc->GetElemValue(1) > 13.2f && StdMetrics.ms_v_env_charging12v->AsBool(false); }
 
   // =========================================================================
   // protected
@@ -243,6 +243,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void Ticker1(uint32_t ticker) override;
     void Ticker10(uint32_t ticker) override;
     void Ticker60(uint32_t ticker) override;
+    void Ticker3600(uint32_t ticker) override;
     void PollerStateTicker(canbus *bus) override;
 
     // --- Dashboard / Calculations ---
@@ -376,6 +377,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     OvmsMetricVector<float> *mt_evc_dcdc;                    // EVC 12V system values vector
     OvmsMetricString        *mt_evc_traceability;            // Frame Traceability: ITG/Factory/Serial
     OvmsMetricBool          *mt_evc_plug_detected;           // Charging plug detected by charger (0x339D)
+    OvmsMetricInt           *mt_12v_trickle_charge_count;    // Number of 12V trickle activations in the last 24h
 
     // --- Custom metrics: BMS ---
     OvmsMetricVector<float> *mt_bms_voltages;                // Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor
@@ -499,6 +501,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // ADC factor calculation is needed based on 12V reading, only check when car is on or charging to avoid false recalculations based on 12V drop when car is off
     // activated only after reboot
     bool m_check12vadc = true;
+    std::deque<uint32_t> m_12v_trickle_charge_times; // activation timestamps for 12V trickle charge alarm within 24h
 
     // --- ADC variables ---
     bool m_ADCfactor_recalc = false;      // request recalculation of ADC factor

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -233,7 +233,9 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
     bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
-    bool Is12VchargeEQ() { return mt_evc_dcdc->GetElemValue(1) > 13.2f && StdMetrics.ms_v_env_charging12v->AsBool(false); }
+    bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) > 13.1f || 
+                                  (m_can_active && mt_evc_dcdc->GetElemValue(1) > 13.1f ) || 
+                                  (m_can_active && can_charging12v); }
 
   // =========================================================================
   // protected
@@ -526,6 +528,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool can_chargeport = false;
     bool can_env_on = false;
     bool can_charge_inprogress = false;
+    bool can_charging12v = false;
     float can_cabintemp = 0.0f;
     float can_bat_temp = 0.0f;
     float can_bat_voltage = 0.0f;


### PR DESCRIPTION
Track 12V trickle-charge activations and alert on frequent activations. Added a new metric xsq.12v.trickle.count and a deque to store activation timestamps; increment the count when trickle charging is activated and prune old entries in a new Ticker3600. If trickle charging is activated 3 times within 24 hours an alert is sent and trickle charging is disabled until reboot. Included the new count in the BMS contactor Notify payload (V3 format). Also adjusted Is12VchargeEQ logic and refactored Ticker60 ADC recalibration checks to use the new helper, plus minor ticker comment/formatting fixes.