### PR TITLE
smartEQ: Use std 12V metric and relax ADC bounds

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -407,8 +407,8 @@ void OvmsVehicleSmartEQ::xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCom
       return;
       } 
         
-    float can12V = smarteq->mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
-    if (can12V <= 13.10f) 
+    float can12V = StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f);   // DCDC voltage = mt_evc_dcdc->GetElemValue(1)
+    if (can12V < 13.1f) 
       {
       writer->puts("Error: vehicle 12V is not charging, 12V voltage is not stable for ADC calibration!");
       return;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -349,7 +349,7 @@ void OvmsVehicleSmartEQ::ReCalcADCfactor(float can12V, OvmsWriter* writer) {
       }
 
     if (writer) writer->printf("ADC recalculation: avg_raw=%.2f  V_batt=%.3f  factor=%.3f\n", avg_raw, V_batt, adc_factor_new);
-    if (adc_factor_new < 180.0f || adc_factor_new > 210.0f) 
+    if (adc_factor_new < 160.0f || adc_factor_new > 230.0f) 
       {
       if (writer) writer->printf("Reject ADC factor %.3f (out of bounds, keeping %.3f)\n", adc_factor_new, adc_factor_prev);
       return;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -76,6 +76,8 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   if (Is12VchargeEQ() != StdMetrics.ms_v_env_charging12v->AsBool(false))
     {
     StdMetrics.ms_v_env_charging12v->SetValue(Is12VchargeEQ());
+    if (!Is12VchargeEQ())
+    StdMetrics.ms_v_charge_12v_voltage->SetValue(0.0f); // reset 12V voltage when not charging to prevent desync
     } 
   // reactivate door lock warning if the car is parked and unlocked
   if( m_enable_lock_state && 
@@ -136,11 +138,10 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
   #ifdef CONFIG_OVMS_COMP_ADC
   if((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ())
     {
-    float can12V = mt_evc_dcdc->GetElemValue(1);   // DCDC voltage
+    float can12V = StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f);   // DCDC voltage = mt_evc_dcdc->GetElemValue(1)
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
-    if(m_check12vadc)
+    if(m_check12vadc && can12V >= 13.1f)
       {
-      float can12V = mt_evc_dcdc->GetElemValue(1);
       float adc12V = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
       float diff = fabs(can12V - adc12V);      
       if (diff > 0.1f && !m_ADCfactor_recalc && Is12VchargeEQ())      
@@ -153,7 +154,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
       m_check12vadc = false;
       }
     // if ADC factor recalculation is enabled, then check if it's time to recalculate the factor
-    if (m_enable_calcADCfactor && m_ADCfactor_recalc) 
+    if (m_enable_calcADCfactor && m_ADCfactor_recalc && can12V >= 13.1f) 
       {
       if (--m_ADCfactor_recalc_timer == 0) 
         {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -427,13 +427,13 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
       // Refresh values from config/metrics to show latest state after command execution
     calcADCfactor = sq->m_enable_calcADCfactor;
       adc_factor  = MyConfig.GetParamValue("system.adc", "factor12v", adc_factor.empty() ? "195.7" : adc_factor);
-      if (sq->mt_evc_dcdc && sq->mt_evc_dcdc->GetElemValue(1) > 10.0f) {
+      if (sq->mt_evc_dcdc && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f) {
         char buf[16];
-        snprintf(buf, sizeof(buf), "%.3f", sq->mt_evc_dcdc->GetElemValue(1));  // DCDC voltage
+        snprintf(buf, sizeof(buf), "%.3f", StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f));  // DCDC voltage
         onboard_12v = buf;
       }
       if (onboard_12v.empty())
-        onboard_12v = "12.600";
+        onboard_12v = "12.500";
       if (sq->mt_adc_factor_history)
         adc_history = sq->mt_adc_factor_history->AsString();
     }
@@ -461,13 +461,13 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
     // read configuration:
     calcADCfactor = sq->m_enable_calcADCfactor;
     adc_factor  = MyConfig.GetParamValue("system.adc", "factor12v", "195.7");
-    if (sq->mt_evc_dcdc && sq->mt_evc_dcdc->GetElemValue(1) > 10.0f) {
+    if (sq->mt_evc_dcdc && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f) {
         char buf[16];
-        snprintf(buf, sizeof(buf), "%.3f", sq->mt_evc_dcdc->GetElemValue(1));  // DCDC voltage
+        snprintf(buf, sizeof(buf), "%.3f", StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f));  // DCDC voltage
         onboard_12v = buf;
       }
     if (onboard_12v.empty())
-      onboard_12v = "12.600";
+      onboard_12v = "12.500";
     if (sq->mt_adc_factor_history)
       adc_history = sq->mt_adc_factor_history->AsString();
     c.head(200);
@@ -479,7 +479,7 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
     if (adc_factor.empty())
       adc_factor = "195.7";
     if (onboard_12v.empty())
-      onboard_12v = "12.600";
+      onboard_12v = "12.500";
   }
 
   if (adc_history.empty() && sq->mt_adc_factor_history)
@@ -503,7 +503,7 @@ void OvmsVehicleSmartEQ::WebCfgADC(PageEntry_t& p, PageContext_t& c) {
   }
   c.input_slider("ADC factor", "adc_factor", 5, "", -1, atof(adc_factor.c_str()), 195.7, 160, 230, 0.1,
     "<p>12V ADC calibration factor (default 195.7)</p>");
-  c.input_slider("12V measured", "onboard_12v", 3, "V",-1, atof(onboard_12v.c_str()), 12.60, 11.00, 15.00, 0.01,
+  c.input_slider("12V measured", "onboard_12v", 3, "V",-1, atof(onboard_12v.c_str()), 12.50, 11.00, 15.00, 0.01,
     "<p>Your measured 12V for calibration calculation</p>");
   c.printf("<input type=\"hidden\" name=\"onboard_12v_submit\" id=\"onboard_12v_submit\" value=\"%s\">\n",
            _attr(onboard_12v.c_str()));

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -233,8 +233,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
     bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
-    bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) > 13.1f || 
-                                  (m_can_active && mt_evc_dcdc->GetElemValue(1) > 13.1f ) || 
+    bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) >= 13.1f || 
+                                  (StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f ) || 
                                   (m_can_active && can_charging12v); }
 
   // =========================================================================


### PR DESCRIPTION
Replace direct mt_evc_dcdc access with StdMetrics.ms_v_charge_12v_voltage for 12V checks, and adjust charging threshold comparisons to >=13.1V. Broaden ADC calibration acceptance range from 180-210 to 160-230 and only perform ADC-recalc checks when 12V is suitably charging. Reset the 12V metric when not charging to avoid desync, update Web UI defaults (onboard_12v default to 12.500 and slider ranges) and change Is12VchargeEQ to rely on standardized metrics/can_charging12v. Changes touch eq_commands.cpp, eq_features.cpp, eq_ticker.cpp, eq_web.cpp and vehicle_smarteq.h.