### PR TITLE
feat(vwegolf): remote climate control over KCAN BAP

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
@@ -1,7 +1,7 @@
 # Climate Control via BAP Battery Control Channel — RE Notes
 
 References:
-- https://github.com/karlsen-technologies/smartkar-cano-new — `docs/canbus-reverse-engineering/BAP_PROTOCOL.md` and `BAP_BATTERY_CONTROL.md` (thomasakarlsen; supersedes e-golf-comfort-can for BAP)
+- https://github.com/karlsen-technologies/smartkar-cano-new/tree/2b191b8e9066d494125b3c0338787a347ec8d205/docs/canbus-reverse-engineering — `BAP_PROTOCOL.md` and `BAP_BATTERY_CONTROL.md` (thomasakarlsen; supersedes e-golf-comfort-can for BAP). Pinned to the commit we validated against (2026-07-09).
 - MIB2 firmware RE by SCjona (PR #1430 review thread) — message/field names below marked *(MIB2 FW)*
 - Local BAP framing notes: `vw-bap-protocol.md` (being aligned to standard terminology)
 

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
@@ -1,95 +1,113 @@
-# Climate Control via BAP — RE Notes
+# Climate Control via BAP Battery Control Channel — RE Notes
 
-Reference: https://github.com/thomasakarlsen/e-golf-comfort-can
+References:
+- https://github.com/karlsen-technologies/smartkar-cano-new — `docs/canbus-reverse-engineering/BAP_PROTOCOL.md` and `BAP_BATTERY_CONTROL.md` (thomasakarlsen; supersedes e-golf-comfort-can for BAP)
+- MIB2 firmware RE by SCjona (PR #1430 review thread) — message/field names below marked *(MIB2 FW)*
+- Local BAP framing notes: `vw-bap-protocol.md` (being aligned to standard terminology)
 
-## CAN IDs
+Terminology (standard BAP; earlier revisions of this doc used ad-hoc terms):
+
+| This doc (old) | Standard BAP | Meaning |
+|---|---|---|
+| "node" 0x25 | **LSG ID** 0x25 | Logical control unit: Battery Control |
+| "port" | **Function ID** | Function within the LSG |
+| "command"/"status push" opcode 2 | **OpCode** 0x02 SetGet | Set value, request confirmation |
+| "rolling counter" | **Transaction-ID** (array header) | Echoed in FSG response |
+
+## Channel
+
+Battery Control channel, LSG 0x25. OVMS acts as an **ASG** (client); the Battery Control Unit is the **FSG** (server).
 
 | Direction | CAN ID (29-bit) | Description |
 |---|---|---|
-| OVMS → Clima ECU | `0x17332501` | Commands |
-| Clima ECU → bus | `0x17332501` | Keepalive polls, 5s status bursts |
-| Clima ECU → bus | `0x17332510` | Command ACKs, full state broadcasts |
+| ASG → FSG | `0x17332501` | Commands (also carries FSG keepalive polls / 5 s status bursts observed on-car) |
+| FSG → ASG | `0x17332510` | Status responses, ACKs, broadcasts |
 
-BAP node address of clima ECU: **0x25**
+## Function IDs (LSG 0x25)
 
-BAP frame encoding (single/multi-start/multi-cont), opcodes, validity rules → `vw-bap-protocol.md`.
+Names per smartkar BAP_BATTERY_CONTROL.md; "obs." column = what we observed on-car (Captures 2/7 etc.).
 
----
+| Func | Name | Dir | On-car observations |
+|---|---|---|---|
+| 0x01 | GetAllProperties | → FSG | empty SetGet poll seen |
+| 0x02 | BAP-Config | → FSG | empty SetGet poll seen |
+| 0x10 | PlugState | ← FSG | — |
+| 0x11 | ChargeState | ← FSG | — |
+| 0x12 | ClimateState | ← FSG | 7-byte status ~1 s; payload[0] `05`=active `00`=idle |
+| 0x13 | (status) | ← FSG | `04 04`=active `04 00`=idle |
+| 0x14–0x16 | timer/schedule slots 0–2 | ↔ | 8-byte records; Ack confirms writes |
+| 0x18 | ClimateOperationModeInstallation | → FSG | start/stop trigger, 2-byte payload |
+| 0x19 | ProfilesArray | ↔ | Battery Control Profiles (see below) |
+| 0x1A | PowerProvidersArray | ← FSG | slot Ack / status observed |
 
-## Port Map (node 0x25)
+**Authoritative stop detection:** Function 0x12 (ClimateState) payload[0] `05`→`00` (works for both OVMS-triggered and schedule-triggered stops). Do NOT rely on `0x5EA` remote_mode — stale in remote mode.
 
-| Port | Dir | Description |
-|---|---|---|
-| 0x01 | → ECU | Status poll (empty SetGet, 2-byte) |
-| 0x02 | → ECU | Status poll (empty SetGet, 2-byte) |
-| 0x12 | ← ECU | Status broadcast (7 bytes, ~1 s) · payload[0]: `05`=active `00`=idle |
-| 0x13 | ← ECU | Status · `04 04`=active `04 00`=idle |
-| 0x14 | ← ECU | Schedule slot 0 (8 bytes) |
-| 0x15 | ← ECU | Schedule slot 1 (8 bytes) |
-| 0x16 | ← / ↔ | Schedule slot 2 (8 bytes); Ack confirms writes |
-| 0x18 | → ECU | Start/stop trigger (2-byte payload) |
-| 0x19 | → ECU | Clima parameters (8-byte payload) |
-| 0x1A | ← ECU | Schedule slot Ack / status |
+## Battery Control Profiles (Function 0x19)
 
-**Authoritative stop detection:** port 0x12 payload[0] `05`→`00` (works for both OVMS-triggered and schedule-triggered stops). Do NOT rely on `0x5EA` remote_mode — stale in remote mode.
+Charging/climate settings live in 4 stored **profiles** (= "Charge Locations" in infotainment): profile 0 = hidden global/immediate profile used by "start now" operations; 1–3 = departure timers. Commands do not carry one-shot parameters — they **write profile fields**, then trigger via Function 0x18.
 
----
+Profiles are BAP arrays; the **RecordAddr** in the array header selects the record format:
+- RecordAddr 0: full profile, 20+ bytes — includes **temperature** at byte 12, encoding `raw = °C × 10 − 100` (22.0 °C → `0x78`), unit byte, lead/holding times, name…
+- RecordAddr 6: compact profile, 4 bytes — `operation, operation2, maxCurrent, targetChargeLevel`. **No temperature field.**
+
+operation flags (byte 0): bit0 charge · bit1 climate · bit2 climateWithoutExternalSupply · bit3 autoDefrost · bits4–7 seat heaters. `0x06` = climate + climate-on-battery.
+
+Full field tables: smartkar `BAP_BATTERY_CONTROL.md`.
 
 ## Climate Start/Stop — 3-Frame Sequence
 
-Must send all 3 frames in order on `0x17332501`.
+All on `0x17332501`. Step 1 is a SetGet on ProfilesArray (0x19) writing profile 0 in **compact (RecordAddr 6)** format; step 2 triggers it.
 
-### Frame 1 — Parameters (multi-frame, port 0x19)
-```
-DLC=8: 80 08 29 59  [counter]  06 00 01
-```
-`29 59` = opcode=2, node=0x25, port=0x19. `[counter]` = rolling byte, increment each call.
+### Frames 1+2 — profile 0 partial update (long BAP message, group 0)
 
-### Frame 2 — Continuation
 ```
-DLC=5: C0  06 00 [temp] 00
-```
-Full 8-byte port 0x19 payload: `[counter] 06 00 01 06 00 [temp] 00`
-
-### Frame 3 — Trigger (port 0x18)
-```
-DLC=4: 29 58  00 01     (START)
-DLC=4: 29 58  00 00     (STOP)
+Frame 1 (start):  80 08 29 59  [ah0] 06 00 01
+Frame 2 (cont):   C0  06 00 20 00
 ```
 
----
+- `80` = long-message start, group 0 · `08` = payload length
+- `29 59` = BAP header: OpCode 0x02 SetGet, LSG 0x25, Function 0x19
+- 8-byte payload = 4-byte array header + 4-byte compact record:
 
-## Port 0x19 Payload Encoding
+| Off | Value | Field |
+|---|---|---|
+| 0 | `[ah0]` | array header: [ASG-ID:4][**Transaction-ID**:4] — TID echoed in FSG response (our TX code rolls this; thomasakarlsen's trace shows `0x22`) |
+| 1 | `06` | array header: RecordAddr = 6 (compact record) *(MIB2 FW: "revision tag")* |
+| 2 | `00` | array header: startIndex |
+| 3 | `01` | array header: elementCount = 1 |
+| 4 | `06` | operation = climate + climateWithoutExternalSupply |
+| 5 | `00` | operation2 = none |
+| 6 | `20` | **maxCurrent = 32 A** (1 A/LSB) |
+| 7 | `00` | targetChargeLevel = 0 (not charging) |
 
-`[counter] 06 00 01 06 00 [temp] 00`
+**There is no temperature in this message.** The car climatizes to the temperature stored in the global profile (set in infotainment / via a RecordAddr-0 profile write). An earlier revision of this doc misread byte 6 as a temperature (the `(°C−10)×10` encoding was confirmed on the `0x17330110` setpoint *status broadcast*, ports 0x1B/0x21, dash-knob sweep, Captures 2/7 — a real encoding, wrong message). Corrected per MIB2 firmware RE (`SetBatteryControlProfileListRA6`) and smartkar docs, PR #1430 review.
 
-Temperature byte 6: `raw = (celsius - 10) * 10`
-- 18°C → `0x50`, 20°C → `0x64`, 21°C → `0x6E`, 22°C → `0x78`
-- Encoding confirmed on the `0x17330110` setpoint status broadcast (ports 0x1B/0x21,
-  dash-knob sweep, Captures 2/7): raw steps of 5 per 0.5°C, floor `0x3C` = 16.0°C,
-  `0xFF` = HI. NOT yet conclusively verified that the ECU honors an explicit temp in
-  this command byte (verify captures log RX only). thomasakarlsen's start trace uses
-  `0x20` here — below the 16.0°C floor, likely a "use stored setting" sentinel.
+> Firmware note: earlier `SendClimaBapBurst()` encoded the `cc-temp` config into byte 6 (sent as maxCurrent, e.g. 21 °C → 110 A). Fixed to constant `0x20`; the `cc-temp` param and web slider were removed since they had no wire effect. Setting an explicit temperature would need a RecordAddr-0 ProfilesArray write (byte 12, `raw = °C × 10 − 100`) — not yet attempted on-car.
 
-Bytes 1–5 unknown; `06 00 01 06 00` constant in all captures.
+### Frame 3 — trigger (Function 0x18, short message)
 
----
+```
+29 58  00 01     START (immediate = profile 0)
+29 58  00 00     STOP
+```
 
-## Schedule Slot Encoding (port 0x14–0x16)
+`29 58` = SetGet, LSG 0x25, Function 0x18 (ClimateOperationModeInstallation). Payload byte 0 = profileId 0 (global); byte 1 = bitmask: bit0 immediately, bit1–3 timers 1–3 *(MIB2 FW)*. Observed on-car: `01` starts, `00` stops.
 
-8-byte ECU status: `ff ff ff [hour] [temp_byte] fe [slot_id] 00`
+## Timer/Schedule Slot Encoding (Functions 0x14–0x16)
+
+8-byte FSG status record: `ff ff ff [hour] [temp_byte] fe [slot_id] 00`
 
 - Byte 3: departure hour (direct decimal, e.g. `0x11` = 17:00)
-- Byte 4: `celsius + 35` (e.g. 20°C → `0x37`)
+- Byte 4: `celsius + 35` (e.g. 20 °C → `0x37`)
 - Byte 6: slot ID (0–2)
 
----
+(On-car observation; not yet reconciled with smartkar's full-profile field layout.)
 
 ## KCAN Bus Wake-Up
 
 ### NM Alive Frame (CRITICAL — required from deep sleep)
 
-Clima ECU rejects BAP from nodes not in OSEK NM ring. Send before any BAP command when bus was sleeping:
+FSG rejects BAP from nodes not in the OSEK NM ring. Send before any BAP command when bus was sleeping:
 
 ```
 CAN ID:  0x1B000067  (29-bit extended)
@@ -110,15 +128,15 @@ Implemented in `CommandWakeup()`, called by `CommandClimateControl()` when `m_bu
 3. Wait 1 s
 4. Send 3-frame clima sequence
 
-**Warning:** do not use the start frame as wake ping — if TX_Fail, continuation arrives orphaned (~110 ms later), ECU discards partial BAP message, clima doesn't start.
+**Warning:** do not use the start frame as wake ping — if TX_Fail, continuation arrives orphaned (~110 ms later), FSG discards the partial long message, clima doesn't start.
+
+(smartkar additionally documents a `0x5A7` keepalive every 200–500 ms and wake payload `40 00 01 1F`; our sequence above is what's validated on this car.)
 
 ### Wake Ping (bus already active)
 ```
 can send can3 17332501 09 41
 ```
 Sufficient only when KCAN already live (e.g. just after ignition-off). Not for deep sleep.
-
----
 
 ## Test Commands (OVMS shell)
 
@@ -138,14 +156,12 @@ can can3 tx extended 17332501 29 58 00 00
 
 Bus effects: `0x3E9` transitions from sentinel to live values; `0x3B5`/`0x530` follow. Blower activates within ~10 s.
 
----
+## FSG ACK Pattern (0x17332510)
 
-## ECU ACK Pattern (0x17332510)
-
-Immediate ACK (~1 s after command):
+Immediate response (~1 s after command):
 ```
-80 0a 49 59  {ectr} 04 46 00   [+ continuation]
+80 0a 49 59  {tid} 04 46 00   [+ continuation]
 ```
-`{ectr}` = our counter | 0x80. Confirms which command was ACKed.
+`49 59` = OpCode 0x04 Status, LSG 0x25, Function 0x19 — the SetGet confirmation. `{tid}` = our array-header byte 0 with the FSG's ASG-ID nibble (observed as our value | 0x80), matching command to response via the Transaction-ID.
 
-After ACK: ECU sends ~4 keepalive cycles on `17332501` at 5 s intervals (~16 s delay), then silent until next command.
+After ACK: FSG sends ~4 keepalive cycles on `17332501` at 5 s intervals (~16 s), then silent until next command.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
@@ -65,6 +65,11 @@ DLC=4: 29 58  00 00     (STOP)
 
 Temperature byte 6: `raw = (celsius - 10) * 10`
 - 18°C → `0x50`, 20°C → `0x64`, 21°C → `0x6E`, 22°C → `0x78`
+- Encoding confirmed on the `0x17330110` setpoint status broadcast (ports 0x1B/0x21,
+  dash-knob sweep, Captures 2/7): raw steps of 5 per 0.5°C, floor `0x3C` = 16.0°C,
+  `0xFF` = HI. NOT yet conclusively verified that the ECU honors an explicit temp in
+  this command byte (verify captures log RX only). thomasakarlsen's start trace uses
+  `0x20` here — below the 16.0°C floor, likely a "use stored setting" sentinel.
 
 Bytes 1–5 unknown; `06 00 01 06 00` constant in all captures.
 

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/clima-control-bap.md
@@ -1,0 +1,146 @@
+# Climate Control via BAP — RE Notes
+
+Reference: https://github.com/thomasakarlsen/e-golf-comfort-can
+
+## CAN IDs
+
+| Direction | CAN ID (29-bit) | Description |
+|---|---|---|
+| OVMS → Clima ECU | `0x17332501` | Commands |
+| Clima ECU → bus | `0x17332501` | Keepalive polls, 5s status bursts |
+| Clima ECU → bus | `0x17332510` | Command ACKs, full state broadcasts |
+
+BAP node address of clima ECU: **0x25**
+
+BAP frame encoding (single/multi-start/multi-cont), opcodes, validity rules → `vw-bap-protocol.md`.
+
+---
+
+## Port Map (node 0x25)
+
+| Port | Dir | Description |
+|---|---|---|
+| 0x01 | → ECU | Status poll (empty SetGet, 2-byte) |
+| 0x02 | → ECU | Status poll (empty SetGet, 2-byte) |
+| 0x12 | ← ECU | Status broadcast (7 bytes, ~1 s) · payload[0]: `05`=active `00`=idle |
+| 0x13 | ← ECU | Status · `04 04`=active `04 00`=idle |
+| 0x14 | ← ECU | Schedule slot 0 (8 bytes) |
+| 0x15 | ← ECU | Schedule slot 1 (8 bytes) |
+| 0x16 | ← / ↔ | Schedule slot 2 (8 bytes); Ack confirms writes |
+| 0x18 | → ECU | Start/stop trigger (2-byte payload) |
+| 0x19 | → ECU | Clima parameters (8-byte payload) |
+| 0x1A | ← ECU | Schedule slot Ack / status |
+
+**Authoritative stop detection:** port 0x12 payload[0] `05`→`00` (works for both OVMS-triggered and schedule-triggered stops). Do NOT rely on `0x5EA` remote_mode — stale in remote mode.
+
+---
+
+## Climate Start/Stop — 3-Frame Sequence
+
+Must send all 3 frames in order on `0x17332501`.
+
+### Frame 1 — Parameters (multi-frame, port 0x19)
+```
+DLC=8: 80 08 29 59  [counter]  06 00 01
+```
+`29 59` = opcode=2, node=0x25, port=0x19. `[counter]` = rolling byte, increment each call.
+
+### Frame 2 — Continuation
+```
+DLC=5: C0  06 00 [temp] 00
+```
+Full 8-byte port 0x19 payload: `[counter] 06 00 01 06 00 [temp] 00`
+
+### Frame 3 — Trigger (port 0x18)
+```
+DLC=4: 29 58  00 01     (START)
+DLC=4: 29 58  00 00     (STOP)
+```
+
+---
+
+## Port 0x19 Payload Encoding
+
+`[counter] 06 00 01 06 00 [temp] 00`
+
+Temperature byte 6: `raw = (celsius - 10) * 10`
+- 18°C → `0x50`, 20°C → `0x64`, 21°C → `0x6E`, 22°C → `0x78`
+
+Bytes 1–5 unknown; `06 00 01 06 00` constant in all captures.
+
+---
+
+## Schedule Slot Encoding (port 0x14–0x16)
+
+8-byte ECU status: `ff ff ff [hour] [temp_byte] fe [slot_id] 00`
+
+- Byte 3: departure hour (direct decimal, e.g. `0x11` = 17:00)
+- Byte 4: `celsius + 35` (e.g. 20°C → `0x37`)
+- Byte 6: slot ID (0–2)
+
+---
+
+## KCAN Bus Wake-Up
+
+### NM Alive Frame (CRITICAL — required from deep sleep)
+
+Clima ECU rejects BAP from nodes not in OSEK NM ring. Send before any BAP command when bus was sleeping:
+
+```
+CAN ID:  0x1B000067  (29-bit extended)
+DLC:     8
+Data:    67 10 41 84 14 00 00 00
+```
+
+- `0x67` = OVMS KCAN NM node ID
+- Byte 1 = `0x10` = NM alive with ring participation bit
+- Wait ≥ 1 s for ring to settle before sending BAP
+
+Implemented in `CommandWakeup()`, called by `CommandClimateControl()` when `m_bus_idle_ticks >= VWEGOLF_BUS_TIMEOUT_SECS`.
+
+### Full Wake Sequence (bus sleeping)
+
+1. Send `0x17330301` (dominant-bit wake, TX_Fail expected — wakes transceivers)
+2. Send `0x1B000067` NM alive (joins ring)
+3. Wait 1 s
+4. Send 3-frame clima sequence
+
+**Warning:** do not use the start frame as wake ping — if TX_Fail, continuation arrives orphaned (~110 ms later), ECU discards partial BAP message, clima doesn't start.
+
+### Wake Ping (bus already active)
+```
+can send can3 17332501 09 41
+```
+Sufficient only when KCAN already live (e.g. just after ignition-off). Not for deep sleep.
+
+---
+
+## Test Commands (OVMS shell)
+
+Start:
+```
+can can3 tx extended 17332501 80 08 29 59 01 06 00 01
+can can3 tx extended 17332501 C0 06 00 20 00
+can can3 tx extended 17332501 29 58 00 01
+```
+
+Stop:
+```
+can can3 tx extended 17332501 80 08 29 59 02 06 00 01
+can can3 tx extended 17332501 C0 06 00 20 00
+can can3 tx extended 17332501 29 58 00 00
+```
+
+Bus effects: `0x3E9` transitions from sentinel to live values; `0x3B5`/`0x530` follow. Blower activates within ~10 s.
+
+---
+
+## ECU ACK Pattern (0x17332510)
+
+Immediate ACK (~1 s after command):
+```
+80 0a 49 59  {ectr} 04 46 00   [+ continuation]
+```
+`{ectr}` = our counter | 0x80. Confirms which command was ACKed.
+
+After ACK: ECU sends ~4 keepalive cycles on `17332501` at 5 s intervals (~16 s delay), then silent until next command.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/index.rst
@@ -66,7 +66,7 @@ GSM Antenna                 1000500 Open Vehicles OVMS GSM Antenna (or compatibl
 GPS Antenna                 1020200 Universal GPS Antenna (or compatible)
 SOC Display                 Yes
 Range Display               Yes
-Cabin Pre-heat/cool Control No
+Cabin Pre-heat/cool Control **Yes**
 GPS Location                Yes (decoded from KCAN frame 0x486)
 Speed Display               Yes
 Temperature Display         Yes (see list of metrics below)

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vw-bap-protocol.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vw-bap-protocol.md
@@ -1,0 +1,60 @@
+# VW BAP Protocol Reference
+
+BAP = *Bedien- und Anzeigeprotokoll*. Runs on raw CAN. Used by VAG vehicles for comfort ECUs (climate, media, etc.). Not ISO-TP/UDS — cannot use OVMS poller.
+
+RE source: https://github.com/norly/revag-bap
+
+## Concepts
+
+| BAP concept | Analogue | Description |
+|---|---|---|
+| Node (LSG) | IP address | 6-bit logical control unit (0–63) |
+| Port | UDP port | RPC port / status register, 6-bit (0–63) |
+| Opcode | Method | Request/reply type, 3-bit (0–7) |
+
+One CAN ID carries all BAP traffic for one direction between two nodes.
+
+## Frame Encoding
+
+### Single-frame (payload ≤ 6 bytes, byte 0 bit 7 = 0)
+```
+Byte 0:  [0 | opcode(3) | node[5:2](4)]
+Byte 1:  [node[1:0](2) | port(6)]
+Byte 2…: payload
+```
+DLC = 2 + payload_len.
+
+### Multi-frame start (byte 0 bit 7 = 1, bit 6 = 0)
+```
+Byte 0:  [1 | 0 | channel(2) | len[11:8](4)]
+Byte 1:  len[7:0]
+Byte 2:  [0 | opcode(3) | node[5:2](4)]
+Byte 3:  [node[1:0](2) | port(6)]
+Byte 4…7: first 4 bytes of payload
+```
+
+### Multi-frame continuation (byte 0 bit 7 = 1, bit 6 = 1)
+```
+Byte 0:  [1 | 1 | channel(2) | 0(4)]
+Byte 1…7: next 7 bytes of payload
+```
+
+## Opcodes
+
+| Opcode | Dir | Meaning |
+|---|---|---|
+| 0x0 | → ECU | **Get** — request current value |
+| 0x1 | → ECU | **SetGet** — write + request new status |
+| 0x2 | ← ECU | **Status** — ECU pushes / replies |
+| 0x3 | ← ECU | **Error** — negative response |
+| 0x4 | ← ECU | **Ack** — write acknowledged |
+| 0x6 | → ECU | **Set** — write, no reply |
+
+## Validity Rules
+
+```
+opcode ≤ 7 · node ≤ 63 · port ≤ 63 · len ≤ 4095
+single-frame: len ≤ 6
+```
+
+e-Golf specific CAN IDs, port map, commands → `clima-control-bap.md`.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vw-bap-protocol.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vw-bap-protocol.md
@@ -3,7 +3,7 @@
 BAP = *Bedien- und Anzeigeprotokoll*. Request/response application protocol on raw CAN — property get/set and function calls between control units. Not ISO-TP/UDS — cannot use the OVMS poller. Not broadcast-style CAN: a channel connects client(s) to one server.
 
 RE sources:
-- https://github.com/karlsen-technologies/smartkar-cano-new — `docs/canbus-reverse-engineering/BAP_PROTOCOL.md` (primary; opcode table and array format below)
+- https://github.com/karlsen-technologies/smartkar-cano-new/tree/2b191b8e9066d494125b3c0338787a347ec8d205/docs/canbus-reverse-engineering — `BAP_PROTOCOL.md` (primary; opcode table and array format below). Pinned to the commit we validated against; check upstream for refinements before trusting the pin as current.
 - https://github.com/norly/revag-bap (earlier; its opcode table is inconsistent with observed e-Golf traffic — superseded)
 
 ## Concepts

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vw-bap-protocol.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vw-bap-protocol.md
@@ -1,60 +1,71 @@
 # VW BAP Protocol Reference
 
-BAP = *Bedien- und Anzeigeprotokoll*. Runs on raw CAN. Used by VAG vehicles for comfort ECUs (climate, media, etc.). Not ISO-TP/UDS — cannot use OVMS poller.
+BAP = *Bedien- und Anzeigeprotokoll*. Request/response application protocol on raw CAN — property get/set and function calls between control units. Not ISO-TP/UDS — cannot use the OVMS poller. Not broadcast-style CAN: a channel connects client(s) to one server.
 
-RE source: https://github.com/norly/revag-bap
+RE sources:
+- https://github.com/karlsen-technologies/smartkar-cano-new — `docs/canbus-reverse-engineering/BAP_PROTOCOL.md` (primary; opcode table and array format below)
+- https://github.com/norly/revag-bap (earlier; its opcode table is inconsistent with observed e-Golf traffic — superseded)
 
 ## Concepts
 
-| BAP concept | Analogue | Description |
-|---|---|---|
-| Node (LSG) | IP address | 6-bit logical control unit (0–63) |
-| Port | UDP port | RPC port / status register, 6-bit (0–63) |
-| Opcode | Method | Request/reply type, 3-bit (0–7) |
+| Term | Description |
+|---|---|
+| **FSG** | Functional control unit — the server; provides data, accepts commands |
+| **ASG** | Display control unit — the client (OVMS acts as an ASG) |
+| **LSG ID** | 6-bit logical control unit ID (0–63); one physical module can host several |
+| **Function ID** | 6-bit function within an LSG (0–63); standard functions ≤ 0x0F, device-specific ≥ 0x10 |
+| **OpCode** | 3-bit operation type |
 
-One CAN ID carries all BAP traffic for one direction between two nodes.
+Each ASG sends on its own CAN ID; the FSG replies to all ASGs on one shared CAN ID.
+
+## OpCodes
+
+| OpCode | Dir | Meaning |
+|---|---|---|
+| 0x00 | FSG→ASG | **Reset** — init, version info |
+| 0x01 | ASG→FSG | **Get** — request data |
+| 0x02 | ASG→FSG | **SetGet** — write + request confirmation |
+| 0x03 | FSG→ASG | **HeartbeatStatus** — periodic status |
+| 0x04 | FSG→ASG | **Status** — response to Get/SetGet |
+| 0x05 | ASG→FSG | **StatusAck** — acknowledge status |
+| 0x06 | FSG→ASG | **Ack** — simple acknowledgment |
+| 0x07 | FSG→ASG | **Error** — negative response |
 
 ## Frame Encoding
 
-### Single-frame (payload ≤ 6 bytes, byte 0 bit 7 = 0)
+### Short message (payload ≤ 6 bytes, byte 0 bit 7 = 0)
 ```
-Byte 0:  [0 | opcode(3) | node[5:2](4)]
-Byte 1:  [node[1:0](2) | port(6)]
+Byte 0:  [0 | opcode(3) | lsg[5:2](4)]
+Byte 1:  [lsg[1:0](2) | function(6)]
 Byte 2…: payload
 ```
 DLC = 2 + payload_len.
 
-### Multi-frame start (byte 0 bit 7 = 1, bit 6 = 0)
+### Long message start (byte 0 = [1|0|group(2)|0000])
 ```
-Byte 0:  [1 | 0 | channel(2) | len[11:8](4)]
-Byte 1:  len[7:0]
-Byte 2:  [0 | opcode(3) | node[5:2](4)]
-Byte 3:  [node[1:0](2) | port(6)]
+Byte 0:  0x80/0x90/0xA0/0xB0 (group 0–3, index always 0)
+Byte 1:  total payload length (excl. BAP header)
+Byte 2:  [0 | opcode(3) | lsg[5:2](4)]
+Byte 3:  [lsg[1:0](2) | function(6)]
 Byte 4…7: first 4 bytes of payload
 ```
 
-### Multi-frame continuation (byte 0 bit 7 = 1, bit 6 = 1)
+### Long message continuation (byte 0 = [1|1|group(2)|index(4)])
 ```
-Byte 0:  [1 | 1 | channel(2) | 0(4)]
+Byte 0:  e.g. 0xC0…0xCF for group 0
 Byte 1…7: next 7 bytes of payload
 ```
+First continuation has index 0 (same as start); index increments per frame, wraps 15→0. Up to 4 concurrent long messages per CAN ID, keyed by group — reassemble on `(can_id, group)`.
 
-## Opcodes
+## Arrays
 
-| Opcode | Dir | Meaning |
-|---|---|---|
-| 0x0 | → ECU | **Get** — request current value |
-| 0x1 | → ECU | **SetGet** — write + request new status |
-| 0x2 | ← ECU | **Status** — ECU pushes / replies |
-| 0x3 | ← ECU | **Error** — negative response |
-| 0x4 | ← ECU | **Ack** — write acknowledged |
-| 0x6 | → ECU | **Set** — write, no reply |
+Functions returning lists (profiles, providers, destinations) use BAP arrays: a 4–5 byte array header then records. SetGet header: `[ASG-ID:4|Transaction-ID:4]`, `[LargeIdx|PosTransmit|Backward|Shift|RecordAddr:4]`, startIndex, elementCount. Status responses echo the Transaction-ID. **RecordAddr** selects the record format for the same function (full vs compact records, partial updates) — same offset means different fields under different RecordAddr values. Full spec: smartkar `BAP_PROTOCOL.md`.
 
 ## Validity Rules
 
 ```
-opcode ≤ 7 · node ≤ 63 · port ≤ 63 · len ≤ 4095
-single-frame: len ≤ 6
+opcode ≤ 7 · lsg ≤ 63 · function ≤ 63
+short message: payload ≤ 6
 ```
 
-e-Golf specific CAN IDs, port map, commands → `clima-control-bap.md`.
+e-Golf Battery Control channel (LSG 0x25: climate/charge functions, profiles, commands) → `clima-control-bap.md`.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -964,18 +964,19 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::SendClimaBapBurst(bool enable
 
     uint8_t data[8];
 
-    // Frame 1: BAP multi-frame start → port 0x19 (clima parameters), 8-byte payload.
-    // 0x80 = multi-frame start, channel 0.  0x08 = total payload length.
-    // 0x29 0x59 = BAP header: opcode=2 (Status push), node=0x25, port=0x19.
-    data[0] = 0x80;
-    data[1] = 0x08;           // 8-byte payload follows across this frame + continuation
-    data[2] = 0x29;           // BAP opcode=2, node=0x25 [5:2]
-    data[3] = 0x59;           // BAP node=0x25 [1:0], port=0x19
-    data[4] = m_bap_counter;  // rolling counter; ACK will echo this | 0x80
-    data[5] = 0x06;           // duration: 0x06 = 15 min (confirmed from capture: port 51 BCD
-                     // countdown, 30s per unit, 0x06 * 150s = 15 min). Use 0x04 for 10 min.
-    data[6] = 0x00;  // unknown
-    data[7] = 0x01;  // unknown (mode/profile flag)
+    // Frames 1+2: SetGet on ProfilesArray (LSG 0x25 function 0x19) — compact
+    // (RecordAddr 6) partial update of profile 0: enable climate + climate-on-battery.
+    // Field semantics per smartkar-cano-new BAP_BATTERY_CONTROL.md and MIB2 firmware RE
+    // (PR #1430 review); see clima-control-bap.md.
+    data[0] = 0x80;           // long BAP message start, group 0
+    data[1] = 0x08;           // payload length: 4-byte array header + 4-byte compact record
+    data[2] = 0x29;           // BAP header: OpCode 0x02 SetGet, LSG 0x25 [5:2]
+    data[3] = 0x59;           // LSG 0x25 [1:0], function 0x19 ProfilesArray
+    data[4] = m_bap_counter;  // array header [ASG-ID:4|Transaction-ID:4]; FSG Status
+                              // response echoes it (observed as our value | 0x80)
+    data[5] = 0x06;           // array header: RecordAddr = 6 (compact record format)
+    data[6] = 0x00;           // array header: startIndex
+    data[7] = 0x01;           // array header: elementCount = 1
     // Accept both ESP_OK (frame in TWAI HW FIFO, physical TX imminent) and ESP_QUEUED
     // (frame placed in the OVMS FreeRTOS SW queue behind a concurrently-transmitting frame).
     // The SW queue is FIFO — if Frame 1 is queued, Frames 2 and 3 will follow it in order,
@@ -989,21 +990,14 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::SendClimaBapBurst(bool enable
         return Fail;
     }
 
-    // Frame 2: BAP continuation — remaining payload bytes including target temperature.
-    // Temperature encoding: raw = (celsius - 10) * 10  (e.g. 21°C → 0x6E)
-    // Clamp here, not just in the web form: cc-temp can also be set from the CLI
-    // (config set xvg cc-temp ...), which bypasses the web validation. An out-of-range
-    // value would otherwise be cast to uint8_t and produce a nonsense temperature byte
-    // sent to the climate ECU. Keep this in int until after clamping.
-    int climate_temp = MyConfig.GetParamValueInt("xvg", "cc-temp", 21);
-    if (climate_temp < VWEGOLF_CLIMA_TEMP_MIN_C) climate_temp = VWEGOLF_CLIMA_TEMP_MIN_C;
-    if (climate_temp > VWEGOLF_CLIMA_TEMP_MAX_C) climate_temp = VWEGOLF_CLIMA_TEMP_MAX_C;
-    uint8_t temp_raw = (uint8_t)((climate_temp - 10) * 10);
-    data[0] = 0xC0;      // multi-frame continuation, channel 0
-    data[1] = 0x06;      // unknown
-    data[2] = 0x00;      // unknown
-    data[3] = temp_raw;  // target temperature: (celsius - 10) * 10
-    data[4] = 0x00;      // padding / unknown
+    // Frame 2: continuation — the 4-byte compact profile record. No temperature here:
+    // the car climatizes to the setpoint stored in its global profile (infotainment).
+    // An explicit setpoint would need a RecordAddr-0 profile write, not yet implemented.
+    data[0] = 0xC0;  // long BAP continuation, group 0, index 0
+    data[1] = 0x06;  // operation: climate | climateWithoutExternalSupply
+    data[2] = 0x00;  // operation2: none
+    data[3] = 0x20;  // maxCurrent = 32 A (1 A/LSB)
+    data[4] = 0x00;  // targetChargeLevel = 0 (not charging)
     esp_err_t ok2 = m_can3->WriteExtended(0x17332501, 5, data, pdMS_TO_TICKS(200));
     if (ok2 == ESP_FAIL) {
         ESP_LOGW(TAG, "BAP clima frame 2 TX queue overflow");
@@ -1012,8 +1006,8 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::SendClimaBapBurst(bool enable
         return Fail;
     }
 
-    // Frame 3: BAP single-frame trigger → port 0x18 (immediate start/stop).
-    // 0x29 0x58 = opcode=2, node=0x25, port=0x18. d[3] = 0x01 start / 0x00 stop.
+    // Frame 3: short BAP trigger — SetGet on function 0x18 (ClimateOperationMode).
+    // Payload: profileId 0 (global), then start bitmask (bit0 = immediately) / 0x00 stop.
     data[0] = 0x29;
     data[1] = 0x58;
     data[2] = 0x00;
@@ -1028,8 +1022,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::SendClimaBapBurst(bool enable
 
     m_bap_burst_active = false;
 
-    ESP_LOGI(TAG, "BAP clima %s sent: counter=0x%02X temp=%u°C", enable ? "start" : "stop",
-             m_bap_counter, climate_temp);
+    ESP_LOGI(TAG, "BAP clima %s sent: tid=0x%02X", enable ? "start" : "stop", m_bap_counter);
 
     // Optimistic update for responsive UX — reflect the command immediately, then let
     // 0x03B5 ClimaRunning confirm/sustain it.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -51,8 +51,8 @@ OvmsVehicleVWeGolf::OvmsVehicleVWeGolf() {
     RegisterCanBus(3, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);  // KCAN — comfort / clima
 
     OvmsCommand* cmd_vweg = MyCommandApp.RegisterCommand("xvg", "VW e-Golf controls");
-    cmd_vweg->RegisterCommand("offline", "Stop sending OCU keepalive", [this](...) {
-        m_is_control_active = false;
+    cmd_vweg->RegisterCommand("offline", "Stop sending OCU keepalive (diagnostic)", [this](...) {
+        m_ocu_active = false;
         ESP_LOGI(TAG, "OCU keepalive stopped");
     });
     cmd_vweg->RegisterCommand("fold_mirrors", "Fold mirrors in",
@@ -138,20 +138,29 @@ void OvmsVehicleVWeGolf::IncomingFrameCan2(CAN_frame_t* p_frame) {
 }
 
 void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
-    m_last_message_received = 0;
+    m_bus_idle_ticks = 0;
+
+    // Send OCU keepalive at ~5Hz while active. VW OSEK NM requires keepalives at
+    // ~200ms intervals; Ticker1 alone (1Hz) is too slow for the ECU to stay in network.
+    // SendOcuHeartbeat self-throttles (180ms min) against TX queue overflow on bus bursts.
+    if (m_ocu_active) {
+        SendOcuHeartbeat();
+    }
+
     uint8_t* d = p_frame->data.u8;
+
+    // Track OEM OCU activity: any non-zero 0x5A7 means the car's OCU is still active.
+    // Reset the idle counter so we don't wake while it would conflict with our heartbeat.
+    if (p_frame->MsgID == 0x5A7) {
+        if (d[0] | d[1] | d[2] | d[3] | d[4] | d[5] | d[6] | d[7]) {
+            m_oem_ocu_idle_ticks = 0;
+        }
+    }
 
     uint8_t tmp_u8 = 0;
     uint16_t tmp_u16 = 0;
     uint32_t tmp_u32 = 0;
-    // int8_t tmp_i8 = 0;
-    // int16_t tmp_i16 = 0;
-    // int32_t tmp_i32 = 0;
     float tmp_f32 = 0.0F;
-
-    // //TODO Debug only doesn't work ECU timeout
-    // vTaskDelay(pdMS_TO_TICKS(500)); //500ms wait.. hopefully my log isn't get messed up
-    // //TODO end doesn't work ECU timeout
 
     switch (p_frame->MsgID) {
         // TODO: Need to move to verify
@@ -187,8 +196,10 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
             StandardMetrics.ms_v_bat_voltage->SetValue(tmp_f32);
 
             // Power: negative = charging, positive = driving.
-            tmp_f32 = -1.0F * (StandardMetrics.ms_v_bat_voltage->AsFloat() *
-                               StandardMetrics.ms_v_bat_current->AsFloat()) / 1000.0F;
+            tmp_f32 = -1.0F *
+                      (StandardMetrics.ms_v_bat_voltage->AsFloat() *
+                       StandardMetrics.ms_v_bat_current->AsFloat()) /
+                      1000.0F;
             StandardMetrics.ms_v_bat_power->SetValue(tmp_f32);
             ESP_LOGV(TAG, "0x0191 I=%.1fA V=%.2fV", StandardMetrics.ms_v_bat_current->AsFloat(),
                      StandardMetrics.ms_v_bat_voltage->AsFloat());
@@ -240,8 +251,8 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
             // Sign bits: bit 55 (d[6] MSB) = Southern hemisphere, bit 56 (d[7] bit 0) = Western.
             // Confirmed consistent with known N/E location. S/W hemisphere still needs a capture.
             // Sentinel frames (all 0xFF) decode to lat=134°/lon=268° — filter by range.
-            tmp_u32 = ((uint32_t)(d[0])) | ((uint32_t)(d[1]) << 8) |
-                      ((uint32_t)(d[2]) << 16) | ((uint32_t)(d[3] & 0x7) << 24);
+            tmp_u32 = ((uint32_t)(d[0])) | ((uint32_t)(d[1]) << 8) | ((uint32_t)(d[2]) << 16) |
+                      ((uint32_t)(d[3] & 0x7) << 24);
             float lat = ((float)tmp_u32) * 0.000001F;
             if ((d[6] >> 7) & 1) lat = -lat;  // Southern hemisphere
 
@@ -268,9 +279,9 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
             StdMetrics.ms_v_door_rl->SetValue((d[3] & 0x4) >> 2);
             StdMetrics.ms_v_door_rr->SetValue((d[3] & 0x8) >> 3);
             StdMetrics.ms_v_door_trunk->SetValue((d[3] & 0x10) >> 4);
-            ESP_LOGV(TAG, "0x0583 locked=%u fl=%u fr=%u rl=%u rr=%u trunk=%u",
-                     (d[2] & 0x2) >> 1, d[3] & 0x1, (d[3] & 0x2) >> 1,
-                     (d[3] & 0x4) >> 2, (d[3] & 0x8) >> 3, (d[3] & 0x10) >> 4);
+            ESP_LOGV(TAG, "0x0583 locked=%u fl=%u fr=%u rl=%u rr=%u trunk=%u", (d[2] & 0x2) >> 1,
+                     d[3] & 0x1, (d[3] & 0x2) >> 1, (d[3] & 0x4) >> 2, (d[3] & 0x8) >> 3,
+                     (d[3] & 0x10) >> 4);
             break;
         }
         case 0x594:  // HV charge management
@@ -305,8 +316,10 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
                         StandardMetrics.ms_v_bat_voltage->AsFloat());
                 }
                 if (is_charging != was_charging) {
-                    if (is_charging) NotifyChargeStart();
-                    else NotifyChargeStopped();
+                    if (is_charging)
+                        NotifyChargeStart();
+                    else
+                        NotifyChargeStopped();
                 }
             }
 
@@ -545,9 +558,11 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
             if (tmp_u16 >= 0x3FE) break;
             tmp_f32 = ((float)tmp_u16) * 0.1F - 40.0F;
 
-            // remote_mode: 0=idle, 2=running, 3=just activated. HVAC on when != 0.
+            // remote_mode reflects "clima ECU energized" (ignition/ACC on OR a remote
+            // session) — NOT cabin conditioning. It pins true with ignition off and is
+            // asserted by radio/ACC mode, so it does NOT drive ms_v_env_hvac; that is owned
+            // by 0x03B5 ClimaRunning. Decoded here for the log only.
             tmp_u8 = ((uint8_t)(d[3] & 0xc0) >> 6) | ((uint8_t)(d[4] & 0x1) << 2);
-            StandardMetrics.ms_v_env_hvac->SetValue(tmp_u8 != 0);
             StandardMetrics.ms_v_env_cabintemp->SetValue(tmp_f32);
             ESP_LOGV(TAG, "0x05EA clima_cabin=%.1f°C remote_mode=%u", tmp_f32, tmp_u8);
             break;
@@ -608,9 +623,8 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
 
             // Park time: 17-bit field at bit offset 20, factor 1 s.
             // d[2] bits [7:4] → result bits [3:0], d[3] → [11:4], d[4] bits [4:0] → [16:12].
-            tmp_u32 =
-                ((uint32_t)(d[2] & 0xf0) >> 4) | ((uint32_t)(d[3]) << 4) |
-                ((uint32_t)(d[4] & 0x1f) << 12);
+            tmp_u32 = ((uint32_t)(d[2] & 0xf0) >> 4) | ((uint32_t)(d[3]) << 4) |
+                      ((uint32_t)(d[4] & 0x1f) << 12);
             StandardMetrics.ms_v_env_parktime->SetValue(tmp_u32);
             ESP_LOGV(TAG, "0x06B7 parktime=%u", tmp_u32);
 
@@ -635,6 +649,37 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
             // Remotestart_Motor_Start Faktor 1 Offset 0, Minimum 0, Maximum 1 [] Initial 0
             break;
         }
+        case 0x3B5: {
+            // ClimaRunning: d[0] bit7 = blower actively conditioning the cabin (0x80=on).
+            // Authoritative ms_v_env_hvac run-state — reflects real conditioning regardless
+            // of trigger (remote, schedule, or driving), unlike 0x05EA remote_mode which only
+            // tracks ECU power.
+            if (d[0] & 0x80) {
+                // Running evidence — refresh the hold timer. Suppress turning the metric back
+                // on during the spin-down right after our own stop command (a stop sets false
+                // immediately for responsive UX); if 0x03B5 still reports running past the
+                // suppress window, the stop didn't take, so trust it.
+                m_clima_run_secs = 0;
+                if (m_hvac_stop_secs >= VWEGOLF_HVAC_STOP_SUPPRESS_SECS) {
+                    StandardMetrics.ms_v_env_hvac->SetValue(true);
+                }
+            }
+            ESP_LOGV(TAG, "0x03B5 clima_running=%u", (d[0] >> 7) & 1);
+            break;
+        }
+        case 0x17332510: {
+            // BAP status/ACK from clima ECU (node 0x25), extended 29-bit frame.
+            // Pattern `49 58 XX` (DLC=3): port 0x18 (start/stop trigger) ACK. This is a
+            // transactional ACK, NOT a run-state — it emits a spurious 49 58 00 mid-session
+            // — so it does NOT drive ms_v_env_hvac (0x03B5 ClimaRunning does). We use it only
+            // to stand down the OCU ring once the transaction has been acknowledged.
+            if (p_frame->FIR.B.DLC == 3 && d[0] == 0x49 && d[1] == 0x58) {
+                ESP_LOGI(TAG, "0x17332510 BAP port 0x18 ACK: d2=0x%02X", d[2]);
+                // Arm grace: transaction is done, keep the ring warm briefly then stand down.
+                m_ocu_grace_secs = 0;
+            }
+            break;
+        }
         default: {
             // only for debug log ALL Incoming frames As i didn't know what frames are coming in
             // after wakeup had to log all only all unknown ESP_LOGI(TAG, "T26: timestamp: %.24i
@@ -646,33 +691,102 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
     }
 }
 
-// ms_v_env_awake;                     // Vehicle is fully awake (switched on by the user)
-// ms_v_env_on;                        // Vehicle is in "ignition" state (drivable)
-
-// 0x12dd546f BCM_04... ansteuerung LED Ladeanzeige mit Dimmung und Farbe?
-
-// 0x5B0 => TimeDate
+// ---------------------------------------------------------------------------
+// Periodic tickers
+// ---------------------------------------------------------------------------
 
 void OvmsVehicleVWeGolf::Ticker1(uint32_t ticker) {
-    // 10 seconds after last received message we assume that the car is sleeping
-    m_is_car_online = m_last_message_received < 10;
+    OvmsVehicle::Ticker1(ticker);
 
-    if (m_last_message_received < 254) m_last_message_received++;
-    ESP_LOGV(TAG, "0x5A7 last_msg=%u", m_last_message_received);
+    // Count consecutive seconds of KCAN silence. IncomingFrameCan3 resets this to 0
+    // whenever a frame arrives, so it measures how long since the last activity.
+    if (m_bus_idle_ticks < 254) m_bus_idle_ticks++;
+    if (m_oem_ocu_idle_ticks < 254) m_oem_ocu_idle_ticks++;
+    if (m_clima_run_secs < 255) m_clima_run_secs++;
+    if (m_hvac_stop_secs < 255) m_hvac_stop_secs++;
 
-    if (m_is_control_active &&
-        m_is_car_online)  // after wakeup the other ECUs waiting for the car to be online before we
-                          // send some Heartbeat messages otherwise we have some serious txerrors
-                          // just before the car ist active
-    {
-        SendOcuHeartbeat();  // working
-        ESP_LOGV(TAG, "Heartbeat sending triggered");
+    // ms_v_env_hvac (driven by 0x03B5 ClimaRunning + commands) clears once no "running"
+    // evidence has arrived for the hold window. Bridges blower thermostat cycling and clears
+    // the metric when the car sleeps. A stop command already set it false immediately, so this
+    // governs only autonomous/timer stops (≈hold-second linger).
+    if (m_clima_run_secs >= VWEGOLF_HVAC_RUN_HOLD_SECS && StandardMetrics.ms_v_env_hvac->AsBool()) {
+        StandardMetrics.ms_v_env_hvac->SetValue(false);
+    }
+
+    bool bus_alive = m_bus_idle_ticks < VWEGOLF_BUS_TIMEOUT_SECS;
+    bool just_went_idle = (m_bus_idle_ticks == VWEGOLF_BUS_TIMEOUT_SECS);
+    ESP_LOGV(TAG, "Ticker1: bus_idle=%u alive=%d ocu=%d", m_bus_idle_ticks, bus_alive,
+             m_ocu_active);
+
+    // Clear OCU node presence on either condition:
+    //   1. Bus went idle (no frames for VWEGOLF_BUS_TIMEOUT_SECS) — no one to hear us.
+    //   2. OEM OCU is present — it owns 0x5A7, our TX would collide on arbitration.
+    // Without (2), m_ocu_active stays set across an entire drive cycle whenever the
+    // bus never idles, and the next RX frame triggers a heartbeat that collides with
+    // the OEM OCU every time. Do NOT clear metrics — decoders own them; stale-expire
+    // handles freshness. (Clearing charge_inprogress here would falsely show "not
+    // charging" during CCS DC, which keeps KCAN silent while actively charging.)
+    bool oem_ocu_present = m_oem_ocu_idle_ticks < VWEGOLF_BUS_TIMEOUT_SECS;
+
+    if (m_ocu_active) {
+        if (m_ocu_session_secs < 255) m_ocu_session_secs++;
+        if (m_ocu_grace_secs < 255) m_ocu_grace_secs++;
+    }
+    bool grace_expired = m_ocu_grace_secs < 255 && m_ocu_grace_secs >= VWEGOLF_OCU_ACK_GRACE_SECS;
+    bool cap_expired = m_ocu_session_secs >= VWEGOLF_OCU_SESSION_CAP_SECS;
+
+    if (m_ocu_active && (just_went_idle || oem_ocu_present || grace_expired || cap_expired)) {
+        m_ocu_active = false;
+        const char* reason = just_went_idle    ? "KCAN idle"
+                             : oem_ocu_present ? "OEM OCU active"
+                             : grace_expired   ? "ACK grace expired"
+                                               : "session cap";
+        ESP_LOGI(TAG, "OCU presence cleared: %s", reason);
+    }
+
+    // Guard: only heartbeat when we've joined the bus and the bus has live traffic.
+    if (m_ocu_active && bus_alive) {
+        SendNmAlive();
+        SendOcuHeartbeat();
+    }
+
+    // Fire deferred clima BAP burst once the wake-settle window has elapsed.
+    // CommandClimateControl returns immediately after WakeKcanBus so the dispatch task
+    // isn't blocked for 1 s; we pick up here on the next Ticker1 once the NM-join flood
+    // has subsided. Bus must still be alive — otherwise wake didn't take and the burst
+    // would just queue against a dead controller.
+    if (m_clima_pending) {
+        uint32_t now = xTaskGetTickCount();
+        uint32_t elapsed_ms = (now - m_clima_pending_tick) * portTICK_PERIOD_MS;
+        if (!bus_alive) {
+            ESP_LOGW(TAG, "Deferred clima: bus went idle before settle — aborting");
+            m_clima_pending = false;
+            // Burst never went out — reflect the opposite of the intended state and reset the
+            // hold timer so Ticker1 doesn't immediately override it.
+            StandardMetrics.ms_v_env_hvac->SetValue(!m_clima_pending_enable);
+            m_clima_run_secs = m_clima_pending_enable ? 255 : 0;
+        } else if (elapsed_ms >= VWEGOLF_CLIMA_SETTLE_MS) {
+            // Keep m_clima_pending set across the burst so a CommandClimateControl arriving
+            // mid-send retargets (see CommandClimateControl) instead of racing this burst.
+            // Clear only once it has returned.
+            bool enable = m_clima_pending_enable;
+            vehicle_command_t result = SendClimaBapBurst(enable);
+            m_clima_pending = false;
+            if (result != Success) {
+                StandardMetrics.ms_v_env_hvac->SetValue(!enable);
+                m_clima_run_secs = enable ? 255 : 0;
+            }
+        }
     }
 }
 
+// ---------------------------------------------------------------------------
+// Vehicle commands
+// ---------------------------------------------------------------------------
+
 OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::CommandLock(const char* pin) {
     if (!PinCheck(pin)) {
-        ESP_LOGW(TAG, "PinCheck failed in CommandLock");
+        ESP_LOGW(TAG, "CommandLock: PIN check failed");
         return Fail;
     }
     m_lock_requested = true;
@@ -681,7 +795,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::CommandLock(const char* pin) 
 
 OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::CommandUnlock(const char* pin) {
     if (!PinCheck(pin)) {
-        ESP_LOGW(TAG, "PinCheck failed in CommandUnlock");
+        ESP_LOGW(TAG, "CommandUnlock: PIN check failed");
         return Fail;
     }
     m_unlock_requested = true;
@@ -704,96 +818,79 @@ OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::CommandIndicators() {
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::CommandPanic() {
-    m_panic_mode_requested = true;
+    m_panic_requested = true;
     return Success;
 }
 
-void OvmsVehicleVWeGolf::Ticker10(uint32_t ticker) {
-    // working
-    m_climate_control_temp = MyConfig.GetParamValueInt("xvg", "cc_temp", 21);
-    m_climate_control_on_battery = (MyConfig.GetParamValueBool("xvg", "cc_onbat", false) ? 1 : 0);
+void OvmsVehicleVWeGolf::WakeKcanBus() {
+    ESP_LOGI(TAG, "WakeKcanBus: asserting dominant bits on KCAN");
 
-    ESP_LOGV(TAG,
-             "Trigger10 cc_temp: %u °C, cc_onbat: %u, control_mirror %u, control_horn: %u, "
-             "control_indicator: %u, control_panicMode: %u, control_unlock %u, control_lock %u",
-             m_climate_control_temp, m_climate_control_on_battery, m_mirror_fold_in_requested,
-             m_horn_requested, m_indicators_requested, m_panic_mode_requested, m_unlock_requested,
-             m_lock_requested);
+    // Reset the KCAN controller to clear any stuck frame from the TWAI HW TX FIFO.
+    // A stale heartbeat left from the prior session occupies the FIFO slot; on a sleeping
+    // bus it can never drain (no ACK), so the wake frame queues behind it and never
+    // produces dominant bits. Stop/Start preserves mode and speed.
+    m_can3->Reset();
+    vTaskDelay(pdMS_TO_TICKS(5));
+
+    uint8_t data[8] = {0x40, 0x00, 0x01, 0x1F, 0x00, 0x00, 0x00, 0x00};
+    m_can3->WriteExtended(0x17330301, 8, data, pdMS_TO_TICKS(50));
+    vTaskDelay(pdMS_TO_TICKS(50));
+
+    data[0] = 0x67;
+    data[1] = 0x10;
+    data[2] = 0x41;
+    data[3] = 0x84;
+    data[4] = 0x14;
+    data[5] = 0x00;
+    data[6] = 0x00;
+    data[7] = 0x00;
+    m_can3->WriteExtended(0x1B000067, 8, data, pdMS_TO_TICKS(50));
+    vTaskDelay(pdMS_TO_TICKS(100));
+
+    m_ocu_active = true;
+    m_ocu_session_secs = 0;
+    m_ocu_grace_secs = 255;
 }
 
 OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::CommandWakeup() {
-    ESP_LOGV(TAG, "Wakeup triggered");
-
-    // Info: eGolf300 after sending only the heartbeat message ID:0x5A7 or the first message here
-    // ID:0x17330301 one ECU with ID:0x5F5 is answering on the bus perhaps ID:0x66E and ID:0x6B5 too
-    // Info: perhaps this could be used for another method to wakeup the car comf CAN perhaps
-    // changing the settings is possible without weaking up everything
-
-    if (!m_is_car_online) {
-        ESP_LOGI(TAG, "Car is sleeping we are trying to wake it up");
-        // Wake up the Bus //CLI: can can3 tx extended 0x17330301 0x40 0x00 0x01 0x1F 0x00 0x00 0x00
-        // 0x00
-        canbus* comfBus;
-        comfBus = m_can3;
-        uint8_t length = 8;
-        uint8_t data[length];
-        data[0] = 0x40;
-        data[1] = 0x00;
-        data[2] = 0x01;
-        data[3] = 0x1F;
-        data[4] = 0x00;
-        data[5] = 0x00;
-        data[6] = 0x00;
-        data[7] = 0x00;
-        comfBus->WriteExtended(0x17330301, length, data);
-        vTaskDelay(pdMS_TO_TICKS(50));
-        ESP_LOGV(TAG, "First message send ID: data 0->7");
-        ESP_LOGV(TAG,
-                 "First message send ID:0x17330301 data %02x %02x %02x %02x %02x %02x %02x %02x",
-                 data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
-
-        vTaskDelay(pdMS_TO_TICKS(100));
-        length = 8;
-        data[0] = 0x67;  // source node identifier identity of the transmitter of the message
-        data[1] = 0x10;  // could be anything
-        data[2] = 0x41;  // 0-5 => State,  6 => eCall Car Wakeup
-        data[3] = 0x84;  // 0-8 => eCall Wakeup
-        data[4] = 0x14;
-        data[5] = 0x00;
-        data[6] = 0x00;
-        data[7] = 0x00;
-        comfBus->WriteExtended(0x1B000067, length, data);
-        vTaskDelay(pdMS_TO_TICKS(50));
-        ESP_LOGV(TAG, "second message send ID: data 0->7");
-        ESP_LOGV(TAG,
-                 "second message send ID:0x1B000067 data %02x %02x %02x %02x %02x %02x %02x %02x",
-                 data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
-
-        m_is_control_active = true;
-    } else {
-        ESP_LOGI(TAG, "Wakeup not necessary car was online before");
+    if (m_bus_idle_ticks < VWEGOLF_BUS_TIMEOUT_SECS) {
+        ESP_LOGI(TAG, "Wakeup: KCAN already active");
+        return Success;
     }
+    WakeKcanBus();
     return Success;
 }
 
 void OvmsVehicleVWeGolf::SendOcuHeartbeat() {
+    // Hard gate: a BAP multi-frame burst is in flight on KCAN. A 0x5A7 queued between
+    // the start/continuation/trigger frames blocks the continuation and the ECU drops
+    // the message. Worst-case burst is 3×200 ms = 600 ms, well past the 180 ms throttle.
+    if (m_bap_burst_active) {
+        return;
+    }
+
+    // Hard gate: OEM OCU owns 0x5A7. If it's alive, our TX collides on arbitration
+    // every frame (identical ID) — TEC climbs on no-ACK until bus-off. Stand down
+    // until the OEM OCU has been silent for >= VWEGOLF_BUS_TIMEOUT_SECS.
+    if (m_oem_ocu_idle_ticks < VWEGOLF_BUS_TIMEOUT_SECS) {
+        return;
+    }
+
+    // Self-throttle: minimum 180 ms between sends regardless of caller (Ticker1,
+    // incoming-frame hook, or any future call site). Guards against TX queue overflow
+    // during NM wake bursts and ensures Ticker1 can't double-fire on top of the
+    // incoming-frame path.
+    uint32_t now = xTaskGetTickCount();
+    if ((now - m_last_heartbeat_tick) * portTICK_PERIOD_MS < 180) {
+        return;
+    }
+    m_last_heartbeat_tick = now;
+
     uint8_t tmp_u8 = 0;
 
-    canbus* comfBus;
-    comfBus = m_can3;
-    uint8_t length = 8;
-    uint8_t data[length];
-    length = 8;
-    data[0] = 0x00;
-    data[1] = 0x00;
-    data[2] = 0x00;
-    data[3] = 0x00;
-    data[4] = 0x00;
-    data[5] = 0x00;
-    data[6] = 0x00;
-    data[7] = 0x00;
+    uint8_t data[8] = {0};
 
-    // Spiegelanklappen
+    // Mirror fold
     if (m_mirror_fold_in_requested) {
         tmp_u8 = 1;
         data[5] = (((uint8_t)tmp_u8) << 7) & 0x80;
@@ -801,7 +898,7 @@ void OvmsVehicleVWeGolf::SendOcuHeartbeat() {
         ESP_LOGI(TAG, "Mirror fold in");
     }
 
-    // Hupen
+    // Horn
     if (m_horn_requested) {
         tmp_u8 = 1;
         data[6] = (((uint8_t)tmp_u8) >> 0) & 0x1;
@@ -827,7 +924,7 @@ void OvmsVehicleVWeGolf::SendOcuHeartbeat() {
         ESP_LOGI(TAG, "DoorUnlock");
     }
 
-    // Warnblinken
+    // Hazard lights
     if (m_indicators_requested) {
         tmp_u8 = 1;
         data[6] = (((uint8_t)tmp_u8) << 3) & 0x8;
@@ -835,17 +932,169 @@ void OvmsVehicleVWeGolf::SendOcuHeartbeat() {
         ESP_LOGI(TAG, "Hazard lights");
     }
 
-    // Panicalarm
-    if (m_panic_mode_requested) {
+    // Panic alarm
+    if (m_panic_requested) {
         tmp_u8 = 1;
         data[6] = (((uint8_t)tmp_u8) << 4) & 0x10;
-        m_panic_mode_requested = false;
+        m_panic_requested = false;
         ESP_LOGI(TAG, "PanicAlarm!");
     }
 
-    comfBus->WriteStandard(0x5A7, length, data);
-    vTaskDelay(pdMS_TO_TICKS(50));
-    ESP_LOGV(TAG, "Heartbeat send ID: data 0->7");
-    ESP_LOGI(TAG, "FHeartbeat send ID:0x5A7 data %02x %02x %02x %02x %02x %02x %02x %02x", data[0],
-             data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
+    m_can3->WriteStandard(0x5A7, 8, data);
+    ESP_LOGV(TAG, "Heartbeat 0x5A7: %02x %02x %02x %02x %02x %02x %02x %02x", data[0], data[1],
+             data[2], data[3], data[4], data[5], data[6], data[7]);
+}
+
+void OvmsVehicleVWeGolf::SendNmAlive() {
+    // Ring drops silent nodes after a few cadences; a one-shot alive on wake survives
+    // long enough for warm-bus commands but not a cold BAP burst. OEM 0x67 cadence
+    // ~1.3 s (kcan-can3-clima_schedule.crtd) — Ticker1's 1 Hz tick matches.
+    // Burst gate: a 0x1B frame between BAP frames blocks the continuation.
+    if (m_bap_burst_active) {
+        return;
+    }
+    uint8_t data[8] = {0x67, 0x10, 0x41, 0x84, 0x14, 0x00, 0x00, 0x00};
+    m_can3->WriteExtended(0x1B000067, 8, data);
+}
+
+OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::SendClimaBapBurst(bool enable) {
+    // Rolling counter: echoed back (| 0x80) in the ECU's ACK to match the command.
+    m_bap_counter = (m_bap_counter == 0xFF) ? 0x01 : m_bap_counter + 1;
+
+    // Suppress heartbeats for the full 3-frame burst. Set before frame 1, cleared on
+    // every exit path below — a 0x5A7 between frames blocks the continuation.
+    m_bap_burst_active = true;
+
+    uint8_t data[8];
+
+    // Frame 1: BAP multi-frame start → port 0x19 (clima parameters), 8-byte payload.
+    // 0x80 = multi-frame start, channel 0.  0x08 = total payload length.
+    // 0x29 0x59 = BAP header: opcode=2 (Status push), node=0x25, port=0x19.
+    data[0] = 0x80;
+    data[1] = 0x08;           // 8-byte payload follows across this frame + continuation
+    data[2] = 0x29;           // BAP opcode=2, node=0x25 [5:2]
+    data[3] = 0x59;           // BAP node=0x25 [1:0], port=0x19
+    data[4] = m_bap_counter;  // rolling counter; ACK will echo this | 0x80
+    data[5] = 0x06;           // duration: 0x06 = 15 min (confirmed from capture: port 51 BCD
+                     // countdown, 30s per unit, 0x06 * 150s = 15 min). Use 0x04 for 10 min.
+    data[6] = 0x00;  // unknown
+    data[7] = 0x01;  // unknown (mode/profile flag)
+    // Accept both ESP_OK (frame in TWAI HW FIFO, physical TX imminent) and ESP_QUEUED
+    // (frame placed in the OVMS FreeRTOS SW queue behind a concurrently-transmitting frame).
+    // The SW queue is FIFO — if Frame 1 is queued, Frames 2 and 3 will follow it in order,
+    // so the ECU always sees a complete multi-frame sequence. Only bail on ESP_FAIL, which
+    // means the SW queue itself overflowed (bus stuck or configuration error).
+    esp_err_t ok1 = m_can3->WriteExtended(0x17332501, 8, data, pdMS_TO_TICKS(200));
+    if (ok1 == ESP_FAIL) {
+        ESP_LOGW(TAG, "BAP clima frame 1 TX queue overflow");
+        m_bap_burst_active = false;
+        m_ocu_active = false;
+        return Fail;
+    }
+
+    // Frame 2: BAP continuation — remaining payload bytes including target temperature.
+    // Temperature encoding: raw = (celsius - 10) * 10  (e.g. 21°C → 0x6E)
+    // Clamp here, not just in the web form: cc-temp can also be set from the CLI
+    // (config set xvg cc-temp ...), which bypasses the web validation. An out-of-range
+    // value would otherwise be cast to uint8_t and produce a nonsense temperature byte
+    // sent to the climate ECU. Keep this in int until after clamping.
+    int climate_temp = MyConfig.GetParamValueInt("xvg", "cc-temp", 21);
+    if (climate_temp < VWEGOLF_CLIMA_TEMP_MIN_C) climate_temp = VWEGOLF_CLIMA_TEMP_MIN_C;
+    if (climate_temp > VWEGOLF_CLIMA_TEMP_MAX_C) climate_temp = VWEGOLF_CLIMA_TEMP_MAX_C;
+    uint8_t temp_raw = (uint8_t)((climate_temp - 10) * 10);
+    data[0] = 0xC0;      // multi-frame continuation, channel 0
+    data[1] = 0x06;      // unknown
+    data[2] = 0x00;      // unknown
+    data[3] = temp_raw;  // target temperature: (celsius - 10) * 10
+    data[4] = 0x00;      // padding / unknown
+    esp_err_t ok2 = m_can3->WriteExtended(0x17332501, 5, data, pdMS_TO_TICKS(200));
+    if (ok2 == ESP_FAIL) {
+        ESP_LOGW(TAG, "BAP clima frame 2 TX queue overflow");
+        m_bap_burst_active = false;
+        m_ocu_active = false;
+        return Fail;
+    }
+
+    // Frame 3: BAP single-frame trigger → port 0x18 (immediate start/stop).
+    // 0x29 0x58 = opcode=2, node=0x25, port=0x18. d[3] = 0x01 start / 0x00 stop.
+    data[0] = 0x29;
+    data[1] = 0x58;
+    data[2] = 0x00;
+    data[3] = enable ? 0x01 : 0x00;
+    esp_err_t ok3 = m_can3->WriteExtended(0x17332501, 4, data, pdMS_TO_TICKS(200));
+    if (ok3 == ESP_FAIL) {
+        ESP_LOGW(TAG, "BAP clima frame 3 TX queue overflow");
+        m_bap_burst_active = false;
+        m_ocu_active = false;
+        return Fail;
+    }
+
+    m_bap_burst_active = false;
+
+    ESP_LOGI(TAG, "BAP clima %s sent: counter=0x%02X temp=%u°C", enable ? "start" : "stop",
+             m_bap_counter, climate_temp);
+
+    // Optimistic update for responsive UX — reflect the command immediately, then let
+    // 0x03B5 ClimaRunning confirm/sustain it.
+    //   start: set true and give the blower the full hold window to spin up; clear any
+    //          stop-suppression.
+    //   stop:  set false now; expire the hold so it can't keep the metric true, and start
+    //          the spin-down suppression so the blower's trailing 0x03B5=running doesn't
+    //          flick it back on (until the suppress window lapses — see case 0x03B5).
+    StandardMetrics.ms_v_env_hvac->SetValue(enable);
+    if (enable) {
+        m_clima_run_secs = 0;
+        m_hvac_stop_secs = 255;
+    } else {
+        m_clima_run_secs = 255;
+        m_hvac_stop_secs = 0;
+    }
+
+    // Stay in the NM ring after both start and stop. On stop the ECU broadcasts a
+    // 0x05→0x00 status transition on BAP port 0x12 a few hundred ms later; dropping
+    // out immediately would miss the ACK. Natural bus-idle timeout in Ticker1 clears
+    // m_ocu_active once KCAN goes quiet.
+    m_ocu_active = true;
+    return Success;
+}
+
+OvmsVehicle::vehicle_command_t OvmsVehicleVWeGolf::CommandClimateControl(bool enable) {
+    ESP_LOGI(TAG, "Climate control: %s", enable ? "start" : "stop");
+
+    if (m_can3->GetErrorState() == CAN_errorstate_busoff) {
+        ESP_LOGW(TAG, "Climate control: KCAN controller in bus-off — aborting");
+        return Fail;
+    }
+
+    // A deferred burst from a previous command is still in flight (woken, waiting on the
+    // settle window, or mid-send — see m_clima_pending). Re-target it and return rather
+    // than starting a second burst: the bus is awake by now, so this command would take
+    // the warm-bus path below and race the pending Ticker1 burst, interleaving two BAP
+    // multi-frame sequences at the ECU. Ticker1 fires once with the latest intent.
+    if (m_clima_pending) {
+        m_clima_pending_enable = enable;
+        ESP_LOGI(TAG, "Climate control: deferred burst pending — retargeted to %s",
+                 enable ? "start" : "stop");
+        return Success;
+    }
+
+    // Wake the bus if it has been quiet long enough that ECUs are likely sleeping.
+    // Two conditions must both be true:
+    //   1. No KCAN frame for >= CLIMA_WAKE_SECS (bus is going/gone to sleep).
+    //   2. No non-zero OEM 0x5A7 for >= CLIMA_WAKE_SECS (OEM OCU is off — safe to
+    //      send our heartbeat without causing an arbitration-loss → bus-off cycle).
+    // Defer the BAP burst to Ticker1 so the dispatch task isn't blocked for 1 s while
+    // the NM-join flood subsides. Ticker1 fires once VWEGOLF_CLIMA_SETTLE_MS elapses.
+    if (m_bus_idle_ticks >= VWEGOLF_CLIMA_WAKE_SECS &&
+        m_oem_ocu_idle_ticks >= VWEGOLF_CLIMA_WAKE_SECS) {
+        ESP_LOGI(TAG, "Climate control: KCAN quiet %u s, OEM OCU quiet %u s — waking bus",
+                 m_bus_idle_ticks, m_oem_ocu_idle_ticks);
+        WakeKcanBus();
+        m_clima_pending = true;
+        m_clima_pending_enable = enable;
+        m_clima_pending_tick = xTaskGetTickCount();
+        return Success;
+    }
+
+    return SendClimaBapBurst(enable);
 }

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -132,9 +132,6 @@ void OvmsVehicleVWeGolf::IncomingFrameCan2(CAN_frame_t* p_frame) {
             break;
         }
     }
-    // J533 bridges KCAN traffic onto CAN2; forward every frame so the KCAN
-    // decoder in IncomingFrameCan3 can process it regardless of which bus it arrives on.
-    IncomingFrameCan3(p_frame);
 }
 
 void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
@@ -26,8 +26,6 @@
 #ifndef __VEHICLE_VWEG_H__
 #define __VEHICLE_VWEG_H__
 
-#include <atomic>
-
 #include "can.h"
 #include "ovms_command.h"
 #include "ovms_config.h"
@@ -35,11 +33,52 @@
 #include "ovms_metrics.h"
 #include "vehicle.h"
 
-// Car (poll) states
+// Poll states — index matches the timing array in poll_pid_t entries.
 #define VWEGOLF_OFF 0       // All systems sleeping
 #define VWEGOLF_AWAKE 1     // Base systems online
-#define VWEGOLF_CHARGING 2  // Base systems online & car is charging the main battery
-#define VWEGOLF_ON 3        // All systems online & car is drivable
+#define VWEGOLF_CHARGING 2  // Base systems online and charging
+#define VWEGOLF_ON 3        // All systems online, drivable
+
+// KCAN goes silent within a few seconds of the car sleeping. After this many
+// consecutive Ticker1 ticks with no incoming frames, the bus is treated as offline
+// and we suppress OCU keepalive transmission to avoid accumulating TX errors.
+#define VWEGOLF_BUS_TIMEOUT_SECS 10
+
+// Shorter threshold for the clima wake-before-send decision. KCAN NM runs at 200ms
+// intervals; 3 seconds of silence means the bus is going to sleep or already asleep,
+// even if m_bus_idle_ticks hasn't reached BUS_TIMEOUT yet. Used together with the
+// OEM OCU idle counter to avoid waking during the 0x5A7 conflict window.
+#define VWEGOLF_CLIMA_WAKE_SECS 3
+
+// Settle delay between WakeKcanBus and the BAP burst. The NM-join flood needs time to
+// subside before the clima ECU will accept the multi-frame command. Applied from
+// Ticker1 (non-blocking) when CommandClimateControl had to wake the bus.
+#define VWEGOLF_CLIMA_SETTLE_MS 1000
+
+// Session length limits after WakeKcanBus. OCU keepalive + NM alive stop when the
+// ring quiesces post-ACK (grace) or if no ACK arrives (hard cap). Without these,
+// we talk alone on a sleeping ring, every TX fails ACK, TEC storms for minutes.
+#define VWEGOLF_OCU_ACK_GRACE_SECS 5
+#define VWEGOLF_OCU_SESSION_CAP_SECS 30
+
+// ms_v_env_hvac is driven by 0x03B5 ClimaRunning (cabin actively conditioned). The blower
+// thermostat-cycles within a session (observed off-gaps up to ~14 s), so the metric holds
+// true for this many seconds after the last "running" evidence — bridges the cycling and
+// clears the metric when the car sleeps. A stop command clears it immediately (responsive
+// UX); this only governs autonomous/timer stops (≈hold-second linger, acceptable).
+#define VWEGOLF_HVAC_RUN_HOLD_SECS 20
+
+// Allowed range for the clima target temperature (config xvg cc-temp), in °C. The BAP
+// burst clamps the configured value to this range before encoding the temperature byte,
+// so an out-of-range config value can never reach the climate ECU as garbage.
+#define VWEGOLF_CLIMA_TEMP_MIN_C 16
+#define VWEGOLF_CLIMA_TEMP_MAX_C 28
+
+// After our own stop command we set hvac false at once but the blower keeps spinning down
+// for a moment (0x03B5 still reports running). Ignore that "running" for this long so the
+// stop stays responsive; if 0x03B5 still insists past the window the stop didn't take, so
+// we trust it and show running again.
+#define VWEGOLF_HVAC_STOP_SUPPRESS_SECS 10
 
 class OvmsVehicleVWeGolf : public OvmsVehicle {
  public:
@@ -56,26 +95,86 @@ class OvmsVehicleVWeGolf : public OvmsVehicle {
     vehicle_command_t CommandLock(const char* pin) override;
     vehicle_command_t CommandUnlock(const char* pin) override;
     vehicle_command_t CommandWakeup() override;
+    vehicle_command_t CommandClimateControl(bool enable) override;
     void SendOcuHeartbeat();
+    void SendNmAlive();
+    void WakeKcanBus();
+    vehicle_command_t SendClimaBapBurst(bool enable);
 
  protected:
     void Ticker1(uint32_t ticker) override;
-    void Ticker10(uint32_t ticker) override;
 
  private:
-    bool m_is_car_online = true;
-    uint8_t m_last_message_received = 255;
-    uint8_t m_climate_control_temp = 19;
-    bool m_climate_control_on_battery = false;
+    // Seconds since the last KCAN (can3) frame arrived. Reset to 0 in IncomingFrameCan3,
+    // incremented each second in Ticker1. Bus is alive while < VWEGOLF_BUS_TIMEOUT_SECS.
+    // Initialized to timeout so we treat the bus as offline at cold boot.
+    uint8_t m_bus_idle_ticks = VWEGOLF_BUS_TIMEOUT_SECS;
+
+    // Seconds since the last non-zero 0x5A7 from the OEM OCU. While the car is on or
+    // just turned off, the OEM OCU sends non-zero 0x5A7 frames that conflict with our
+    // all-zeros heartbeat (arbitration loss → bus-off). Must not wake while this is <
+    // CLIMA_WAKE_SECS. Initialized to timeout so cold boot treats the OEM OCU as absent.
+    uint8_t m_oem_ocu_idle_ticks = VWEGOLF_BUS_TIMEOUT_SECS;
+
+    // OVMS must send the 0x5A7 OCU keepalive while it is an active node.
+    // VW OSEK NM requires keepalives at ~200ms intervals — Ticker1 alone (1Hz) is
+    // insufficient. We enforce a 180ms minimum interval via a FreeRTOS tick timestamp
+    // checked on every incoming KCAN frame, giving ~5Hz without storm risk when the
+    // bus gets a sudden traffic burst (e.g. from an NM wake).
+    // We only start sending after deliberately taking an action (wakeup or command)
+    // to avoid asserting an unexpected node presence when the car is idle.
+    bool m_ocu_active = false;
+    uint32_t m_last_heartbeat_tick = 0;
+
+    // Session bounds (seconds, incremented in Ticker1 while m_ocu_active).
+    // Without a bounded session, NM alive + heartbeat keep firing after the ring
+    // quiesces; every TX fails ACK, TEC storms for minutes. See cap 20260422-173035.
+    // Session cap ends it if no ACK arrives; grace ends it shortly after an ACK.
+    uint8_t m_ocu_session_secs = 0;
+    uint8_t m_ocu_grace_secs = 255;  // 255 = no ACK seen yet
+
+    // Rolling BAP counter included in each command frame. The ECU echoes it (| 0x80) in
+    // its ACK so we can match responses to commands. Must never be zero; wraps 0xFF → 0x01.
+    uint8_t m_bap_counter = 0;
+
+    // hvac run-state tracking — source of truth is 0x03B5 ClimaRunning.
+    // m_clima_run_secs: seconds since the last "running" evidence; metric clears when it
+    //   exceeds VWEGOLF_HVAC_RUN_HOLD_SECS. m_hvac_stop_secs: seconds since our last stop
+    //   command; 0x03B5 'running' is ignored while below VWEGOLF_HVAC_STOP_SUPPRESS_SECS.
+    // 255 = "long ago / inactive". Both incremented in Ticker1.
+    uint8_t m_clima_run_secs = 255;
+    uint8_t m_hvac_stop_secs = 255;
+
+    // Set while a multi-frame BAP command burst is in flight (CommandClimateControl).
+    // SendOcuHeartbeat skips if set — a 0x5A7 queued between BAP frames blocks the
+    // continuation and the ECU discards the message. The 180 ms throttle isn't enough
+    // when the 3×WriteExtended calls can take up to 600 ms worst-case.
+    bool m_bap_burst_active = false;
+
+    // Deferred clima burst. When CommandClimateControl has to wake the bus, it kicks
+    // WakeKcanBus, records the tick, and returns Success immediately so the command
+    // dispatch task isn't blocked for the 1 s NM-join settle. Ticker1 fires the 3-frame
+    // BAP burst once VWEGOLF_CLIMA_SETTLE_MS has elapsed.
+    bool m_clima_pending = false;
+    bool m_clima_pending_enable = false;
+    uint32_t m_clima_pending_tick = 0;
+
     bool m_mirror_fold_in_requested = false;
     bool m_horn_requested = false;
     bool m_indicators_requested = false;
-    bool m_panic_mode_requested = false;
+    bool m_panic_requested = false;
     bool m_unlock_requested = false;
     bool m_lock_requested = false;
-    bool m_is_control_active = false;
+
+    // VIN assembly state. Frame 0x6B4 carries the 17-char VIN split across three frames
+    // identified by data[0]. We collect all three before committing to the metric.
     uint8_t m_vin_parts_received = 0;
     char m_vin_buf[18] = {};
+
+#ifdef VWEGOLF_NATIVE_TEST
+ public:
+    uint8_t test_bus_idle_ticks() const { return m_bus_idle_ticks; }
+#endif
 };
 
-#endif  // #ifndef __VEHICLE_VWEG_H__
+#endif  // __VEHICLE_VWEG_H__

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
@@ -68,12 +68,6 @@
 // UX); this only governs autonomous/timer stops (≈hold-second linger, acceptable).
 #define VWEGOLF_HVAC_RUN_HOLD_SECS 20
 
-// Allowed range for the clima target temperature (config xvg cc-temp), in °C. The BAP
-// burst clamps the configured value to this range before encoding the temperature byte,
-// so an out-of-range config value can never reach the climate ECU as garbage.
-#define VWEGOLF_CLIMA_TEMP_MIN_C 16
-#define VWEGOLF_CLIMA_TEMP_MAX_C 28
-
 // After our own stop command we set hvac false at once but the blower keeps spinning down
 // for a moment (0x03B5 still reports running). Ignore that "running" for this long so the
 // stop stays responsive; if 0x03B5 still insists past the window the stop didn't take, so

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/Makefile
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/Makefile
@@ -1,5 +1,6 @@
 CXX      := g++
 CXXFLAGS := -std=c++17 -Wall -Wextra -g \
+            -DVWEGOLF_NATIVE_TEST \
             -Imock \
             -I. \
             -I../src \
@@ -8,7 +9,8 @@ CXXFLAGS := -std=c++17 -Wall -Wextra -g \
 SRC := mock/mock_ovms.cpp \
        ../src/vehicle_vwegolf.cpp \
        test_can_decode.cpp \
-       test_crtd_replay.cpp
+       test_crtd_replay.cpp \
+       test_clima.cpp
 
 all: test
 

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.cpp
@@ -1,6 +1,7 @@
 #include "mock_ovms.hpp"
 
 MetricStore         g_metrics;
+uint32_t            g_tick_count = 0;
 StandardMetricsType StandardMetrics;
 OvmsConfig          MyConfig;
 OvmsCommandApp      MyCommandApp;

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
@@ -4,11 +4,13 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <functional>
 #include <map>
 #include <string>
+#include <vector>
 
 // ---------------------------------------------------------------------------
 // Logging
@@ -25,6 +27,9 @@
 typedef uint32_t TickType_t;
 inline void vTaskDelay(TickType_t) {}
 inline TickType_t pdMS_TO_TICKS(uint32_t ms) { return ms; }
+extern uint32_t g_tick_count;
+inline TickType_t xTaskGetTickCount() { return g_tick_count; }
+static constexpr uint32_t portTICK_PERIOD_MS = 1;
 
 // ---------------------------------------------------------------------------
 // CAN types
@@ -32,18 +37,56 @@ inline TickType_t pdMS_TO_TICKS(uint32_t ms) { return ms; }
 typedef enum { CAN_frame_std, CAN_frame_ext } CAN_frame_format_t;
 typedef enum { CAN_MODE_LISTEN, CAN_MODE_ACTIVE, CAN_MODE_OFF } CAN_mode_t;
 typedef enum { CAN_SPEED_100KBPS = 100, CAN_SPEED_500KBPS = 500 } CAN_speed_t;
+typedef enum {
+    CAN_errorstate_none = 0,
+    CAN_errorstate_active,
+    CAN_errorstate_warning,
+    CAN_errorstate_passive,
+    CAN_errorstate_busoff,
+} CAN_errorstate_t;
 
 typedef union {
     struct { CAN_frame_format_t FF; uint8_t DLC; } B;
 } CAN_FIR_t;
 
 typedef int esp_err_t;
-static constexpr esp_err_t ESP_OK = 0;
+static constexpr esp_err_t ESP_OK   =  0;
+static constexpr esp_err_t ESP_FAIL = -1;
+
+// One transmitted frame, recorded so the clima tests can assert exactly what the
+// module put on the bus. The real canbus discards frames after TX; the mock keeps
+// an ordered log (std vs ext, ID, DLC, payload).
+struct TxRecord {
+    bool     extended = false;
+    uint32_t id       = 0;
+    uint8_t  len      = 0;
+    uint8_t  data[8]  = {};
+};
 
 struct canbus {
-    uint8_t m_busnumber = 0;
-    esp_err_t WriteStandard(uint32_t /*id*/, uint8_t /*len*/, uint8_t* /*data*/, int /*wait*/ = 0) { return 0; }
-    esp_err_t WriteExtended(uint32_t /*id*/, uint8_t /*len*/, uint8_t* /*data*/, int /*wait*/ = 0) { return 0; }
+    uint8_t               m_busnumber = 0;
+    std::vector<TxRecord> tx_log;
+    CAN_errorstate_t      error_state = CAN_errorstate_none;
+
+    esp_err_t WriteStandard(uint32_t id, uint8_t len, uint8_t* data, int /*wait*/ = 0) {
+        return LogTx(false, id, len, data);
+    }
+    esp_err_t WriteExtended(uint32_t id, uint8_t len, uint8_t* data, int /*wait*/ = 0) {
+        return LogTx(true, id, len, data);
+    }
+    CAN_errorstate_t GetErrorState() { return error_state; }
+    esp_err_t Reset() { return ESP_OK; }
+
+ private:
+    esp_err_t LogTx(bool ext, uint32_t id, uint8_t len, uint8_t* data) {
+        TxRecord r;
+        r.extended = ext;
+        r.id       = id;
+        r.len      = len;
+        for (uint8_t i = 0; i < len && i < 8; i++) r.data[i] = data[i];
+        tx_log.push_back(r);
+        return ESP_OK;
+    }
 };
 
 // 'Minutes' is used as a unit tag in some metric SetValue calls
@@ -69,7 +112,15 @@ struct CAN_frame_t {
 struct MetricStore {
     std::map<std::string, double>      numbers;
     std::map<std::string, std::string> strings;
-    void reset() { numbers.clear(); strings.clear(); }
+    // Per-metric SetValue call count. Used by the replay test to catch
+    // "set once at boot, never updated again" regressions like the stuck
+    // range_est bug — a static-value check passes but the metric isn't live.
+    std::map<std::string, int>         writes;
+    void reset() { numbers.clear(); strings.clear(); writes.clear(); }
+    int  write_count(const std::string& n) const {
+        auto it = writes.find(n);
+        return it == writes.end() ? 0 : it->second;
+    }
 };
 extern MetricStore g_metrics;
 
@@ -77,7 +128,10 @@ template<typename T>
 struct OvmsMetric {
     std::string name;
     explicit OvmsMetric(const char* n) : name(n) {}
-    void SetValue(T v)              { g_metrics.numbers[name] = static_cast<double>(v); }
+    void SetValue(T v)              {
+        g_metrics.numbers[name] = static_cast<double>(v);
+        g_metrics.writes[name]++;
+    }
     void SetValue(T v, int /*unit*/) { SetValue(v); }  // unit arg used by real metrics, ignored here
     void Clear()                    { g_metrics.numbers.erase(name); }
     T    AsValue() const  { return static_cast<T>(g_metrics.numbers[name]); }
@@ -88,8 +142,14 @@ template<>
 struct OvmsMetric<std::string> {
     std::string name;
     explicit OvmsMetric(const char* n) : name(n) {}
-    void        SetValue(const std::string& v) { g_metrics.strings[name] = v; }
-    void        SetValue(const char* v)        { g_metrics.strings[name] = v ? v : ""; }
+    void        SetValue(const std::string& v) {
+        g_metrics.strings[name] = v;
+        g_metrics.writes[name]++;
+    }
+    void        SetValue(const char* v)        {
+        g_metrics.strings[name] = v ? v : "";
+        g_metrics.writes[name]++;
+    }
     std::string AsValue()  const {
         auto it = g_metrics.strings.find(name);
         return it != g_metrics.strings.end() ? it->second : "";
@@ -101,7 +161,10 @@ template<>
 struct OvmsMetric<bool> {
     std::string name;
     explicit OvmsMetric(const char* n) : name(n) {}
-    void SetValue(bool v) { g_metrics.numbers[name] = v ? 1.0 : 0.0; }
+    void SetValue(bool v) {
+        g_metrics.numbers[name] = v ? 1.0 : 0.0;
+        g_metrics.writes[name]++;
+    }
     bool AsValue() const  { return g_metrics.numbers[name] != 0.0; }
     bool AsBool()  const  { return AsValue(); }
 };
@@ -171,11 +234,24 @@ extern StandardMetricsType StandardMetrics;
 // Config
 // ---------------------------------------------------------------------------
 struct OvmsConfig {
+    // Backing store so tests can exercise config-driven paths (e.g. clima cc-temp).
+    // Real OvmsConfig persists per param+instance; here a flat "param/instance" map.
+    std::map<std::string, std::string> store;
+
     void RegisterParam(const char*, const char*, bool=true, bool=true) {}
-    std::string GetParamValue(const char*, const char*, const char* def="") const { return def; }
-    int  GetParamValueInt(const char*, const char*, int def=0) const { return def; }
+    std::string GetParamValue(const char* param, const char* instance,
+                              const char* def="") const {
+        auto it = store.find(std::string(param) + "/" + instance);
+        return it != store.end() ? it->second : def;
+    }
+    int GetParamValueInt(const char* param, const char* instance, int def=0) const {
+        auto it = store.find(std::string(param) + "/" + instance);
+        return it != store.end() ? atoi(it->second.c_str()) : def;
+    }
     bool GetParamValueBool(const char*, const char*, bool def=false) const { return def; }
-    void SetParamValue(const char*, const char*, const char*) {}
+    void SetParamValue(const char* param, const char* instance, const char* value) {
+        store[std::string(param) + "/" + instance] = value;
+    }
 };
 extern OvmsConfig MyConfig;
 
@@ -215,7 +291,17 @@ struct OvmsVehicle {
     canbus* m_can2 = nullptr;
     canbus* m_can3 = nullptr;
 
-    void RegisterCanBus(int /*bus*/, CAN_mode_t, CAN_speed_t) {}
+    // Allocate a real canbus per registered bus so the command/wake/heartbeat paths
+    // (which call m_canN->WriteStandard/WriteExtended/GetErrorState) have a live object
+    // and the clima tests can read its tx_log. Decode-only tests never touch the bus, but
+    // a null m_canN segfaults the moment any TX is attempted.
+    void RegisterCanBus(int bus, CAN_mode_t, CAN_speed_t) {
+        canbus** slot = (bus == 1) ? &m_can1 : (bus == 2) ? &m_can2 : &m_can3;
+        if (!*slot) {
+            *slot = new canbus();
+            (*slot)->m_busnumber = static_cast<uint8_t>(bus);
+        }
+    }
 
     virtual void IncomingFrameCan1(CAN_frame_t*) {}
     virtual void IncomingFrameCan2(CAN_frame_t*) {}
@@ -230,5 +316,5 @@ struct OvmsVehicle {
     virtual vehicle_command_t CommandUnlock(const char*) { return NotImplemented; }
     virtual vehicle_command_t CommandWakeup()                 { return NotImplemented; }
     virtual vehicle_command_t CommandClimateControl(bool)     { return NotImplemented; }
-    virtual ~OvmsVehicle() = default;
+    virtual ~OvmsVehicle() { delete m_can1; delete m_can2; delete m_can3; }
 };

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_can_decode.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_can_decode.cpp
@@ -264,6 +264,7 @@ void test_sentinel_filters() {
 // ---------------------------------------------------------------------------
 
 extern void test_crtd_replay();
+extern void test_clima_all();
 
 int main() {
     printf("=== vehicle_vwegolf CAN decode tests ===\n");
@@ -275,6 +276,7 @@ int main() {
     test_gps_0x486();
     test_sentinel_filters();
     test_crtd_replay();
+    test_clima_all();
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_clima.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_clima.cpp
@@ -1,0 +1,532 @@
+// test_clima.cpp — Tests for climate control, wakeup, heartbeat, and bus idle logic.
+
+#include "mock/mock_ovms.hpp"
+#include "../src/vehicle_vwegolf.h"
+
+#include <cassert>
+#include <cstdio>
+
+extern int tests_run;
+extern int tests_passed;
+
+#define CHECK(cond, msg) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; printf("  PASS: %s\n", msg); } \
+    else       { printf("  FAIL: %s\n", msg); } \
+} while(0)
+
+// Helper: get the KCAN (can3) stub from a vehicle instance.
+static canbus* kcan(OvmsVehicleVWeGolf* v) {
+    return v->m_can3;
+}
+
+// Advance the mock tick counter by ms milliseconds (portTICK_PERIOD_MS=1 in mock).
+static void advance_ms(uint32_t ms) {
+    g_tick_count += ms;
+}
+
+// Ticker1/Ticker10 are protected in OvmsVehicleVWeGolf. Call via base-class pointer
+// (public virtual in the mock OvmsVehicle) to dispatch correctly.
+static void call_ticker1(OvmsVehicleVWeGolf* v, uint32_t tick) {
+    static_cast<OvmsVehicle*>(v)->Ticker1(tick);
+}
+
+// Helper: make a KCAN frame with origin set to m_can3 so the bus-idle logic accepts it.
+static CAN_frame_t make_kcan_frame(OvmsVehicleVWeGolf* v, uint32_t id,
+                                   std::initializer_list<uint8_t> bytes) {
+    CAN_frame_t f{};
+    f.MsgID = id;
+    f.origin = v->m_can3;
+    f.FIR.B.DLC = static_cast<uint8_t>(bytes.size());
+    int i = 0;
+    for (uint8_t b : bytes) f.data.u8[i++] = b;
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// CommandWakeup
+// ---------------------------------------------------------------------------
+
+void test_wakeup_sends_nm_alive() {
+    printf("\ntest_wakeup_sends_nm_alive\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Bus starts idle (m_bus_idle_ticks == VWEGOLF_BUS_TIMEOUT_SECS).
+    auto result = v->CommandWakeup();
+    CHECK(result == Success, "CommandWakeup returns Success");
+
+    auto& log = kcan(v)->tx_log;
+    CHECK(log.size() >= 2, "At least 2 frames sent (wake + NM alive)");
+
+    if (log.size() >= 2) {
+        // Frame 1: 0x17330301 dominant-bit wake frame
+        CHECK(log[0].extended && log[0].id == 0x17330301,
+              "Frame 1 is extended 0x17330301 (wake)");
+
+        // Frame 2: 0x1B000067 NM alive for OVMS node 0x67
+        CHECK(log[1].extended && log[1].id == 0x1B000067,
+              "Frame 2 is extended 0x1B000067 (NM alive)");
+        CHECK(log[1].data[0] == 0x67, "NM alive byte 0 = node ID 0x67");
+    }
+
+    delete v;
+}
+
+void test_wakeup_skips_when_bus_active() {
+    printf("\ntest_wakeup_skips_when_bus_active\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Simulate bus activity by sending a KCAN frame (resets idle counter).
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+
+    kcan(v)->tx_log.clear();
+    auto result = v->CommandWakeup();
+    CHECK(result == Success, "Returns Success when bus already active");
+    CHECK(kcan(v)->tx_log.empty(), "No frames sent when bus already active");
+
+    delete v;
+}
+
+// ---------------------------------------------------------------------------
+// CommandClimateControl — BAP frame construction
+// ---------------------------------------------------------------------------
+
+void test_clima_start_bap_frames() {
+    printf("\ntest_clima_start_bap_frames\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Simulate bus active so clima doesn't trigger wakeup.
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+    kcan(v)->tx_log.clear();
+
+    auto result = v->CommandClimateControl(true);
+    CHECK(result == Success, "CommandClimateControl(true) returns Success");
+
+    auto& log = kcan(v)->tx_log;
+    // Should have at least 3 extended frames (the BAP sequence).
+    // May also have heartbeat frames from IncomingFrameCan3, so check the extended ones.
+    size_t ext_count = 0;
+    for (auto& r : log) if (r.extended) ext_count++;
+    CHECK(ext_count == 3, "3 extended BAP frames sent");
+
+    // Find the 3 extended frames.
+    std::vector<TxRecord> bap;
+    for (auto& r : log) if (r.extended) bap.push_back(r);
+
+    if (bap.size() >= 3) {
+        // Frame 1: multi-frame start to port 0x19
+        CHECK(bap[0].id == 0x17332501, "BAP frame 1 ID = 0x17332501");
+        CHECK(bap[0].len == 8, "BAP frame 1 DLC = 8");
+        CHECK(bap[0].data[0] == 0x80, "BAP frame 1 byte 0 = 0x80 (multi-frame start)");
+        CHECK(bap[0].data[1] == 0x08, "BAP frame 1 byte 1 = 0x08 (payload length)");
+        CHECK(bap[0].data[2] == 0x29, "BAP frame 1 byte 2 = 0x29 (opcode=2, node=0x25 hi)");
+        CHECK(bap[0].data[3] == 0x59, "BAP frame 1 byte 3 = 0x59 (node=0x25 lo, port=0x19)");
+        CHECK(bap[0].data[4] == 0x01, "BAP frame 1 byte 4 = counter (first call = 0x01)");
+
+        // Frame 2: continuation with temperature
+        CHECK(bap[1].id == 0x17332501, "BAP frame 2 ID = 0x17332501");
+        CHECK(bap[1].data[0] == 0xC0, "BAP frame 2 byte 0 = 0xC0 (continuation)");
+        // Default temp = 21°C → (21-10)*10 = 110 = 0x6E
+        CHECK(bap[1].data[3] == 0x6E, "BAP frame 2 temp byte = 0x6E (21°C)");
+
+        // Frame 3: single-frame trigger to port 0x18, start=0x01
+        CHECK(bap[2].id == 0x17332501, "BAP frame 3 ID = 0x17332501");
+        CHECK(bap[2].len == 4, "BAP frame 3 DLC = 4");
+        CHECK(bap[2].data[0] == 0x29, "BAP frame 3 byte 0 = 0x29");
+        CHECK(bap[2].data[1] == 0x58, "BAP frame 3 byte 1 = 0x58 (port 0x18)");
+        CHECK(bap[2].data[3] == 0x01, "BAP frame 3 byte 3 = 0x01 (start)");
+    }
+
+    // Optimistic metric update
+    CHECK(StandardMetrics.ms_v_env_hvac->AsBool(), "HVAC metric set to true after start");
+
+    delete v;
+}
+
+void test_clima_stop_bap_trigger() {
+    printf("\ntest_clima_stop_bap_trigger\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+    kcan(v)->tx_log.clear();
+
+    v->CommandClimateControl(false);
+
+    // Find the trigger frame (frame 3)
+    std::vector<TxRecord> bap;
+    for (auto& r : kcan(v)->tx_log) if (r.extended) bap.push_back(r);
+
+    CHECK(bap.size() >= 3, "3 BAP frames sent for stop");
+    if (bap.size() >= 3) {
+        CHECK(bap[2].data[3] == 0x00, "BAP frame 3 byte 3 = 0x00 (stop)");
+    }
+
+    CHECK(!StandardMetrics.ms_v_env_hvac->AsBool(), "HVAC metric set to false after stop");
+
+    delete v;
+}
+
+void test_clima_busoff_aborts() {
+    printf("\ntest_clima_busoff_aborts\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Simulate bus active
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+
+    kcan(v)->error_state = CAN_errorstate_busoff;
+    auto result = v->CommandClimateControl(true);
+    CHECK(result == Fail, "Returns Fail when KCAN is in bus-off");
+
+    delete v;
+}
+
+void test_clima_wakes_sleeping_bus() {
+    printf("\ntest_clima_wakes_sleeping_bus\n");
+    g_metrics = MetricStore{};
+    g_tick_count = 0;
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Bus starts idle. CommandClimateControl should kick WakeKcanBus and defer BAP.
+    auto result = v->CommandClimateControl(true);
+    CHECK(result == Success, "Clima start succeeds from idle bus");
+
+    auto& log = kcan(v)->tx_log;
+    bool has_wake = false;
+    bool has_nm = false;
+    bool has_bap_immediate = false;
+    for (auto& r : log) {
+        if (r.extended && r.id == 0x17330301) has_wake = true;
+        if (r.extended && r.id == 0x1B000067) has_nm = true;
+        if (r.extended && r.id == 0x17332501) has_bap_immediate = true;
+    }
+    CHECK(has_wake, "Wake frame 0x17330301 sent");
+    CHECK(has_nm, "NM alive 0x1B000067 sent");
+    CHECK(!has_bap_immediate, "BAP not sent immediately — deferred to Ticker1");
+
+    delete v;
+}
+
+void test_clima_deferred_burst_fires() {
+    printf("\ntest_clima_deferred_burst_fires\n");
+    g_metrics = MetricStore{};
+    g_tick_count = 0;
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Idle bus → CommandClimateControl defers burst, returns Success immediately.
+    auto result = v->CommandClimateControl(true);
+    CHECK(result == Success, "Returns Success with deferred burst");
+
+    // Simulate KCAN activity after wake (ECUs responding to NM wake).
+    // This resets m_bus_idle_ticks so Ticker1 sees bus_alive=true.
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+
+    // Settle time not yet elapsed — no BAP.
+    kcan(v)->tx_log.clear();
+    call_ticker1(v, 1);
+    bool has_bap_early = false;
+    for (auto& r : kcan(v)->tx_log) {
+        if (r.extended && r.id == 0x17332501) has_bap_early = true;
+    }
+    CHECK(!has_bap_early, "BAP not sent before settle window");
+
+    // Advance tick past VWEGOLF_CLIMA_SETTLE_MS (1000 ms).
+    advance_ms(VWEGOLF_CLIMA_SETTLE_MS);
+    kcan(v)->tx_log.clear();
+    call_ticker1(v, 2);
+
+    size_t bap_count = 0;
+    for (auto& r : kcan(v)->tx_log) {
+        if (r.extended && r.id == 0x17332501) bap_count++;
+    }
+    CHECK(bap_count == 3, "3 BAP frames fired after settle");
+
+    CHECK(StandardMetrics.ms_v_env_hvac->AsBool(), "HVAC metric true after deferred start");
+
+    delete v;
+}
+
+void test_clima_counter_increments() {
+    printf("\ntest_clima_counter_increments\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Make bus active
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+
+    // First call: counter should be 0x01
+    kcan(v)->tx_log.clear();
+    v->CommandClimateControl(true);
+    std::vector<TxRecord> bap1;
+    for (auto& r : kcan(v)->tx_log) if (r.extended) bap1.push_back(r);
+    uint8_t ctr1 = bap1.size() > 0 ? bap1[0].data[4] : 0;
+
+    // Second call: counter should be 0x02
+    kcan(v)->tx_log.clear();
+    v->CommandClimateControl(false);
+    std::vector<TxRecord> bap2;
+    for (auto& r : kcan(v)->tx_log) if (r.extended) bap2.push_back(r);
+    uint8_t ctr2 = bap2.size() > 0 ? bap2[0].data[4] : 0;
+
+    CHECK(ctr1 == 0x01, "First call counter = 0x01");
+    CHECK(ctr2 == 0x02, "Second call counter = 0x02");
+
+    delete v;
+}
+
+// Helper: run a synchronous clima start with cc-temp set to raw_cfg, return the
+// temperature byte (BAP frame 2, data[3]). Bus is made active first so the burst
+// runs inline rather than deferring to Ticker1.
+static uint8_t clima_temp_byte_for(int raw_cfg) {
+    g_metrics = MetricStore{};
+    MyConfig.store.clear();
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d", raw_cfg);
+    MyConfig.SetParamValue("xvg", "cc-temp", buf);
+
+    auto* v = new OvmsVehicleVWeGolf();
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+    kcan(v)->tx_log.clear();
+
+    v->CommandClimateControl(true);
+
+    uint8_t temp_byte = 0;
+    int ext = 0;
+    for (auto& r : kcan(v)->tx_log) {
+        if (r.extended && ++ext == 2) { temp_byte = r.data[3]; break; }
+    }
+    delete v;
+    return temp_byte;
+}
+
+// Regression for the cc-temp clamp (vehicle_vwegolf.cpp SendClimaBapBurst). cc-temp can be
+// set from the CLI, bypassing the web form's 16–28 validation; the burst must clamp before
+// the uint8_t byte calc or it sends a garbage temperature to the climate ECU.
+// Encoding: temp_byte = (clamped_celsius - 10) * 10.
+void test_clima_temp_clamped() {
+    printf("\ntest_clima_temp_clamped\n");
+
+    // In-range value passes through untouched (proves it clamps, not pins).
+    // 22°C → (22-10)*10 = 120 = 0x78.
+    CHECK(clima_temp_byte_for(22) == 0x78, "in-range 22C → 0x78 (passthrough)");
+
+    // Over-range high clamps to MAX (28°C) → (28-10)*10 = 180 = 0xB4,
+    // NOT the truncated garbage of (50-10)*10 = 400 → 0x90.
+    CHECK(clima_temp_byte_for(50) == 0xB4, "over-range 50C clamps to 28C → 0xB4");
+
+    // Below-range clamps to MIN (16°C) → (16-10)*10 = 60 = 0x3C,
+    // NOT (5-10)*10 = -50 → 0xCE as a wrapped uint8_t.
+    CHECK(clima_temp_byte_for(5) == 0x3C, "below-range 5C clamps to 16C → 0x3C");
+
+    // Boundaries map exactly to MIN/MAX bytes.
+    CHECK(clima_temp_byte_for(VWEGOLF_CLIMA_TEMP_MIN_C) == 0x3C, "min boundary 16C → 0x3C");
+    CHECK(clima_temp_byte_for(VWEGOLF_CLIMA_TEMP_MAX_C) == 0xB4, "max boundary 28C → 0xB4");
+
+    MyConfig.store.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Ticker1 bus idle logic
+// ---------------------------------------------------------------------------
+
+void test_ticker1_bus_idle_timeout() {
+    printf("\ntest_ticker1_bus_idle_timeout\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Make bus active and start OCU
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+    v->CommandWakeup();  // wakeup is a no-op since bus is active, but sets m_ocu_active... actually no
+    // After receiving a frame, bus is active. We need to explicitly start ocu.
+    // Use CommandClimateControl which sets m_ocu_active = true.
+    v->CommandClimateControl(true);
+
+    kcan(v)->tx_log.clear();
+
+    // Tick 10 times with no incoming frames → bus goes idle
+    for (int i = 0; i < 10; i++) {
+        call_ticker1(v, i);
+    }
+
+    // After 10 ticks of silence, OCU should be deactivated.
+    // Tick 11 should NOT produce heartbeats.
+    kcan(v)->tx_log.clear();
+    call_ticker1(v, 10);
+
+    bool has_heartbeat = false;
+    for (auto& r : kcan(v)->tx_log) {
+        if (!r.extended && r.id == 0x5A7) has_heartbeat = true;
+    }
+    CHECK(!has_heartbeat, "No heartbeat after bus idle timeout");
+
+    delete v;
+}
+
+// ---------------------------------------------------------------------------
+// Twilight wake: bus quiet 3+ s, OEM OCU gone — should still wake
+// ---------------------------------------------------------------------------
+
+void test_clima_wakes_in_twilight() {
+    printf("\ntest_clima_wakes_in_twilight\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Simulate bus activity (resets idle to 0, OEM OCU idle stays at default=timeout).
+    auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&f);
+
+    // Tick the bus idle counter to CLIMA_WAKE_SECS (3) — past the clima threshold but
+    // below BUS_TIMEOUT (10). This is the "twilight" zone from the failing capture.
+    for (int i = 0; i < VWEGOLF_CLIMA_WAKE_SECS; i++) {
+        call_ticker1(v, i);
+    }
+
+    kcan(v)->tx_log.clear();
+    auto result = v->CommandClimateControl(true);
+    CHECK(result == Success, "Clima succeeds in twilight");
+
+    bool has_wake = false;
+    bool has_nm = false;
+    for (auto& r : kcan(v)->tx_log) {
+        if (r.extended && r.id == 0x17330301) has_wake = true;
+        if (r.extended && r.id == 0x1B000067) has_nm = true;
+    }
+    CHECK(has_wake, "Wake frame sent in twilight (idle=3, below BUS_TIMEOUT=10)");
+    CHECK(has_nm, "NM alive sent in twilight");
+
+    delete v;
+}
+
+void test_clima_no_wake_when_oem_ocu_active() {
+    printf("\ntest_clima_no_wake_when_oem_ocu_active\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Non-zero OEM 0x5A7 is the last KCAN frame before the bus goes quiet.
+    // This resets both bus_idle and oem_ocu_idle to 0.
+    auto ocu = make_kcan_frame(v, 0x5A7, {0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00});
+    v->IncomingFrameCan3(&ocu);
+
+    // Tick twice → bus_idle = 2, oem_ocu_idle = 2. Both below CLIMA_WAKE_SECS (3).
+    // The OEM OCU was active just 2 seconds ago — not safe to wake yet.
+    call_ticker1(v, 0);
+    call_ticker1(v, 1);
+
+    kcan(v)->tx_log.clear();
+    v->CommandClimateControl(true);
+
+    bool has_wake = false;
+    for (auto& r : kcan(v)->tx_log) {
+        if (r.extended && r.id == 0x17330301) has_wake = true;
+    }
+    CHECK(!has_wake, "No wake when bus quiet only 2 s after OEM OCU 0x5A7");
+
+    // Now tick one more → bus_idle = 3, oem_ocu_idle = 3. Both meet threshold.
+    call_ticker1(v, 2);
+    kcan(v)->tx_log.clear();
+    v->CommandClimateControl(true);
+
+    has_wake = false;
+    for (auto& r : kcan(v)->tx_log) {
+        if (r.extended && r.id == 0x17330301) has_wake = true;
+    }
+    CHECK(has_wake, "Wake fires once 3 s have passed since OEM OCU 0x5A7");
+
+    delete v;
+}
+
+// NOTE: the 0x17332510 BAP-ACK *decode* (single-frame, port 0x18) is covered by
+// test_bap_ack_0x17332510 in test_can_decode.cpp. Earlier port-0x12 / multi-frame tests
+// here were removed when the decode was re-validated on-car to port 0x18 (commit 3180b08ef);
+// they asserted a superseded understanding the shipping code no longer implements.
+
+// ---------------------------------------------------------------------------
+// ms_v_env_hvac run-state: 0x03B5 ClimaRunning + hold + stop-suppression
+// ---------------------------------------------------------------------------
+
+void test_hvac_hold_bridges_thermostat_cycle() {
+    printf("\ntest_hvac_hold_bridges_thermostat_cycle\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    auto running = make_kcan_frame(v, 0x3B5, {0x80, 0xFE, 0x00, 0x00});
+    v->IncomingFrameCan3(&running);
+    CHECK(StandardMetrics.ms_v_env_hvac->AsBool(), "hvac true after ClimaRunning=1");
+
+    // Blower pauses (thermostat). Tick within the hold window — must stay true (no flicker).
+    for (int i = 0; i < VWEGOLF_HVAC_RUN_HOLD_SECS - 1; i++) call_ticker1(v, i);
+    CHECK(StandardMetrics.ms_v_env_hvac->AsBool(), "hvac held true within hold window");
+
+    // Blower resumes before the window elapsed — refreshes the hold.
+    v->IncomingFrameCan3(&running);
+    for (int i = 0; i < VWEGOLF_HVAC_RUN_HOLD_SECS - 1; i++) call_ticker1(v, 100 + i);
+    CHECK(StandardMetrics.ms_v_env_hvac->AsBool(), "hold refreshed by new running evidence");
+
+    // No further evidence — clears once the hold elapses (autonomous/timer stop).
+    for (int i = 0; i < 3; i++) call_ticker1(v, 300 + i);
+    CHECK(!StandardMetrics.ms_v_env_hvac->AsBool(), "hvac clears after hold window with no evidence");
+
+    delete v;
+}
+
+void test_hvac_stop_command_responsive() {
+    printf("\ntest_hvac_stop_command_responsive\n");
+    g_metrics = MetricStore{};
+    auto* v = new OvmsVehicleVWeGolf();
+
+    // Bus active so the stop runs synchronously; clima reported running.
+    auto active = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
+    v->IncomingFrameCan3(&active);
+    auto running = make_kcan_frame(v, 0x3B5, {0x80, 0xFE, 0x00, 0x00});
+    v->IncomingFrameCan3(&running);
+    CHECK(StandardMetrics.ms_v_env_hvac->AsBool(), "hvac true while running");
+
+    // Stop command → false immediately (no 20s linger).
+    v->CommandClimateControl(false);
+    CHECK(!StandardMetrics.ms_v_env_hvac->AsBool(), "stop command clears hvac immediately");
+
+    // Blower spin-down still reports running, but within the suppress window → ignored.
+    v->IncomingFrameCan3(&running);
+    CHECK(!StandardMetrics.ms_v_env_hvac->AsBool(), "spin-down ClimaRunning ignored after stop");
+
+    // Past the suppress window, persistent running means the stop didn't take → trust it.
+    for (int i = 0; i < VWEGOLF_HVAC_STOP_SUPPRESS_SECS + 1; i++) call_ticker1(v, i);
+    v->IncomingFrameCan3(&running);
+    CHECK(StandardMetrics.ms_v_env_hvac->AsBool(), "ClimaRunning trusted again past suppress window");
+
+    delete v;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point (called from test_can_decode.cpp main)
+// ---------------------------------------------------------------------------
+
+void test_clima_all() {
+    printf("\n=== climate control tests ===\n");
+    test_wakeup_sends_nm_alive();
+    test_wakeup_skips_when_bus_active();
+    test_clima_start_bap_frames();
+    test_clima_stop_bap_trigger();
+    test_clima_busoff_aborts();
+    test_clima_wakes_sleeping_bus();
+    test_clima_deferred_burst_fires();
+    test_clima_wakes_in_twilight();
+    test_clima_no_wake_when_oem_ocu_active();
+    test_clima_counter_increments();
+    test_clima_temp_clamped();
+    test_ticker1_bus_idle_timeout();
+    test_hvac_hold_bridges_thermostat_cycle();
+    test_hvac_stop_command_responsive();
+}

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_clima.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_clima.cpp
@@ -128,11 +128,10 @@ void test_clima_start_bap_frames() {
         CHECK(bap[0].data[3] == 0x59, "BAP frame 1 byte 3 = 0x59 (node=0x25 lo, port=0x19)");
         CHECK(bap[0].data[4] == 0x01, "BAP frame 1 byte 4 = counter (first call = 0x01)");
 
-        // Frame 2: continuation with temperature
+        // Frame 2: continuation with the compact profile record
         CHECK(bap[1].id == 0x17332501, "BAP frame 2 ID = 0x17332501");
         CHECK(bap[1].data[0] == 0xC0, "BAP frame 2 byte 0 = 0xC0 (continuation)");
-        // Default temp = 21°C → (21-10)*10 = 110 = 0x6E
-        CHECK(bap[1].data[3] == 0x6E, "BAP frame 2 temp byte = 0x6E (21°C)");
+        CHECK(bap[1].data[3] == 0x20, "BAP frame 2 maxCurrent byte = 0x20 (32 A)");
 
         // Frame 3: single-frame trigger to port 0x18, start=0x01
         CHECK(bap[2].id == 0x17332501, "BAP frame 3 ID = 0x17332501");
@@ -284,15 +283,17 @@ void test_clima_counter_increments() {
     delete v;
 }
 
-// Helper: run a synchronous clima start with cc-temp set to raw_cfg, return the
-// temperature byte (BAP frame 2, data[3]). Bus is made active first so the burst
-// runs inline rather than deferring to Ticker1.
-static uint8_t clima_temp_byte_for(int raw_cfg) {
+// Regression pinning the exact BAP burst bytes (vehicle_vwegolf.cpp SendClimaBapBurst).
+// Frames 1+2 are a SetGet on ProfilesArray (0x19), RecordAddr-6 compact update of
+// profile 0: operation=0x06 (climate | climateWithoutExternalSupply), operation2=0x00,
+// maxCurrent=0x20 (32 A), targetChargeLevel=0x00. Field semantics per smartkar-cano-new
+// BAP_BATTERY_CONTROL.md / MIB2 firmware RE (PR #1430 review) — an earlier revision
+// wrongly encoded a temperature into the maxCurrent byte.
+void test_clima_burst_bytes() {
+    printf("\ntest_clima_burst_bytes\n");
+
     g_metrics = MetricStore{};
     MyConfig.store.clear();
-    char buf[16];
-    snprintf(buf, sizeof(buf), "%d", raw_cfg);
-    MyConfig.SetParamValue("xvg", "cc-temp", buf);
 
     auto* v = new OvmsVehicleVWeGolf();
     auto f = make_kcan_frame(v, 0x131, {0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00});
@@ -301,38 +302,27 @@ static uint8_t clima_temp_byte_for(int raw_cfg) {
 
     v->CommandClimateControl(true);
 
-    uint8_t temp_byte = 0;
-    int ext = 0;
+    std::vector<std::vector<uint8_t>> ext;
     for (auto& r : kcan(v)->tx_log) {
-        if (r.extended && ++ext == 2) { temp_byte = r.data[3]; break; }
+        if (r.extended) ext.push_back(std::vector<uint8_t>(r.data, r.data + r.len));
+    }
+    CHECK(ext.size() == 3, "burst is 3 extended frames");
+    if (ext.size() == 3) {
+        // Frame 1: long start, SetGet LSG 0x25 func 0x19, array header
+        // [tid] [RecordAddr=6] [startIndex=0] [elementCount=1].
+        CHECK(ext[0].size() == 8, "frame 1 DLC 8");
+        CHECK(ext[0][0] == 0x80 && ext[0][1] == 0x08, "frame 1 long-start, len 8");
+        CHECK(ext[0][2] == 0x29 && ext[0][3] == 0x59, "frame 1 header SetGet 0x25/0x19");
+        CHECK(ext[0][5] == 0x06 && ext[0][6] == 0x00 && ext[0][7] == 0x01,
+              "frame 1 array header RecordAddr=6, start=0, count=1");
+        // Frame 2: compact record — no temperature field in this message.
+        std::vector<uint8_t> want2 = {0xC0, 0x06, 0x00, 0x20, 0x00};
+        CHECK(ext[1] == want2, "frame 2 compact record: op=0x06, maxCurrent=32A, target=0");
+        // Frame 3: trigger, profile 0 immediate start.
+        std::vector<uint8_t> want3 = {0x29, 0x58, 0x00, 0x01};
+        CHECK(ext[2] == want3, "frame 3 trigger start immediate");
     }
     delete v;
-    return temp_byte;
-}
-
-// Regression for the cc-temp clamp (vehicle_vwegolf.cpp SendClimaBapBurst). cc-temp can be
-// set from the CLI, bypassing the web form's 16–28 validation; the burst must clamp before
-// the uint8_t byte calc or it sends a garbage temperature to the climate ECU.
-// Encoding: temp_byte = (clamped_celsius - 10) * 10.
-void test_clima_temp_clamped() {
-    printf("\ntest_clima_temp_clamped\n");
-
-    // In-range value passes through untouched (proves it clamps, not pins).
-    // 22°C → (22-10)*10 = 120 = 0x78.
-    CHECK(clima_temp_byte_for(22) == 0x78, "in-range 22C → 0x78 (passthrough)");
-
-    // Over-range high clamps to MAX (28°C) → (28-10)*10 = 180 = 0xB4,
-    // NOT the truncated garbage of (50-10)*10 = 400 → 0x90.
-    CHECK(clima_temp_byte_for(50) == 0xB4, "over-range 50C clamps to 28C → 0xB4");
-
-    // Below-range clamps to MIN (16°C) → (16-10)*10 = 60 = 0x3C,
-    // NOT (5-10)*10 = -50 → 0xCE as a wrapped uint8_t.
-    CHECK(clima_temp_byte_for(5) == 0x3C, "below-range 5C clamps to 16C → 0x3C");
-
-    // Boundaries map exactly to MIN/MAX bytes.
-    CHECK(clima_temp_byte_for(VWEGOLF_CLIMA_TEMP_MIN_C) == 0x3C, "min boundary 16C → 0x3C");
-    CHECK(clima_temp_byte_for(VWEGOLF_CLIMA_TEMP_MAX_C) == 0xB4, "max boundary 28C → 0xB4");
-
     MyConfig.store.clear();
 }
 
@@ -525,7 +515,7 @@ void test_clima_all() {
     test_clima_wakes_in_twilight();
     test_clima_no_wake_when_oem_ocu_active();
     test_clima_counter_increments();
-    test_clima_temp_clamped();
+    test_clima_burst_bytes();
     test_ticker1_bus_idle_timeout();
     test_hvac_hold_bridges_thermostat_cycle();
     test_hvac_stop_command_responsive();

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_crtd_replay.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_crtd_replay.cpp
@@ -1,9 +1,10 @@
 // test_crtd_replay.cpp — Feed a real CRTD capture through the decode pipeline.
 //
-// Reads candumps/kcan-capture.crtd (relative to the tests/ directory), builds
-// CAN_frame_t objects from each data line, and dispatches them to the vehicle
-// module exactly as the OVMS runtime would.  After the replay we check that
-// the metrics contain plausible values derived from the real capture.
+// Replays the committed synthetic KCAN fixture (candumps/kcan-synthetic.crtd,
+// relative to the tests/ directory) by default, building CAN_frame_t objects from
+// each data line and dispatching them to the vehicle module exactly as the OVMS
+// runtime would.  After the replay we check that the metrics hold the expected
+// values. Set VWEGOLF_CRTD=<path> to replay a real capture during local dev.
 
 #include "mock/mock_ovms.hpp"
 #include "../src/vehicle_vwegolf.h"
@@ -116,10 +117,13 @@ void test_crtd_replay() {
     g_metrics = MetricStore{};
     auto* v = new OvmsVehicleVWeGolf();
 
-    // Prefer the real capture (not committed, developer only); fall back to the
-    // committed synthetic fixture so the test runs in CI without real car data.
+    // Deterministic by default: the push-gate hook and CI replay the committed
+    // synthetic fixture, never a developer-local capture. Set VWEGOLF_CRTD=<path>
+    // to replay a real capture during local development (falls back to the
+    // synthetic fixture if the path can't be read).
+    const char* env_path = getenv("VWEGOLF_CRTD");
     const char* candidates[] = {
-        "candumps/kcan-capture.crtd",
+        env_path ? env_path : "candumps/kcan-synthetic.crtd",
         "candumps/kcan-synthetic.crtd",
     };
     const char* used_path = nullptr;


### PR DESCRIPTION
This adds remote cabin pre-conditioning for the VW e-Golf, on top of the decode baseline merged in #1369/#1376.

The car's clima ECU is commanded over BAP on the comfort CAN (KCAN). To talk on that bus at all, the module has to join the OSEK-NM network ring first — so this also brings the OCU wake infrastructure:

- CommandWakeup + OCU keepalive (0x5A7) and NM-alive (0x1B000067). Joins the ring at ~5 Hz, bounded by ACK-grace and a hard session cap so we never talk alone on a sleeping ring (that storms the TEC to bus-off). Stands down when the bus goes idle or the OEM OCU is active — it owns 0x5A7.
- CommandClimateControl: 3-frame BAP burst (start params, temperature, start/stop trigger) to clima node 0x25. Wakes a sleeping bus first and defers the burst to Ticker1 after a settle window, so the command dispatch task isn't blocked. Re-targets instead of racing if a new command arrives while a burst is pending.
- hvac metric driven by ClimaRunning evidence with a hold window, and a suppress window after stop so spin-down frames don't flip it back on.

Also in here:

- fix: CAN2 frames were being forwarded into IncomingFrameCan3. That was based on a mislabeled capture and would falsely hold the KCAN ring alive off FCAN traffic. Removed — each bus decodes its own frames.
- test: CRTD replay now defaults to the committed synthetic fixture instead of a gitignored local capture, so the test gate is deterministic. VWEGOLF_CRTD=<path> still replays a real capture.

Tested on my own car (2018 e-Golf): multiple start/stop cycles over the app, BAP ACKs confirmed both ways, including cold start from a fully sleeping bus (KCAN quiet >250 s — module wakes the ring, clima starts). Native test suite covers the state machine, 86/86.

Like the earlier e-Golf PRs this is heavily vibecoded — built with Claude against compiler feedback, the native test suite, and CAN captures from the car. I review and validate everything on the car before it goes in a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)