### PR TITLE
smartEQ: Handle USM 14V voltage scaling differences

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -808,9 +808,11 @@ void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_Power(const char* data, uint16_t rep
 void OvmsVehicleSmartEQ::PollReply_EVC_USM14VVoltage(const char* data, uint16_t reply_len) {
   // POSITIVE RESPONSE FORMAT: 62 33 01 <Byte>
   REQUIRE_LEN(1);
-  uint8_t raw = CAN_BYTE(0);
-  float value = 6.0f + raw * 0.06f;
-  mt_evc_dcdc->SetElemValue(3, value);  // usm_volt
+  uint8_t raw = CAN_BYTE(0);  
+  float value_2020 = (raw * 0.06f) + 6.0f;  // offset 6.0, step 0.06 Model >= 2020
+  float value_2019 = raw * 0.0625f;         // step 0.0625 (1/16) Model <= 2019
+  float value = value_2020 > 15.5f ? value_2019 : value_2020; // sanity check using year offset
+  mt_evc_dcdc->SetElemValue(3, value);      // usm_volt
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_14VBatteryVoltage(const char* data, uint16_t reply_len) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -75,9 +75,7 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   // if 12V charging state has changed, then update metric to prevent desync
   if (Is12VchargeEQ() != StdMetrics.ms_v_env_charging12v->AsBool(false))
     {
-    StdMetrics.ms_v_env_charging12v->SetValue(Is12VchargeEQ());
-    if (!Is12VchargeEQ())
-    StdMetrics.ms_v_charge_12v_voltage->SetValue(0.0f); // reset 12V voltage when not charging to prevent desync
+    StdMetrics.ms_v_env_charging12v->SetValue(Is12VchargeEQ());    
     } 
   // reactivate door lock warning if the car is parked and unlocked
   if( m_enable_lock_state && 
@@ -116,6 +114,8 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
     DoorOpenState();
   if(IsOnEQ())
     setTPMSValue();   // update TPMS metrics
+  if(!Is12VchargeEQ() && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) > 0.1f)
+    StdMetrics.ms_v_charge_12v_voltage->SetValue(0.0f); // reset 12V voltage when not charging to prevent desync
 
   #if defined(CONFIG_OVMS_COMP_WIFI) || defined(CONFIG_OVMS_COMP_CELLULAR)
     if(m_reboot_time > 0) 


### PR DESCRIPTION
Support differing USM 14V voltage encodings across model years by computing both interpretations: 2020+ (6.0 + raw*0.06) and <=2019 (raw*0.0625). Use the pre-2020 formula when the 2020 result is implausibly high (>15.5V) to avoid incorrect voltage readings. Also apply a minor indentation/style fix in eq_ticker.cpp for the 12V voltage reset line.