### PR TITLE
smartEQ: Add 1h contactor changes count and alert

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -8,10 +8,10 @@ Open Vehicle Monitor System v3 - Change log
     New metric:
       xsq.12v.trickle.count                  -- Count of 12V trickle-charge cycles in 24h
     updated metric:
-      xsq.bms.contactor.cycles (vector int)  -- [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
+      xsq.bms.contactor.cycles (vector int)  -- [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_counted_changes
     New config:
       [xsq] bms.alert.above.cycles (int)     -- alert threshold for cycles counted; default 50000
-      [xsq] bms.contactor.1h.limit (int)     -- limit for contactor cycles per hour (for alerting); default 10
+      [xsq] bms.contactor.1h.limit (int)     -- limit for contactor cycles changes per hour for alerting; default 8
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -6,7 +6,12 @@ Open Vehicle Monitor System v3 - Change log
     The counted value is set in `xsq.12v.trickle.count`.
     Within `Ticker3600`, a routine removes all timestamps older than 24 hours and updates `xsq.12v.trickle.count` by -1.
     New metric:
-      xsq.12v.trickle.count             -- Count of 12V trickle-charge cycles in 24h
+      xsq.12v.trickle.count                  -- Count of 12V trickle-charge cycles in 24h
+    updated metric:
+      xsq.bms.contactor.cycles (vector int)  -- [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
+    New config:
+      [xsq] bms.alert.above.cycles (int)     -- alert threshold for cycles counted; default 50000
+      [xsq] bms.contactor.1h.limit (int)     -- limit for contactor cycles per hour (for alerting); default 10
 
 2026-05-17 MB   3.3.006  OTA release
 - VW e-Up: extended battery health / aging info (with web UI integration): total battery age,

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -212,7 +212,7 @@ xsq.obl.leakdiag                       OBL leakage diagnostic status
 xsq.bms.prod.data                      BMS production data formatted (serial, MM/YYYY)
 xsq.bms.temps                          BMS temperature sensors vector [°C]
 xsq.bms.voltages                       BMS voltage values vector: [0]=cell_min(V), [1]=cell_max(V), [2]=cell_mean(V), [3]=link_volt(V), [4]=pack_volt(V), [5]=ocv_volt(V), [6]=12v_system(V)
-xsq.bms.contactor.cycles               HV contactor cycles vector: [0]=max, [1]=remaining, [2]=counted
+xsq.bms.contactor.cycles               HV contactor cycles vector: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
 xsq.bms.soc.values                     SOC values vector [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display [%]
 xsq.bms.soc.recal.state                SOC recalibration state
 xsq.bms.soh                            State of Health [%]

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -165,7 +165,6 @@ Vehicle metrics:
 =========================== ==============
 Metric                      description
 =========================== ==============
-xsq.v.bus.awake                        CAN bus awake status [bool]
 xsq.v.bat.serial                       Battery serial number (hex string)
 xsq.v.energy.used                      Energy used since mission start [kWh]
 xsq.v.energy.recd                      Energy recovered since mission start [kWh]
@@ -180,8 +179,8 @@ xsq.v.reset.energy                     Trip energy consumption (reset) [kWh]
 xsq.v.reset.speed                      Average trip speed (reset) [km/h]
 xsq.v.start.time                       Time since start [hh:mm]
 xsq.v.start.distance                   Trip distance since start [km]
-xsq.adc.factor                         Current ADC factor for 12V calculation
-xsq.adc.factor.history                 Last calculated ADC factors (ring buffer)
+xsq.adc.factor                         Current ADC factor for 12V calculation [float] - persistent
+xsq.adc.factor.history                 Last calculated ADC factors (ring buffer) - persistent
 xsq.poll.state                         Current poll state (OFF/ON/RUNNING/CHARGING)
 xsq.ed4.values                         ED4scan: number of cells to show
 xsq.ddt4all.canbyte                    DDT4all CAN response bytes [hex string]
@@ -212,7 +211,7 @@ xsq.obl.leakdiag                       OBL leakage diagnostic status
 xsq.bms.prod.data                      BMS production data formatted (serial, MM/YYYY)
 xsq.bms.temps                          BMS temperature sensors vector [°C]
 xsq.bms.voltages                       BMS voltage values vector: [0]=cell_min(V), [1]=cell_max(V), [2]=cell_mean(V), [3]=link_volt(V), [4]=pack_volt(V), [5]=ocv_volt(V), [6]=12v_system(V)
-xsq.bms.contactor.cycles               HV contactor cycles vector: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
+xsq.bms.contactor.cycles               HV contactor cycles vector: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count - persistent
 xsq.bms.soc.values                     SOC values vector [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display [%]
 xsq.bms.soc.recal.state                SOC recalibration state
 xsq.bms.soh                            State of Health [%]
@@ -228,7 +227,7 @@ xsq.bms.interlock.hvplug               HV plug interlock status [bool]
 xsq.bms.interlock.service              Service interlock status [bool]
 xsq.bms.fusi                           FUSI mode text
 xsq.bms.safety                         Safety mode text
-xsq.12v.trickle.count                  12V trickle charge counted in 24h, reset to 0 after 24h. Alert if count == 3 in 24h [count]
+xsq.12v.trickle.count                  12V trickle charge counted in 24h, reset to 0 after 24h. Alert if count == 3 in 24h [count] - persistent
 =========================== ==============
 
 -------------------------

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -350,8 +350,15 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
   mt_bms_contactor_cycles->SetElemValue(2, cycles_consumed);
   mt_bms_contactor_cycles->SetElemValue(3, cycles_diff);
   if (cycles_now != cycles_prev) 
-    {
-    ESP_LOGD(TAG,"HV contactor cycles (%u / %u / %u)", cycles_max, cycles_now, cycles_diff);
+    {    
+    time_t now = time(NULL);
+    while (!m_contactor_act_times.empty() && (now - m_contactor_act_times.front()) > 1 * 3600)
+      m_contactor_act_times.pop_front();
+
+    m_contactor_act_times.push_back((uint32_t)now);
+    int contactor_act_count_1h = (int)m_contactor_act_times.size();
+    mt_bms_contactor_cycles->SetElemValue(4, contactor_act_count_1h);
+    ESP_LOGD(TAG,"HV contactor cycles (%u / %u / %u / %d)", cycles_max, cycles_now, cycles_diff,contactor_act_count_1h);
     // Send data log XSQ-BMS-ContactorLog 
     //V1:
     //  <cycles_max>,<cycles_prev>,<cycles_now>,<cycles_diff>,<odometer>
@@ -359,12 +366,14 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
     //  ,<bms_mileage>,<can_soc>,<can_soh>,<USM_12V>,<contactor_state>,<bms_prod_data>,<bat_serial>,<evc_traceability>
     //V3:
     //  ,<12V_trickle_charge_count within 24h>
-    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,3,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s,%d",
+    //V4:
+    // ,<contactor_activation_count within 1h>
+    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,3,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s,%d,%d",
       86400 * 30, // hold time 30 days
       cycles_max, cycles_prev, cycles_now, cycles_diff, odometer, 
       mt_bms_mileage->AsFloat(), can_soc, can_soh, mt_evc_dcdc->GetElemValue(3), mt_bms_HVcontactStateTXT->AsString().c_str(),
       mp_encode(mt_bms_prod_data->AsString()).c_str(), mt_bat_serial->AsString().c_str(), mp_encode(mt_evc_traceability->AsString()).c_str(),
-      mt_12v_trickle_charge_count->AsInt(0));
+      mt_12v_trickle_charge_count->AsInt(0), contactor_act_count_1h);
     // Send alert in case of a large unexpected jump
     if (cycles_prev > cycles_now && cycles_diff > 100) 
       {
@@ -398,6 +407,19 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
       else
         m_above_cycles = roundup(cycles_consumed, 10000);
       MyConfig.SetParamValueInt("xsq", "bms.alert.above.cycles", m_above_cycles);
+      }
+    if (contactor_act_count_1h > m_contactor_1h_limit)
+      {
+      ESP_LOGW(TAG, "Contactor activated %d times within 1h", contactor_act_count_1h);
+      char contactor_alert_msg[256];
+      snprintf(contactor_alert_msg, sizeof(contactor_alert_msg),
+        "The contactor was activated more than %d times within 1 hour.\n"
+        "Please check the contactor and related systems for possible issues.\n"
+        "The number of switching operations for the contactor is limited,\n"
+        "and excessive actuation can lead to total failure!\n"
+        "Contactor cycle remaining: %d\n",
+        m_contactor_1h_limit, cycles_now);
+      MyNotify.NotifyString("alert", "xsq.contactor.alert", contactor_alert_msg);
       }
     }
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -350,30 +350,31 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
   mt_bms_contactor_cycles->SetElemValue(2, cycles_consumed);
   mt_bms_contactor_cycles->SetElemValue(3, cycles_diff);
   if (cycles_now != cycles_prev) 
-    {    
+    {
+    // Track contactor changes times for alerting on excessive actuation within 1h
     time_t now = time(NULL);
-    while (!m_contactor_act_times.empty() && (now - m_contactor_act_times.front()) > 1 * 3600)
-      m_contactor_act_times.pop_front();
+    while (!m_cchange_times.empty() && (now - m_cchange_times.front()) > 1 * 3600)
+      m_cchange_times.pop_front();
 
-    m_contactor_act_times.push_back((uint32_t)now);
-    int contactor_act_count_1h = (int)m_contactor_act_times.size();
-    mt_bms_contactor_cycles->SetElemValue(4, contactor_act_count_1h);
-    ESP_LOGD(TAG,"HV contactor cycles (%u / %u / %u / %d)", cycles_max, cycles_now, cycles_diff,contactor_act_count_1h);
+    m_cchange_times.push_back((uint32_t)now);
+    int ccc_1h = (int)m_cchange_times.size(); // contactor cycle changes count within last 1 hour
+    mt_bms_contactor_cycles->SetElemValue(4, ccc_1h);
+    ESP_LOGD(TAG,"HV contactor cycles (%u / %u / %u / %d)", cycles_max, cycles_now, cycles_diff,ccc_1h);
     // Send data log XSQ-BMS-ContactorLog 
     //V1:
     //  <cycles_max>,<cycles_prev>,<cycles_now>,<cycles_diff>,<odometer>
     //V2:
     //  ,<bms_mileage>,<can_soc>,<can_soh>,<USM_12V>,<contactor_state>,<bms_prod_data>,<bat_serial>,<evc_traceability>
     //V3:
-    //  ,<12V_trickle_charge_count within 24h>
+    //  ,<tcc_12v_24h>
     //V4:
-    // ,<contactor_activation_count within 1h>
-    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,3,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s,%d,%d",
+    // ,<cchanges_1h>
+    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,4,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s,%d,%d",
       86400 * 30, // hold time 30 days
       cycles_max, cycles_prev, cycles_now, cycles_diff, odometer, 
       mt_bms_mileage->AsFloat(), can_soc, can_soh, mt_evc_dcdc->GetElemValue(3), mt_bms_HVcontactStateTXT->AsString().c_str(),
       mp_encode(mt_bms_prod_data->AsString()).c_str(), mt_bat_serial->AsString().c_str(), mp_encode(mt_evc_traceability->AsString()).c_str(),
-      mt_12v_trickle_charge_count->AsInt(0), contactor_act_count_1h);
+      mt_12v_trickle_charge_count->AsInt(0), ccc_1h);
     // Send alert in case of a large unexpected jump
     if (cycles_prev > cycles_now && cycles_diff > 100) 
       {
@@ -408,18 +409,17 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
         m_above_cycles = roundup(cycles_consumed, 10000);
       MyConfig.SetParamValueInt("xsq", "bms.alert.above.cycles", m_above_cycles);
       }
-    if (contactor_act_count_1h > m_contactor_1h_limit)
+    // Alert if contactor has changes more than m_contactor_1h_limit times within last 1 hour:
+    if (ccc_1h > m_contactor_1h_limit)
       {
-      ESP_LOGW(TAG, "Contactor activated %d times within 1h", contactor_act_count_1h);
-      char contactor_alert_msg[256];
-      snprintf(contactor_alert_msg, sizeof(contactor_alert_msg),
-        "The contactor was activated more than %d times within 1 hour.\n"
+      ESP_LOGW(TAG, "Contactor has changed more than %d times within 1h", ccc_1h);
+      MyNotify.NotifyStringf("alert", "bms.contactor.alert",
+        "The contactor has changed more than %d times within 1 hour.\n"
         "Please check the contactor and related systems for possible issues.\n"
         "The number of switching operations for the contactor is limited,\n"
         "and excessive actuation can lead to total failure!\n"
         "Contactor cycle remaining: %d\n",
         m_contactor_1h_limit, cycles_now);
-      MyNotify.NotifyString("alert", "xsq.contactor.alert", contactor_alert_msg);
       }
     }
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -409,12 +409,12 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
         m_above_cycles = roundup(cycles_consumed, 10000);
       MyConfig.SetParamValueInt("xsq", "bms.alert.above.cycles", m_above_cycles);
       }
-    // Alert if contactor has changes more than m_contactor_1h_limit times within last 1 hour:
-    if (ccc_1h > m_contactor_1h_limit)
+    // Alert if contactor has changes m_contactor_1h_limit times within last 1 hour:
+    if (ccc_1h >= m_contactor_1h_limit)
       {
-      ESP_LOGW(TAG, "Contactor has changed more than %d times within 1h", ccc_1h);
+      ESP_LOGW(TAG, "Contactor has changed %d times within 1h", ccc_1h);
       MyNotify.NotifyStringf("alert", "bms.contactor.alert",
-        "The contactor has changed more than %d times within 1 hour.\n"
+        "The contactor has changed %d times within 1 hour.\n"
         "Please check the contactor and related systems for possible issues.\n"
         "The number of switching operations for the contactor is limited,\n"
         "and excessive actuation can lead to total failure!\n"

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
@@ -82,7 +82,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandTripCounters(int verbo
     writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
     writer->printf("  CAP: %s\n", (char*) StdMetrics.ms_v_bat_capacity->AsUnitString("-", Native, 1).c_str());
     writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
-    writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
+    writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(4));
     return Success;
 }
 void OvmsVehicleSmartEQ::NotifyTripCounters() {
@@ -108,7 +108,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandTripTotal(int verbosit
     writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
     writer->printf("  CAP: %s\n", (char*) StdMetrics.ms_v_bat_capacity->AsUnitString("-", Native, 1).c_str());
     writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
-    writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
+    writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(4));
     return Success;
 }
 void OvmsVehicleSmartEQ::NotifyTotalCounters() {
@@ -137,10 +137,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandMaintenance(int verbos
     writer->printf("  days: %d\n", mt_obd_mt_day_usual->AsInt());
     writer->printf("  level: %s\n", mt_obd_mt_level->AsString().c_str());
     writer->printf("  km: %d\n", mt_obd_mt_km_usual->AsInt());    
-    writer->printf("  remaining HV contactor cycles: %d of %d (%d consumed)\n", 
+    writer->printf("  remaining HV contactor cycles: %d of %d (%d consumed, %d changes within 1h)\n", 
                    mt_bms_contactor_cycles->GetElemValue(1), 
                    mt_bms_contactor_cycles->GetElemValue(0),
-                   mt_bms_contactor_cycles->GetElemValue(2));
+                   mt_bms_contactor_cycles->GetElemValue(2),
+                   mt_bms_contactor_cycles->GetElemValue(4));
     writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
     return Success;
 }
@@ -170,7 +171,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::Command12Vcharge(int verbosit
   writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
   writer->printf("  CAP: %s\n", (char*) StdMetrics.ms_v_bat_capacity->AsUnitString("-", Native, 1).c_str());
   writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
-  writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
+  writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(4));
   return Success;
 }
 void OvmsVehicleSmartEQ::Notify12Vcharge() {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
@@ -200,6 +200,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandHVCycles(int verbosity
   writer->printf("  remaining Cycles:        %d\n", mt_bms_contactor_cycles->GetElemValue(1));
   writer->printf("  Cycles consumed:         %d\n", mt_bms_contactor_cycles->GetElemValue(2));
   writer->printf("  Cycles diff (last/now):  %d\n", mt_bms_contactor_cycles->GetElemValue(3));
+  writer->printf("  last 1h Count:           %d\n", mt_bms_contactor_cycles->GetElemValue(4));
   if (alert)
     writer->puts("Please check the vehicle and contact support!\n");
   if (!alert)
@@ -241,6 +242,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  remaining Cycles:        %d\n", mt_bms_contactor_cycles->GetElemValue(1));
   writer->printf("  consumed Cycles:         %d\n", mt_bms_contactor_cycles->GetElemValue(2));
   writer->printf("  Cycles diff (last/now):  %d\n", mt_bms_contactor_cycles->GetElemValue(3));
+  writer->printf("  last 1h Count:           %d\n", mt_bms_contactor_cycles->GetElemValue(4));
 
   writer->puts("\n--- SOC Kernel Data (PID 0x08) ---");
   writer->printf("  Open Circuit Voltage:    %.2f V\n", mt_bms_voltages->GetElemValue(5));

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
@@ -82,7 +82,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandTripCounters(int verbo
     writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
     writer->printf("  CAP: %s\n", (char*) StdMetrics.ms_v_bat_capacity->AsUnitString("-", Native, 1).c_str());
     writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
-    writer->printf("  HV contactor consumed cycles: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
+    writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
     return Success;
 }
 void OvmsVehicleSmartEQ::NotifyTripCounters() {
@@ -108,7 +108,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandTripTotal(int verbosit
     writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
     writer->printf("  CAP: %s\n", (char*) StdMetrics.ms_v_bat_capacity->AsUnitString("-", Native, 1).c_str());
     writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
-    writer->printf("  HV contactor consumed cycles: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
+    writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
     return Success;
 }
 void OvmsVehicleSmartEQ::NotifyTotalCounters() {
@@ -170,7 +170,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::Command12Vcharge(int verbosit
   writer->printf("  SOC: %s\n", (char*) StdMetrics.ms_v_bat_soc->AsUnitString("-", Native, 1).c_str());
   writer->printf("  CAP: %s\n", (char*) StdMetrics.ms_v_bat_capacity->AsUnitString("-", Native, 1).c_str());
   writer->printf("  SOH: %s %s\n", StdMetrics.ms_v_bat_soh->AsUnitString("-", ToUser, 0).c_str(), StdMetrics.ms_v_bat_health->AsUnitString("-", ToUser, 0).c_str());
-  writer->printf("  HV contactor resumed cycles: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
+  writer->printf("  HV contactor changes within 1h: %d \n", mt_bms_contactor_cycles->GetElemValue(2));
   return Success;
 }
 void OvmsVehicleSmartEQ::Notify12Vcharge() {
@@ -200,7 +200,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandHVCycles(int verbosity
   writer->printf("  remaining Cycles:        %d\n", mt_bms_contactor_cycles->GetElemValue(1));
   writer->printf("  Cycles consumed:         %d\n", mt_bms_contactor_cycles->GetElemValue(2));
   writer->printf("  Cycles diff (last/now):  %d\n", mt_bms_contactor_cycles->GetElemValue(3));
-  writer->printf("  last 1h Count:           %d\n", mt_bms_contactor_cycles->GetElemValue(4));
+  writer->printf("  changes within 1h:       %d\n", mt_bms_contactor_cycles->GetElemValue(4));
   if (alert)
     writer->puts("Please check the vehicle and contact support!\n");
   if (!alert)
@@ -242,7 +242,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  remaining Cycles:        %d\n", mt_bms_contactor_cycles->GetElemValue(1));
   writer->printf("  consumed Cycles:         %d\n", mt_bms_contactor_cycles->GetElemValue(2));
   writer->printf("  Cycles diff (last/now):  %d\n", mt_bms_contactor_cycles->GetElemValue(3));
-  writer->printf("  last 1h Count:           %d\n", mt_bms_contactor_cycles->GetElemValue(4));
+  writer->printf("  changes within 1h:       %d\n", mt_bms_contactor_cycles->GetElemValue(4));
 
   writer->puts("\n--- SOC Kernel Data (PID 0x08) ---");
   writer->printf("  Open Circuit Voltage:    %.2f V\n", mt_bms_voltages->GetElemValue(5));

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -186,6 +186,14 @@ void OvmsVehicleSmartEQ::Ticker3600(uint32_t ticker)
       m_12v_trickle_charge_times.pop_front();
     mt_12v_trickle_charge_count->SetValue((int)m_12v_trickle_charge_times.size());
     }
+  if (mt_bms_contactor_cycles->GetElemValue(4) > 0)
+    {
+    // remove timestamps older than 1h
+    time_t now = time(NULL);
+    while (!m_contactor_act_times.empty() && (now - m_contactor_act_times.front()) > 1 * 3600)
+      m_contactor_act_times.pop_front();
+    mt_bms_contactor_cycles->SetElemValue(4, (int)m_contactor_act_times.size());
+    }
   } // Ticker 3600
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -114,7 +114,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
     DoorOpenState();
   if(IsOnEQ())
     setTPMSValue();   // update TPMS metrics
-  if(!Is12VchargeEQ() && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) > 0.1f)
+  if(!Is12VchargeEQ() && (StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) > 0.1f))
     StdMetrics.ms_v_charge_12v_voltage->SetValue(0.0f); // reset 12V voltage when not charging to prevent desync
 
   #if defined(CONFIG_OVMS_COMP_WIFI) || defined(CONFIG_OVMS_COMP_CELLULAR)
@@ -190,9 +190,9 @@ void OvmsVehicleSmartEQ::Ticker3600(uint32_t ticker)
     {
     // remove timestamps older than 1h
     time_t now = time(NULL);
-    while (!m_contactor_act_times.empty() && (now - m_contactor_act_times.front()) > 1 * 3600)
-      m_contactor_act_times.pop_front();
-    mt_bms_contactor_cycles->SetElemValue(4, (int)m_contactor_act_times.size());
+    while (!m_cchange_times.empty() && (now - m_cchange_times.front()) > 1 * 3600)
+      m_cchange_times.pop_front();
+    mt_bms_contactor_cycles->SetElemValue(4, (int)m_cchange_times.size());
     }
   } // Ticker 3600
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -62,11 +62,11 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   BmsSetCellDefaultThresholdsVoltage(0.040, 0.060);  // Warn: 40mV, Alert: 60mV
   BmsSetCellDefaultThresholdsTemperature(4.0, 5.5);  // Warn: 4,0°C, Alert: 5,5°C
 
-  //mt_bus_awake                  = MyMetrics.InitBool("xsq.v.bus.awake", SM_STALE_MIN, false);
   mt_canbyte                    = MyMetrics.InitString("xsq.ddt4all.canbyte", SM_STALE_MAX, "", Other);
-  mt_adc_factor                 = MyMetrics.InitFloat("xsq.adc.factor", SM_STALE_MAX, 0, Other);
-  mt_adc_factor_history         = MyMetrics.InitVector<float>("xsq.adc.factor.history", SM_STALE_MAX, nullptr, Other);
-  mt_adc_factor_history->SetElemValue(m_adc_samples -1, 0.0f);  // Pre-allocate x samples to avoid reallocs
+  mt_adc_factor                 = MyMetrics.InitFloat("xsq.adc.factor", SM_STALE_MAX, 0, Other,true);
+  mt_adc_factor_history         = MyMetrics.InitVector<float>("xsq.adc.factor.history", SM_STALE_MAX, nullptr, Other,true);
+  if(mt_adc_factor_history->GetSize() < m_adc_samples)
+    mt_adc_factor_history->SetElemValue(m_adc_samples -1, 0.0f);  // Pre-allocate x samples to avoid reallocs
   mt_poll_state                 = MyMetrics.InitString("xsq.poll.state", SM_STALE_MAX, "UNKNOWN", Other);  
   mt_ed4_values                 = MyMetrics.InitInt("xsq.ed4.values", SM_STALE_MAX, 10);
 
@@ -104,10 +104,13 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
 
   mt_tpms_low_batt               = MyMetrics.InitVector<short> ("xsq.tpms.lowbatt", SM_STALE_MID, nullptr, Other);
   mt_tpms_missing_tx             = MyMetrics.InitVector<short> ("xsq.tpms.missing", SM_STALE_MID, nullptr, Other);
-    // Pre-allocate TPMS vectors for 4 wheels to avoid heap fragmentation
-  StdMetrics.ms_v_tpms_temp->SetElemValue(3, 0.0f);
-  StdMetrics.ms_v_tpms_pressure->SetElemValue(3, 0.0f);
-  StdMetrics.ms_v_tpms_alert->SetElemValue(3, 0);
+  // Pre-allocate TPMS vectors for 4 wheels to avoid heap fragmentation
+  if(StdMetrics.ms_v_tpms_pressure->GetSize() < 4)
+    {
+    StdMetrics.ms_v_tpms_temp->SetElemValue(3, 0.0f);
+    StdMetrics.ms_v_tpms_pressure->SetElemValue(3, 0.0f);
+    StdMetrics.ms_v_tpms_alert->SetElemValue(3, 0);
+    }
   mt_tpms_low_batt->SetElemValue(3, 0);
   mt_tpms_missing_tx->SetElemValue(3, 0);
 
@@ -121,7 +124,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_evc_dcdc->SetElemValue(7, 0.0f);           // Pre-allocate 8 entries
   mt_evc_traceability           = MyMetrics.InitString("xsq.evc.traceability", SM_STALE_MAX, "");
   mt_evc_plug_detected          = MyMetrics.InitBool("xsq.evc.plug.detected", SM_STALE_MIN, false);
-  mt_12v_trickle_charge_count   = MyMetrics.InitInt("xsq.12v.trickle.count", SM_STALE_MAX, 0, Other);
+  mt_12v_trickle_charge_count   = MyMetrics.InitInt("xsq.12v.trickle.count", SM_STALE_MAX, 0, Other, true);
   // 0x793 OBL charger metrics
   mt_obl_fastchg                = MyMetrics.InitBool("xsq.obl.fastchg", SM_STALE_MIN, false);
   mt_obl_main_volts             = MyMetrics.InitVector<float>("xsq.obl.volts", SM_STALE_HIGH, nullptr, Volts);
@@ -138,8 +141,9 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   // 0x7BB BMS metrics
   mt_bms_voltages               = MyMetrics.InitVector<float>("xsq.bms.voltages", SM_STALE_MID, nullptr, Volts);
   mt_bms_voltages->SetElemValue(6, 0.0f);       // Pre-allocate: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor, [5]=cv_sum, [6]=12v_system
-  mt_bms_contactor_cycles       = MyMetrics.InitVector<int>("xsq.bms.contactor.cycles", SM_STALE_HIGH, nullptr);
-  mt_bms_contactor_cycles->SetElemValue(4, 0);  // Pre-allocate: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
+  mt_bms_contactor_cycles       = MyMetrics.InitVector<int>("xsq.bms.contactor.cycles", SM_STALE_HIGH, nullptr, Other, true);
+  if(mt_bms_contactor_cycles->GetSize() < 5)
+    mt_bms_contactor_cycles->SetElemValue(4, 0);  // Pre-allocate: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
   mt_bms_soc_values             = MyMetrics.InitVector<float>("xsq.bms.soc.values", SM_STALE_MID, nullptr, Percentage);
   mt_bms_soc_values->SetElemValue(4, 0.0f);     // Pre-allocate: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
   mt_bms_soc_recal_state        = MyMetrics.InitString("xsq.bms.soc.recal.state", SM_STALE_MID, "");
@@ -286,7 +290,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     cell_interval_drv      = map->GetValueInt("cell_interval_drv", 60);
     cell_interval_chg      = map->GetValueInt("cell_interval_chg", 60);
     m_above_cycles         = map->GetValueInt("bms.alert.above.cycles", 50000);
-    m_contactor_1h_limit   = map->GetValueInt("bms.contactor.1h.limit", 10);
+    m_contactor_1h_limit   = map->GetValueInt("bms.contactor.1h.limit", 8);
     
     m_front_pressure       = map->GetValueFloat("tpms.front.pressure", 225.0f);
     m_rear_pressure        = map->GetValueFloat("tpms.rear.pressure", 255.0f);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -92,8 +92,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bcb_power_mains            = MyMetrics.InitFloat("xsq.v.charge.bcb.power", SM_STALE_MID, 0, Watts);
   // 0x763 OBD metrics
   mt_obd_duration               = MyMetrics.InitInt("xsq.obd.charge.duration", SM_STALE_MID, 0, Minutes);
-  mt_obd_mt_day_prewarn         = MyMetrics.InitInt("xsq.obd.mt.day.prewarn", SM_STALE_MID, 45, Other);
-  mt_obd_mt_day_usual           = MyMetrics.InitInt("xsq.obd.mt.day.usual", SM_STALE_MID, 0, Other);
+  mt_obd_mt_day_prewarn         = MyMetrics.InitInt("xsq.obd.mt.day.prewarn", SM_STALE_MID, 45, Days);
+  mt_obd_mt_day_usual           = MyMetrics.InitInt("xsq.obd.mt.day.usual", SM_STALE_MID, 0, Days);
   mt_obd_mt_km_usual            = MyMetrics.InitInt("xsq.obd.mt.km.usual", SM_STALE_MID, 0, Kilometers);
   mt_obd_mt_level               = MyMetrics.InitString("xsq.obd.mt.level", SM_STALE_MID, "unknown", Other);
 
@@ -139,7 +139,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_voltages               = MyMetrics.InitVector<float>("xsq.bms.voltages", SM_STALE_MID, nullptr, Volts);
   mt_bms_voltages->SetElemValue(6, 0.0f);       // Pre-allocate: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor, [5]=cv_sum, [6]=12v_system
   mt_bms_contactor_cycles       = MyMetrics.InitVector<int>("xsq.bms.contactor.cycles", SM_STALE_HIGH, nullptr);
-  mt_bms_contactor_cycles->SetElemValue(3, 0);  // Pre-allocate Max/Total entries
+  mt_bms_contactor_cycles->SetElemValue(4, 0);  // Pre-allocate: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
   mt_bms_soc_values             = MyMetrics.InitVector<float>("xsq.bms.soc.values", SM_STALE_MID, nullptr, Percentage);
   mt_bms_soc_values->SetElemValue(4, 0.0f);     // Pre-allocate: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
   mt_bms_soc_recal_state        = MyMetrics.InitString("xsq.bms.soc.recal.state", SM_STALE_MID, "");
@@ -286,6 +286,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     cell_interval_drv      = map->GetValueInt("cell_interval_drv", 60);
     cell_interval_chg      = map->GetValueInt("cell_interval_chg", 60);
     m_above_cycles         = map->GetValueInt("bms.alert.above.cycles", 50000);
+    m_contactor_1h_limit   = map->GetValueInt("bms.contactor.1h.limit", 10);
     
     m_front_pressure       = map->GetValueFloat("tpms.front.pressure", 225.0f);
     m_rear_pressure        = map->GetValueFloat("tpms.rear.pressure", 255.0f);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -504,7 +504,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // activated only after reboot
     bool m_check12vadc = true;
     std::deque<uint32_t> m_12v_trickle_charge_times;  // activation timestamps for 12V trickle charge alarm within 24h
-    std::deque<uint32_t> m_contactor_act_times;       // activation timestamps for contactor activation within 24h
+    std::deque<uint32_t> m_cchange_times;             // contactor changes timestamps for tracking within 1h
 
     // --- ADC variables ---
     bool m_ADCfactor_recalc = false;      // request recalculation of ADC factor
@@ -560,7 +560,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_charge_finished = true;    
     int m_candata_timer = -1;
     int32_t m_above_cycles = 50000;       // alert threshold for cycles counted
-    int m_contactor_1h_limit = 10;        // limit for contactor cycles per hour (for alerting)
+    int m_contactor_1h_limit = 10;        // limit for contactor cycles changes per hour (for alerting)
 
     // --- TPMS internal arrays ---
     bool m_tpms_lowbatt[4] = {};          // 0=ok, 1=low

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -560,7 +560,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_charge_finished = true;    
     int m_candata_timer = -1;
     int32_t m_above_cycles = 50000;       // alert threshold for cycles counted
-    int m_contactor_1h_limit = 10;        // limit for contactor cycles changes per hour (for alerting)
+    int m_contactor_1h_limit = 8;         // limit for contactor cycles changes per hour (for alerting)
 
     // --- TPMS internal arrays ---
     bool m_tpms_lowbatt[4] = {};          // 0=ok, 1=low

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -383,7 +383,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
 
     // --- Custom metrics: BMS ---
     OvmsMetricVector<float> *mt_bms_voltages;                // Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor
-    OvmsMetricVector<int>   *mt_bms_contactor_cycles;        // Max/Total HV contactor cycles [0]=max, [1]=remaining, [2]=consumed, [3]=diff last/now remained cycles
+    OvmsMetricVector<int>   *mt_bms_contactor_cycles;        // [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
     OvmsMetricVector<float> *mt_bms_soc_values;              // SOC values: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
     OvmsMetricString        *mt_bms_soc_recal_state;         // SOC Recalibration State
     OvmsMetricFloat         *mt_bms_soh;                     // State of Health (%)
@@ -503,7 +503,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // ADC factor calculation is needed based on 12V reading, only check when car is on or charging to avoid false recalculations based on 12V drop when car is off
     // activated only after reboot
     bool m_check12vadc = true;
-    std::deque<uint32_t> m_12v_trickle_charge_times; // activation timestamps for 12V trickle charge alarm within 24h
+    std::deque<uint32_t> m_12v_trickle_charge_times;  // activation timestamps for 12V trickle charge alarm within 24h
+    std::deque<uint32_t> m_contactor_act_times;       // activation timestamps for contactor activation within 24h
 
     // --- ADC variables ---
     bool m_ADCfactor_recalc = false;      // request recalculation of ADC factor
@@ -559,6 +560,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_charge_finished = true;    
     int m_candata_timer = -1;
     int32_t m_above_cycles = 50000;       // alert threshold for cycles counted
+    int m_contactor_1h_limit = 10;        // limit for contactor cycles per hour (for alerting)
 
     // --- TPMS internal arrays ---
     bool m_tpms_lowbatt[4] = {};          // 0=ok, 1=low


### PR DESCRIPTION
Track HV contactor activations within the last hour and alert on excessive switching. Added a new element to xsq.bms.contactor.cycles ([4]=1h_count), stored activation timestamps in m_contactor_act_times, pruned by Ticker3600, and incremented on PollReply_BMS_HVContactorCycles. Data log format (XSQ-BMS-ContactorLog) updated to V4 to include the 1h count. Added configurable alert threshold xsq.bms.contactor.1h.limit (default 10) and send a notification when the limit is exceeded. Also updated CLI/status outputs to show the last 1h count, adjusted metric pre-allocation/comments, updated docs and changes.txt, and fixed mt_obd_mt_day_* metric units to Days.