### PR TITLE
smartEQ: Add BMS identification (PID 0x80) support

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -227,6 +227,12 @@ xsq.bms.interlock.hvplug               HV plug interlock status [bool]
 xsq.bms.interlock.service              Service interlock status [bool]
 xsq.bms.fusi                           FUSI mode text
 xsq.bms.safety                         Safety mode text
+xsq.bms.id.ident.data                  BMS Identification: PartNo|Supplier|DiagV|HW|SW|basicPart|Ed|Cal
+xsq.bms.id.part.no                     BMS Part Number (PartNumber.LowerPart)
+xsq.bms.id.hw.version                  BMS Hardware Version (HardwareNumber.LowerPart)
+xsq.bms.id.sw.version                  BMS Software Version (SoftwareNumber hex)
+xsq.bms.id.basic.parts                 BMS BasicPartList (PN/HW/Approval hex)
+xsq.bms.id.mfr                         BMS Manufacturer Identification Code
 xsq.12v.trickle.count                  12V trickle charge counted in 24h, reset to 0 after 24h. Alert if count == 3 in 24h [count] - persistent
 =========================== ==============
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -188,6 +188,9 @@ void OvmsVehicleSmartEQ::IncomingPollReply(const OvmsPoller::poll_job_t &job, ui
         case 0x61: // Battery Health (SOH)
           PollReply_BMS_BattHealth(m_rxbuf.data(), m_rxbuf.size());
           break;
+        case 0x80: // DataRead.Identification.RenaultR2
+          PollReply_BMS_IdentificationData(m_rxbuf.data(), m_rxbuf.size());
+          break;
         case 0x90: // BMS Production Number Supplier Read
           PollReply_BMS_ProductionData(m_rxbuf.data(), m_rxbuf.size());
           break;
@@ -369,12 +372,15 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
     //  ,<tcc_12v_24h>
     //V4:
     // ,<cchanges_1h>
-    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,4,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s,%d,%d",
+    //V5:
+    // ,<bms_id_data>
+    MyNotify.NotifyStringf("data", "xsq.bms.log.contactor", "XSQ-BMS-ContactorLog,5,%d,%d,%d,%d,%d,%.1f,%.0f,%.1f,%.0f,%.2f,%s,%s,%s,%s,%d,%d,%s",
       86400 * 30, // hold time 30 days
       cycles_max, cycles_prev, cycles_now, cycles_diff, odometer, 
       mt_bms_mileage->AsFloat(), can_soc, can_soh, mt_evc_dcdc->GetElemValue(3), mt_bms_HVcontactStateTXT->AsString().c_str(),
       mp_encode(mt_bms_prod_data->AsString()).c_str(), mt_bat_serial->AsString().c_str(), mp_encode(mt_evc_traceability->AsString()).c_str(),
-      mt_12v_trickle_charge_count->AsInt(0), ccc_1h);
+      mt_12v_trickle_charge_count->AsInt(0), ccc_1h, mp_encode(mt_bms_ident_data->AsString()).c_str()
+      );
     // Send alert in case of a large unexpected jump
     if (cycles_prev > cycles_now && cycles_diff > 100) 
       {
@@ -558,6 +564,82 @@ void OvmsVehicleSmartEQ::PollReply_BMS_BattHealth(const char* data, uint16_t rep
   mt_bms_cap->SetElemValue(4, cap_useable);   // usable_capacity 
   mt_bms_mileage->SetValue(mileage_raw);      // total mileage stored in BMS
   StdMetrics.ms_v_bat_cac->SetValue(cap_useable);
+}
+
+void OvmsVehicleSmartEQ::PollReply_BMS_IdentificationData(const char* data, uint16_t reply_len) {
+  // DataRead.Identification.RenaultR2 (PID 0x80), sentbytes "2180"
+  // Reply layout after stripping response header (61 80), all offsets 0-based:
+  // data[0..4]  : PartNumber.LowerPart          (5 bytes ASCII, DDT firstbyte 3-7)
+  // data[5]     : DiagnosticIdentificationCode  (1 byte,        DDT firstbyte 8)
+  // data[6..8]  : SupplierNumber.ITG            (3 bytes ASCII, DDT firstbyte 9-11, e.g. "DA1")
+  // data[9..13] : HardwareNumber.LowerPart      (5 bytes ASCII, DDT firstbyte 12-16)
+  // data[14..15]: SoftwareNumber                (2 bytes,       DDT firstbyte 17-18, e.g. 0x0470)
+  // data[16..17]: EditionNumber                 (2 bytes,       DDT firstbyte 19-20)
+  // data[18..19]: CalibrationNumber             (2 bytes,       DDT firstbyte 21-22)
+  // data[20]    : PartNumber.BasicPartList      (1 byte,        DDT firstbyte 23)
+  // data[21]    : HardwareNumber.BasicPartList  (1 byte,        DDT firstbyte 24)
+  // data[22]    : ApprovalNumber.BasicPartList  (1 byte,        DDT firstbyte 25)
+  // data[23]    : ManufacturerIdentificationCode(1 byte,        DDT firstbyte 26)
+  // minbytes: 26 (2 header + 24 payload) → REQUIRE_LEN(24)
+  REQUIRE_LEN(24);
+
+  // PartNumber.LowerPart: bytes 0-4 (5 bytes ASCII)
+  char part_no[6];
+  memcpy(part_no, &CAN_BYTE(0), 5);
+  part_no[5] = '\0';
+
+  // DiagnosticIdentificationCode: byte 5 (matches "diagversion" in autoidents)
+  uint8_t diag_version = (uint8_t)CAN_BYTE(5);
+
+  // SupplierNumber.ITG: bytes 6-8 (3 bytes ASCII, e.g. "DA1")
+  char supplier[4];
+  memcpy(supplier, &CAN_BYTE(6), 3);
+  supplier[3] = '\0';
+
+  // HardwareNumber.LowerPart: bytes 9-13 (5 bytes ASCII)
+  char hw_num[6];
+  memcpy(hw_num, &CAN_BYTE(9), 5);
+  hw_num[5] = '\0';
+
+  // SoftwareNumber: bytes 14-15 (2 bytes, displayed as 4-digit hex, e.g. 0x0470 → "0470")
+  uint16_t sw_num_raw = CAN_UINT(14);
+  char sw_version[5];
+  snprintf(sw_version, sizeof(sw_version), "%04X", sw_num_raw);
+
+  // EditionNumber: bytes 16-17 (2 bytes)
+  uint16_t edition = CAN_UINT(16);
+  char edition_str[5];
+  snprintf(edition_str, sizeof(edition_str), "%04X", edition);
+
+  // CalibrationNumber: bytes 18-19 (2 bytes)
+  uint16_t calibration = CAN_UINT(18);
+  char calibration_str[5];
+  snprintf(calibration_str, sizeof(calibration_str), "%04X", calibration);
+
+  // BasicPartList: bytes 20-22 (PartNumber / HardwareNumber / ApprovalNumber)
+  uint8_t bpl_part     = (uint8_t)CAN_BYTE(20);
+  uint8_t bpl_hw       = (uint8_t)CAN_BYTE(21);
+  uint8_t bpl_approval = (uint8_t)CAN_BYTE(22);
+  char basic_parts[10];
+  snprintf(basic_parts, sizeof(basic_parts), "%02X/%02X/%02X", bpl_part, bpl_hw, bpl_approval);
+
+  // ManufacturerIdentificationCode: byte 23 (1 byte)
+  uint8_t mfr_id = (uint8_t)CAN_BYTE(23);
+
+  // Build combined identification string for mt_bms_ident_data
+  char ident_str[48];
+  snprintf(ident_str, sizeof(ident_str), "%s|%s|%d|%s|%s|%s|%s|%s",
+           part_no, supplier, (int)diag_version, hw_num, sw_version, basic_parts, edition_str, calibration_str);
+
+  mt_bms_ident_data->SetValue(ident_str);
+  mt_bms_part_no->SetValue(part_no);
+  mt_bms_hw_version->SetValue(hw_num);
+  mt_bms_sw_version->SetValue(sw_version);
+  mt_bms_mfr_id->SetValue((int)mfr_id);
+  mt_bms_basic_parts->SetValue(basic_parts);
+
+  ESP_LOGD(TAG, "BMS Identification (PID 0x80): PartNo=%s, DiagVer=%u, Supplier=%s, HW=%s, SW=%s, Ed=%s, Cal=%s, BPL=%s, Mfr=%02X",
+           part_no, diag_version, supplier, hw_num, sw_version, edition_str, calibration_str, basic_parts, mfr_id);
 }
 
 void OvmsVehicleSmartEQ::PollReply_BMS_ProductionData(const char* data, uint16_t reply_len) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -43,7 +43,8 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,60,60,60 }, 0, ISOTP_STD },    // SOC
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,60,60,60 }, 0, ISOTP_STD },    // SOC Recalibration
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Health (SOH)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,3600,0,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, { 0,3600,3600,0 }, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,3600,3600,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
 };
 
 //   -> HandleOBDpolling() will add the following PIDs with modified intervals m_cfg_cell_interval_drv/m_cfg_cell_interval_chg
@@ -58,7 +59,7 @@ static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] =
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,3600,0,0 }, 0, ISOTP_STD },      // req.VIN
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,3600,3600,0 }, 0, ISOTP_STD },   // req.VIN
   { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,8,8,8 }, 0, ISOTP_STD },         // Doorlock EEPROM
 };
 
@@ -70,7 +71,7 @@ static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,3600,0,0 }, 0, ISOTP_STD },      // Frame Traceability Information
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,3600,3600,0 }, 0, ISOTP_STD },   // Frame Traceability Information
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,16,0,16 }, 0, ISOTP_STD },  // Charging plug detected (B_PlugConnected_bcb_status_S)  
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,60,60,16 }, 0, ISOTP_STD }, // rqHV_Energy
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,60,60,60 }, 0, ISOTP_STD }, // Cabin blower command
@@ -87,19 +88,19 @@ static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,60,14,14 }, 0, ISOTP_STD }, // rqDCDC_Power
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,60,14,14 }, 0, ISOTP_STD }, // USM 14V voltage (CAN)
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,60,14,14 }, 0, ISOTP_STD }, // Battery voltage 14V
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, { 0,60,0,60 }, 0, ISOTP_STD },  // Vehicle Speed
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, { 0,60,0,60 }, 0, ISOTP_STD },  // Total vehicle distance
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, { 0,60,60,60 }, 0, ISOTP_STD }, // Vehicle Speed
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, { 0,60,60,60 }, 0, ISOTP_STD }, // Total vehicle distance
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,60,60,60 }, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,60,60,0 }, 0, ISOTP_STD }, // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,60,60,0 }, 0, ISOTP_STD }, // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,60,60,0 }, 0, ISOTP_STD }, // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,3600,0,0 }, 0, ISOTP_STD }, // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,3600,0,0 }, 0, ISOTP_STD }, // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,3600,0,0 }, 0, ISOTP_STD }, // maintenance level
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,60,60,60 }, 0, ISOTP_STD },  // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,60,60,0 }, 0, ISOTP_STD },   // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,60,60,0 }, 0, ISOTP_STD },   // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,60,60,0 }, 0, ISOTP_STD },   // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,3600,3600,0 }, 0, ISOTP_STD }, // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,3600,3600,0 }, 0, ISOTP_STD }, // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,3600,3600,0 }, 0, ISOTP_STD }, // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -80,8 +80,6 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_reset_speed                = MyMetrics.InitFloat("xsq.v.reset.speed", SM_STALE_MID, 0, Kph);
   // 0x658 metrics
   mt_bat_serial                 = MyMetrics.InitString("xsq.v.bat.serial", SM_STALE_MAX, "");
-    // BMS production data (PID 0x9000)
-  mt_bms_prod_data              = MyMetrics.InitString("xsq.bms.prod.data", SM_STALE_MAX, "");
   // 0x646 metrics
   mt_energy_used                = MyMetrics.InitFloat("xsq.v.energy.used", SM_STALE_MID, 0, kWh);
   mt_energy_recd                = MyMetrics.InitFloat("xsq.v.energy.recd", SM_STALE_MID, 0, kWh);
@@ -162,6 +160,15 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_interlock_service      = MyMetrics.InitBool("xsq.bms.interlock.service", SM_STALE_MID, false);
   mt_bms_fusi_mode_txt          = MyMetrics.InitString("xsq.bms.fusi",SM_STALE_MID, "", Other);
   mt_bms_safety_mode_txt        = MyMetrics.InitString("xsq.bms.safety",SM_STALE_MID, "", Other);
+  // BMS production data (PID 0x90)
+  mt_bms_prod_data              = MyMetrics.InitString("xsq.bms.prod.data", SM_STALE_MAX, "");
+  // BMS identification data (PID 0x80)
+  mt_bms_ident_data             = MyMetrics.InitString("xsq.bms.id.ident.data", SM_STALE_MAX, "",  Other);
+  mt_bms_part_no                = MyMetrics.InitString("xsq.bms.id.part.no", SM_STALE_MAX, "",  Other);
+  mt_bms_hw_version             = MyMetrics.InitString("xsq.bms.id.hw.version", SM_STALE_MAX, "",  Other);
+  mt_bms_sw_version             = MyMetrics.InitString("xsq.bms.id.sw.version", SM_STALE_MAX, "",  Other);
+  mt_bms_mfr_id                 = MyMetrics.InitInt("xsq.bms.id.mfr", SM_STALE_MAX, 0,   Other);
+  mt_bms_basic_parts            = MyMetrics.InitString("xsq.bms.id.basic.parts", SM_STALE_MAX, "",  Other);
 
   // Start CAN bus in CAN_MODE_ACTIVE mode
   RegisterCanBus(1, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -276,6 +276,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void PollReply_BMS_CellResistance(const char* data, uint16_t reply_len, uint16_t start);
     void PollReply_BMS_BattHealth(const char* data, uint16_t reply_len);
     void PollReply_BMS_ProductionData(const char* data, uint16_t reply_len);
+    void PollReply_BMS_IdentificationData(const char* data, uint16_t reply_len);
 
     // --- Poll reply handlers: TDB ---
     void PollReply_TDB(const char* data, uint16_t reply_len);
@@ -357,6 +358,14 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
 
     // --- Custom metrics: BMS production data (PID 0x90) ---
     OvmsMetricString        *mt_bms_prod_data;          // BMS production data formatted (serial, MM/YYYY)
+
+    // --- Custom metrics: BMS Identification (PID 0x80) ---
+    OvmsMetricString        *mt_bms_ident_data;         // BMS Identification: PartNo|Supplier|DiagV|HW|SW|basicPart|Ed|Cal
+    OvmsMetricString        *mt_bms_part_no;            // BMS Part Number (PartNumber.LowerPart)
+    OvmsMetricString        *mt_bms_hw_version;         // BMS Hardware Version (HardwareNumber.LowerPart)
+    OvmsMetricString        *mt_bms_sw_version;         // BMS Software Version (SoftwareNumber hex)
+    OvmsMetricInt           *mt_bms_mfr_id;             // BMS Manufacturer Identification Code
+    OvmsMetricString        *mt_bms_basic_parts;        // BMS BasicPartList (PN/HW/Approval hex)
 
     // --- Custom metrics: 0x637 ---
     OvmsMetricFloat         *mt_energy_used;            // Energy used since mission start (kWh)


### PR DESCRIPTION
Add parsing and metrics for BMS Identification (DataRead.Identification.RenaultR2, PID 0x80). Implements PollReply_BMS_IdentificationData to decode part number, supplier, diag version, HW/SW/edition/calibration, basic part list and manufacturer ID and stores them in new metrics (xsq.bms.id.*). Update vehicle class to initialize these metrics and declare the new handler. Include the BMS identification string in the contactor log Notify (log format version bumped to 5). Update docs to expose the new metrics keys. Adjust various poll intervals in eq_poller.h (add 0x80 poll, and make several PIDs polled at the longer 3600s interval where appropriate) and tweak some existing poll interval entries. Also relocate/init BMS production metric initialization in the constructor.