### PR TITLE
smartEQ: Add BMS ident output & contactor 1h limit UI

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -387,6 +387,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
       ESP_LOGW(TAG, "HV contactor cycles alert: last: %d, now: %d, consumed: %d odo: %0.0f, counted more than expected!", cycles_prev, cycles_now, cycles_consumed, odometer);
       if (IsCANwrite()) 
         {
+        smartCoolDownPolling();
         smartOBDpolling(false);
         MyConfig.SetParamValueBool("xsq", "canwrite", false);
         MyConfig.SetParamValueBool("xsq", "canwrite.caron", false);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -141,12 +141,6 @@ void OvmsVehicleSmartEQ::IncomingPollReply(const OvmsPoller::poll_job_t &job, ui
         case 0x2005: // Battery voltage 14V
           PollReply_EVC_14VBatteryVoltage(m_rxbuf.data(), m_rxbuf.size());
           break;
-        case 0x2003: // Vehicle Speed
-          PollReply_EVC_VehSpeed(m_rxbuf.data(), m_rxbuf.size());
-          break;
-        case 0x2006: // Odometer (Total Vehicle Distance)
-          PollReply_EVC_Odometer(m_rxbuf.data(), m_rxbuf.size());
-          break;
         case 0x339D: // Charging plug detected (B_PlugConnected_bcb_status_S)
           PollReply_EVC_PlugDetected(m_rxbuf.data(), m_rxbuf.size());
           break;
@@ -932,21 +926,7 @@ void OvmsVehicleSmartEQ::PollReply_EVC_14VBatteryVoltageReq(const char* data, ui
   REQUIRE_LEN(1);
   uint8_t raw = CAN_BYTE(0);
   float value = 12.0f + raw * 0.05f;
-  can_speed = value;
-}
-
-void OvmsVehicleSmartEQ::PollReply_EVC_VehSpeed(const char* data, uint16_t reply_len) {
-  // POSITIVE RESPONSE FORMAT: 62 20 03  <Byte> <Byte>
-  REQUIRE_LEN(2);
-  uint16_t raw = CAN_UINT(0);
-  float value = raw * 0.01f;
-  can_speed = value;
-}
-
-void OvmsVehicleSmartEQ::PollReply_EVC_Odometer(const char* data, uint16_t reply_len) {
-  // POSITIVE RESPONSE FORMAT: 62 20 06  <Byte>
-  REQUIRE_LEN(3);
-  can_odometer = (float)CAN_UINT24(0);
+  mt_evc_dcdc->SetElemValue(5, value);  // dcdc_volt_req
 }
 
 void OvmsVehicleSmartEQ::PollReply_EVC_PlugDetected(const char* data, uint16_t reply_len) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -460,6 +460,9 @@ void OvmsVehicleSmartEQ::smartOn()
   // canwrite enable write access, only when car is on
   if(IsCANwrite()) 
     {
+    smartCoolDownPolling(5);
+    if (!m_static_ids_read)
+      smartOBDpollingSingle();
     smartOBDpolling(true);
     }
   ESP_LOGD(TAG, "smartOn()");
@@ -469,10 +472,12 @@ void OvmsVehicleSmartEQ::smartOff()
 {
   // Reset gear
   StdMetrics.ms_v_env_gear->SetValue(0);
+  smartCoolDownPolling();
 }
 
 void OvmsVehicleSmartEQ::smartAwake()
 {
+  smartCoolDownPolling();
   // enable active polling when car wakes up (canwrite only)
   if(m_enable_write) 
     {
@@ -489,11 +494,13 @@ void OvmsVehicleSmartEQ::smartSleep()
   // disable active polling when car goes to sleep
   if((m_enable_write_caron && m_can_active) || (m_enable_write_sleep && m_can_active))
     smartOBDpolling(false);
+  smartCoolDownPolling(20);
   ESP_LOGD(TAG, "smartSleep()");
 }
 
 void OvmsVehicleSmartEQ::smartChargeStart()
 {
+  smartCoolDownPolling();
   if (m_charge_finished)
     {
     ResetChargingValues();
@@ -514,12 +521,13 @@ void OvmsVehicleSmartEQ::smartChargeStart()
     m_ADCfactor_recalc_timer = 2;   // wait at least 2 min. before recalculation
     m_ADCfactor_recalc = true;      // recalculate ADC factor when HV charging
     }
-  smartOBDpolling(true);
+  smartOBDpolling(true);  
   ESP_LOGD(TAG, "smartChargeStart()");
 }
 
 void OvmsVehicleSmartEQ::smartChargeStop()
 {
+  smartCoolDownPolling();
   StdMetrics.ms_v_charge_pilot->SetValue(false);
   StdMetrics.ms_v_charge_mode->SetValue("standard");
   StdMetrics.ms_v_charge_type->SetValue("type2");
@@ -561,14 +569,22 @@ void OvmsVehicleSmartEQ::smartChargeFinish()
   m_poll_on_charge = false;
   StdMetrics.ms_v_charge_power->SetValue(0);
   ESP_LOGD(TAG, "smartChargeFinish()");
+  smartAwake(); // polling cooldown and reload polling list
+}
+
+void OvmsVehicleSmartEQ::smartCoolDownPolling(int delay_sec)
+{
+  m_poll_cooldown = true;
+  m_cooldown_ticker = delay_sec;
+  PollSetState(POLLSTATE_OFF);
 }
 
 void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
 {
+  smartCoolDownPolling();
   if(!IsCANwrite())
     {
     PollSetPidList(m_can1, NULL);
-    vTaskDelay(200 / portTICK_PERIOD_MS);
     m_can_active = false;
     m_poll_on_charge = false;
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared (write access disabled)");
@@ -585,6 +601,35 @@ void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared");
     }
   HandleOBDpolling();
+}
+// Perform single OBD polling for static IDs (VIN, BMS Ident, Frame Traceability) when CAN write access is available
+void OvmsVehicleSmartEQ::smartOBDpollingSingle()
+{
+  if (!m_static_ids_read && IsCANwrite()) {      
+      smartCoolDownPolling(15); // Short cooldown to allow single polling without interference
+      m_static_ids_read = true;
+      xTaskCreate([](void* ctx) {
+          auto* sq = static_cast<OvmsVehicleSmartEQ*>(ctx);
+          std::string response;
+          
+          // VIN
+          if (sq->PollSingleRequest(sq->m_can1, 0x745, 0x765,
+                  VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, response) == POLLSINGLE_OK)
+              sq->PollReply_BCM_VIN(response.data(), response.size());
+          
+          // BMS Identification
+          if (sq->PollSingleRequest(sq->m_can1, 0x79B, 0x7BB,
+                  VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, response) == POLLSINGLE_OK)
+              sq->PollReply_BMS_IdentificationData(response.data(), response.size());
+
+          // Frame Traceability
+          if (sq->PollSingleRequest(sq->m_can1, 0x7E4, 0x7EC,
+                  VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, response) == POLLSINGLE_OK)
+              sq->PollReply_EVC_Traceability(response.data(), response.size());
+
+          vTaskDelete(nullptr);
+      }, "xsq.staticpoll", 4096, this, 5, nullptr);
+  }
 }
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -461,8 +461,6 @@ void OvmsVehicleSmartEQ::smartOn()
   if(IsCANwrite()) 
     {
     smartCoolDownPolling(5);
-    if (!m_static_ids_read)
-      smartOBDpollingSingle();
     smartOBDpolling(true);
     }
   ESP_LOGD(TAG, "smartOn()");
@@ -490,17 +488,17 @@ void OvmsVehicleSmartEQ::smartAwake()
 }
 
 void OvmsVehicleSmartEQ::smartSleep()
-{
+{  
+  smartCoolDownPolling(20);
   // disable active polling when car goes to sleep
   if((m_enable_write_caron && m_can_active) || (m_enable_write_sleep && m_can_active))
     smartOBDpolling(false);
-  smartCoolDownPolling(20);
   ESP_LOGD(TAG, "smartSleep()");
 }
 
 void OvmsVehicleSmartEQ::smartChargeStart()
 {
-  smartCoolDownPolling();
+  smartCoolDownPolling(20);
   if (m_charge_finished)
     {
     ResetChargingValues();
@@ -527,7 +525,7 @@ void OvmsVehicleSmartEQ::smartChargeStart()
 
 void OvmsVehicleSmartEQ::smartChargeStop()
 {
-  smartCoolDownPolling();
+  smartCoolDownPolling(20);
   StdMetrics.ms_v_charge_pilot->SetValue(false);
   StdMetrics.ms_v_charge_mode->SetValue("standard");
   StdMetrics.ms_v_charge_type->SetValue("type2");
@@ -577,11 +575,11 @@ void OvmsVehicleSmartEQ::smartCoolDownPolling(int delay_sec)
   m_poll_cooldown = true;
   m_cooldown_ticker = delay_sec;
   PollSetState(POLLSTATE_OFF);
+  mt_poll_state->SetValue("Off");
 }
 
 void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
 {
-  smartCoolDownPolling();
   if(!IsCANwrite())
     {
     PollSetPidList(m_can1, NULL);
@@ -601,35 +599,6 @@ void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared");
     }
   HandleOBDpolling();
-}
-// Perform single OBD polling for static IDs (VIN, BMS Ident, Frame Traceability) when CAN write access is available
-void OvmsVehicleSmartEQ::smartOBDpollingSingle()
-{
-  if (!m_static_ids_read && IsCANwrite()) {      
-      smartCoolDownPolling(15); // Short cooldown to allow single polling without interference
-      m_static_ids_read = true;
-      xTaskCreate([](void* ctx) {
-          auto* sq = static_cast<OvmsVehicleSmartEQ*>(ctx);
-          std::string response;
-          
-          // VIN
-          if (sq->PollSingleRequest(sq->m_can1, 0x745, 0x765,
-                  VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, response) == POLLSINGLE_OK)
-              sq->PollReply_BCM_VIN(response.data(), response.size());
-          
-          // BMS Identification
-          if (sq->PollSingleRequest(sq->m_can1, 0x79B, 0x7BB,
-                  VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, response) == POLLSINGLE_OK)
-              sq->PollReply_BMS_IdentificationData(response.data(), response.size());
-
-          // Frame Traceability
-          if (sq->PollSingleRequest(sq->m_can1, 0x7E4, 0x7EC,
-                  VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, response) == POLLSINGLE_OK)
-              sq->PollReply_EVC_Traceability(response.data(), response.size());
-
-          vTaskDelete(nullptr);
-      }, "xsq.staticpoll", 4096, this, 5, nullptr);
-  }
 }
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -43,7 +43,7 @@ void OvmsVehicleSmartEQ::HandlePollState() {
     {
     if (m_poll_state != POLLSTATE_OFF) 
       {
-      PollSetState(POLLSTATE_OFF);
+      smartCoolDownPolling();
       ESP_LOGD(TAG, "Pollstate Off (write disabled)");
       }
     mt_poll_state->SetValue(state_disabled);
@@ -60,7 +60,7 @@ void OvmsVehicleSmartEQ::HandlePollState() {
     {
     desired_state = POLLSTATE_ON;         //- car is on
     }
-  else if (IsAwakeEQ())
+  else if (IsAwakeEQ() && !m_poll_cooldown)
     {
     desired_state = POLLSTATE_AWAKE;      //- car is awake (but not on)
     }    
@@ -95,9 +95,9 @@ void OvmsVehicleSmartEQ::HandlePollState() {
 
 void OvmsVehicleSmartEQ::HandleOBDpolling() {
   PollSetPidList(m_can1, NULL);
-  PollSetThrottling(5);
+  PollSetThrottling(2);
   PollSetResponseSeparationTime(20);
-  HandlePollState();
+  smartCoolDownPolling();
 
   // modify Poller..
   m_poll_vector.clear();
@@ -107,15 +107,15 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
     return;
     }
   // Pre-allocate capacity to avoid reallocs during insert operations
-  // obdii_polls + slow/fast_charger_polls + 2 cell polls + terminator = ~60 entries max
-  m_poll_vector.reserve(60);
+  // obdii_polls + slow/fast_charger_polls + 2 cell polls + terminator = ~50 entries max
+  m_poll_vector.reserve(50);
 
   // Add PIDs to poll list:
   
   if (m_obdii_79b) // 79b non-cell PIDs
     m_poll_vector.insert(m_poll_vector.end(), obdii_79b_polls, endof_array(obdii_79b_polls));
 
-  if (m_obdii_745) // 745 PIDs Doorlock and VIN
+  if (m_obdii_745) // 745 PIDs Driver Door lock
     m_poll_vector.insert(m_poll_vector.end(), obdii_745_polls, endof_array(obdii_745_polls));
        
   if (m_obdii_745_tpms && IsOnEQ()) // full TPMS mode with individual pressure/temp/alert status for each wheel
@@ -138,7 +138,7 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
   if (m_obdii_7e4) // 7e4 PIDs charging plug, 12V system, and misc
     m_poll_vector.insert(m_poll_vector.end(), obdii_7e4_polls, endof_array(obdii_7e4_polls));
   
-  if (m_obdii_743) // 743 PIDs Maintenance data, OBD trip counters
+  if (m_obdii_743) // 743 PIDs OBD trip counters
     m_poll_vector.insert(m_poll_vector.end(), obdii_743_polls, endof_array(obdii_743_polls));
   
   if (m_poll_on_charge) // additional PIDs to poll when charging, depending on fast/slow charger detected

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -45,8 +45,8 @@ void OvmsVehicleSmartEQ::HandlePollState() {
       {
       smartCoolDownPolling();
       ESP_LOGD(TAG, "Pollstate Off (write disabled)");
+      mt_poll_state->SetValue(state_disabled);
       }
-    mt_poll_state->SetValue(state_disabled);
     return;
     }
   
@@ -60,7 +60,7 @@ void OvmsVehicleSmartEQ::HandlePollState() {
     {
     desired_state = POLLSTATE_ON;         //- car is on
     }
-  else if (IsAwakeEQ() && !m_poll_cooldown)
+  else if (IsAwakeEQ())
     {
     desired_state = POLLSTATE_AWAKE;      //- car is awake (but not on)
     }    
@@ -70,13 +70,11 @@ void OvmsVehicleSmartEQ::HandlePollState() {
     }
 
   if (desired_state != m_poll_state) 
-    {
-    PollSetState(desired_state);
-    ESP_LOGD(TAG, "Pollstate %s", state_names[desired_state]);
-    mt_poll_state->SetValue(state_names[desired_state]);
+    {      
+    PollSetState(POLLSTATE_OFF);          // Reset to off while transitioning between states to avoid conflicts
     if (desired_state == POLLSTATE_OFF)
       {
-      smartSleep();                      // switch to liten mode OBDII polling immediately
+      smartSleep();                      // switch to listen mode OBDII polling immediately
       }
     else if (desired_state == POLLSTATE_AWAKE)
       {
@@ -90,14 +88,20 @@ void OvmsVehicleSmartEQ::HandlePollState() {
       {
       smartChargeStart();                 // switch to active mode OBDII polling immediately
       }
+    // smartCoolDownPolling() (called inside smart* functions) resets m_poll_state → POLLSTATE_OFF.
+    // Restore only the tracking variable here so HandlePollState() does not re-trigger on cooldown expiry.
+    // MyPollers stays at POLLSTATE_OFF (cooldown still active); PollerStateTicker re-activates it
+    // via PollSetState(m_poll_state) once the cooldown ticker reaches zero.
+    ESP_LOGD(TAG, "Pollstate %s", state_names[desired_state]);
+    m_poll_state = desired_state;
+    mt_poll_state->SetValue(state_names[desired_state]);
     }
 }
 
 void OvmsVehicleSmartEQ::HandleOBDpolling() {
-  PollSetPidList(m_can1, NULL);
-  PollSetThrottling(2);
+  PollSetPidList(m_can1, NULL);  // Stop active polls during list rebuild (sufficient – no smartCoolDownPolling needed here)
+  PollSetThrottling(3);
   PollSetResponseSeparationTime(20);
-  smartCoolDownPolling();
 
   // modify Poller..
   m_poll_vector.clear();
@@ -107,8 +111,8 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
     return;
     }
   // Pre-allocate capacity to avoid reallocs during insert operations
-  // obdii_polls + slow/fast_charger_polls + 2 cell polls + terminator = ~50 entries max
-  m_poll_vector.reserve(50);
+  // obdii_polls + slow/fast_charger_polls + 2 cell polls + terminator = ~60 entries max
+  m_poll_vector.reserve(60);
 
   // Add PIDs to poll list:
   
@@ -153,6 +157,10 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
       }
     }
 
+  // Skip one-time polls if static IDs are already known from this session
+  if (!m_static_ids_read)
+      m_poll_vector.insert(m_poll_vector.end(), obdii_onetime_polls, endof_array(obdii_onetime_polls));
+      
   // Terminate poll list:
   m_poll_vector.push_back(POLL_LIST_END);
   // Release excess capacity to free unused heap memory

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
@@ -245,6 +245,13 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  Cycles diff (last/now):  %d\n", mt_bms_contactor_cycles->GetElemValue(3));
   writer->printf("  changes within 1h:       %d\n", mt_bms_contactor_cycles->GetElemValue(4));
 
+  writer->puts("\n--- BMS Ident Data (PID 0x80) ---");
+  writer->printf("  Basic Part:              %s\n", mt_bms_basic_parts->AsString().c_str());
+  writer->printf("  Part Number:             %s\n", mt_bms_part_no->AsString().c_str());
+  writer->printf("  HW Version:              %s\n", mt_bms_hw_version->AsString().c_str());
+  writer->printf("  SW Version:              %s\n", mt_bms_sw_version->AsString().c_str());
+  writer->printf("  Manufacturer ID:         %s\n", mt_bms_mfr_id->AsString().c_str());
+
   writer->puts("\n--- SOC Kernel Data (PID 0x08) ---");
   writer->printf("  Open Circuit Voltage:    %.2f V\n", mt_bms_voltages->GetElemValue(5));
   writer->printf("  Real SOC (Min):          %.2f%%\n", mt_bms_soc_values->GetElemValue(2));

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -38,13 +38,11 @@
 static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,60,10,4 }, 0, ISOTP_STD },     // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,60,10,10 }, 0, ISOTP_STD },    // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,60,60,60 }, 0, ISOTP_STD },    // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,60,60,60 }, 0, ISOTP_STD },    // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Health (SOH)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, { 0,3600,3600,0 }, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,3600,3600,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,300,10,10 }, 0, ISOTP_STD },   // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,10,10,10 }, 0, ISOTP_STD },    // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,0,300,300 }, 0, ISOTP_STD },   // SOC
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,0,300,300 }, 0, ISOTP_STD },   // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,0,3600,3600 }, 0, ISOTP_STD }, // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs with modified intervals m_cfg_cell_interval_drv/m_cfg_cell_interval_chg
@@ -60,7 +58,6 @@ static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] =
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
   { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,3600,3600,0 }, 0, ISOTP_STD },   // req.VIN
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,8,8,8 }, 0, ISOTP_STD },         // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
@@ -71,36 +68,33 @@ static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,3600,3600,0 }, 0, ISOTP_STD },   // Frame Traceability Information
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,16,0,16 }, 0, ISOTP_STD },  // Charging plug detected (B_PlugConnected_bcb_status_S)  
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,8,0,8 }, 0, ISOTP_STD },  // Charging plug detected (B_PlugConnected_bcb_status_S)  
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,60,60,16 }, 0, ISOTP_STD }, // rqHV_Energy
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,60,60,60 }, 0, ISOTP_STD }, // Cabin blower command
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,300,60,0 }, 0, ISOTP_STD }, // Cabin blower command
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,60,14,14 }, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,60,14,14 }, 0, ISOTP_STD }, // DCDC activation request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,60,14,14 }, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,60,14,14 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,60,14,14 }, 0, ISOTP_STD }, // 14V DCDC current measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,60,14,14 }, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,60,14,14 }, 0, ISOTP_STD }, // USM 14V voltage (CAN)
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,60,14,14 }, 0, ISOTP_STD }, // Battery voltage 14V
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2003, { 0,60,60,60 }, 0, ISOTP_STD }, // Vehicle Speed
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2006, { 0,60,60,60 }, 0, ISOTP_STD }, // Total vehicle distance
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,300,60,60 }, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,10,10,10 }, 0, ISOTP_STD },  // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,300,30,30 }, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,300,15,15 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,300,20,20 }, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,300,20,20 }, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,60,15,15 }, 0, ISOTP_STD },  // USM 14V voltage (CAN)
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,300,15,15 }, 0, ISOTP_STD }, // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,60,60,60 }, 0, ISOTP_STD },  // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,60,60,0 }, 0, ISOTP_STD },   // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,60,60,0 }, 0, ISOTP_STD },   // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,60,60,0 }, 0, ISOTP_STD },   // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,3600,3600,0 }, 0, ISOTP_STD }, // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,3600,3600,0 }, 0, ISOTP_STD }, // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,3600,3600,0 }, 0, ISOTP_STD }, // maintenance level
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,300,300,300 }, 0, ISOTP_STD },  // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,0,60,0 }, 0, ISOTP_STD },   // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,0,60,0 }, 0, ISOTP_STD },   // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,0,60,0 }, 0, ISOTP_STD },   // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,0,3600,0 }, 0, ISOTP_STD }, // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,0,3600,0 }, 0, ISOTP_STD }, // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,0,3600,0 }, 0, ISOTP_STD }, // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
@@ -113,13 +107,13 @@ static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, { 0,0,0,4 }, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, { 0,0,0,4 }, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, { 0,0,0,4 }, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, { 0,0,0,4 }, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, { 0,0,0,4 }, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, { 0,0,0,4 }, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, { 0,0,0,4 }, 0, ISOTP_STD }, // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, { 0,0,0,4 }, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_Max Current limitation
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -42,7 +42,7 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,10,10,10 }, 0, ISOTP_STD },    // HV Contactor Cycles
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,0,300,300 }, 0, ISOTP_STD },   // SOC
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,0,300,300 }, 0, ISOTP_STD },   // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,0,3600,3600 }, 0, ISOTP_STD }, // Battery Health (SOH)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,0,3600,0 }, 0, ISOTP_STD },    // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs with modified intervals m_cfg_cell_interval_drv/m_cfg_cell_interval_chg
@@ -57,7 +57,7 @@ static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] =
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,3600,3600,0 }, 0, ISOTP_STD },   // req.VIN
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,8,8,8 }, 0, ISOTP_STD },         // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
@@ -68,7 +68,7 @@ static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,8,0,8 }, 0, ISOTP_STD },  // Charging plug detected (B_PlugConnected_bcb_status_S)  
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,8,0,8 }, 0, ISOTP_STD },    // Charging plug detected (B_PlugConnected_bcb_status_S)  
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,60,60,16 }, 0, ISOTP_STD }, // rqHV_Energy
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,300,60,0 }, 0, ISOTP_STD }, // Cabin blower command
 };
@@ -101,7 +101,7 @@ static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, { 0,0,0,4 }, 0, ISOTP_STD }, // rqChargerAC
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, { 0,0,0,4 }, 0, ISOTP_STD },  // rqChargerAC
 };
 
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
@@ -122,4 +122,13 @@ static const OvmsPoller::poll_pid_t fast_charger_polls[] =
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_HF Current
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_LF Current
+};
+//   -> HandleOBDpolling() will add the following PIDs once m_static_ids_read is false and IsOnEQ() is true
+static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
+{
+  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, { 0,3600,3600,0 }, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,3600,3600,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,3600,3600,0 }, 0, ISOTP_STD },    // Frame Traceability Information
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,3600,3600,0 }, 0, ISOTP_STD },    // req.VIN
 };

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -37,6 +37,23 @@ static const char *TAG = "v-smarteq";
 
 void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker) 
   {
+  // when 12V voltage is critically low, then switch to sleep mode immediately
+  float volt = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
+  float vref = std::max(StdMetrics.ms_v_bat_12v_voltage_ref->AsFloat(), m_ref12V);
+  if(volt > 0.0f && vref > 0.0f && vref-volt > m_alert12V)
+    {
+    if(m_poll_state != POLLSTATE_OFF)
+      {      
+      smartCoolDownPolling(60);
+      ESP_LOGI(TAG, "Pollstate Off (under voltage detected: %.2fV)", volt);
+      }
+    if(m_cooldown_ticker <= 10) 
+      {
+      m_poll_cooldown = true;
+      m_cooldown_ticker = 60;
+      } 
+    }
+
   if (m_ddt4all_exec >= 1)
     --m_ddt4all_exec;
 
@@ -49,7 +66,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     can_battery_on = false;
     smartCAN2Metrics();
     }
-    
+
   if(IsAwakeEQ())
     smartCAN2Metrics();
 
@@ -91,9 +108,8 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
 
   if(m_enable_LED_state) 
     OnlineState();
-
-  // if HVAC is on, then modify polling to get the DCDC data (reboot prevention)
-  if (IsOnHVACEQ() && IsAwakeEQ() && IsCANwrite() && !m_can_active)
+  if((!m_can_active && m_enable_write && IsAwakeEQ()) ||
+     (!m_can_active && m_enable_write_caron && IsOnEQ()))
     {
     smartOBDpolling(true);
     }
@@ -219,5 +235,15 @@ void OvmsVehicleSmartEQ::PollerStateTicker(canbus *bus)
   // - base system is awake if we've got a fresh lv_pwrstate:
   // use CAN 0x350 state for 12V aux state, because it seems to be more reliable than the 12V voltage for detecting if the car is in accessory mode or not, which is needed for the powermgmt system
   StdMetrics.ms_v_env_aux12v->SetValue(Is12VchargeEQ());
-  HandlePollState();
+  if(m_poll_cooldown && m_cooldown_ticker > 0 && --m_cooldown_ticker == 0) 
+    {
+    ESP_LOGD(TAG, "Poll state cooldown ended, new poll state: %d", m_poll_state);
+    m_poll_cooldown = false;
+    m_cooldown_ticker = -1;
+    HandlePollState();
+    }
+  else if (!m_cooldown_ticker)
+    {
+    HandlePollState();
+    }
   }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -111,6 +111,7 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   if((!m_can_active && m_enable_write && IsAwakeEQ()) ||
      (!m_can_active && m_enable_write_caron && IsOnEQ()))
     {
+    smartCoolDownPolling();
     smartOBDpolling(true);
     }
   // if charging is in progress, then modify polling to get the DCDC/Charging data (reboot prevention)
@@ -193,7 +194,9 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
   } // Ticker 60
 
 void OvmsVehicleSmartEQ::Ticker3600(uint32_t ticker) 
-  { 
+  {
+  if (!m_static_ids_read && StdMetrics.ms_v_vin->IsDefined() && mt_bms_ident_data->IsDefined() && mt_evc_traceability->IsDefined())
+      m_static_ids_read = true;  // already have all static IDs, no need to re-poll
   if (mt_12v_trickle_charge_count->AsInt(0) > 0)
     {
     // remove timestamps older than 24h
@@ -237,13 +240,15 @@ void OvmsVehicleSmartEQ::PollerStateTicker(canbus *bus)
   StdMetrics.ms_v_env_aux12v->SetValue(Is12VchargeEQ());
   if(m_poll_cooldown && m_cooldown_ticker > 0 && --m_cooldown_ticker == 0) 
     {
-    ESP_LOGD(TAG, "Poll state cooldown ended, new poll state: %d", m_poll_state);
+    ESP_LOGD(TAG, "Poll state cooldown ended, resuming poll state: %d", m_poll_state);
     m_poll_cooldown = false;
     m_cooldown_ticker = -1;
-    HandlePollState();
+    PollSetState(m_poll_state);  // Re-activate MyPollers at the target state after cooldown pause
+    HandlePollState();           // Re-evaluate; no-op if state is already correct
     }
-  else if (!m_cooldown_ticker)
+  else if (!m_poll_cooldown)
     {
+    PollSetState(m_poll_state);
     HandlePollState();
     }
   }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -81,7 +81,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
 
   auto lock = MyConfig.Lock();
 
-  std::string error, full_km, rebootnw;
+  std::string error, full_km, rebootnw, contactor_1h_limit;
   bool canwrite, canwrite_caron, canwrite_sleep, led, resettrip, resettotal, bcvalue;
   bool charge12v, extstats, unlocked, tripnotify, opendoors;
   bool obdii79b, obdii79b_cell, obdii743, obdii745, obdii745_tpms, obdii7e4, obdii7e4_dcdc;
@@ -109,6 +109,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     obdii745_tpms = (c.getvar("obdii745_tpms") == "yes");
     obdii7e4 = (c.getvar("obdii7e4") == "yes");
     obdii7e4_dcdc = (c.getvar("obdii7e4_dcdc") == "yes");
+    contactor_1h_limit = c.getvar("contactor_1h_limit");
 
     // Basic numeric validation:
     auto validFloat = [&](const std::string& s, double minv, double maxv, const char* fname)->bool {
@@ -123,6 +124,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     };
     if(!validFloat(full_km, 50, 300, "WLTP km")) full_km = "126.0";
     if(!validFloat(rebootnw, 0, 1440, "Restart Network Time")) rebootnw = "0";
+    if(!validFloat(contactor_1h_limit, 1, 100, "Contactor 1h limit")) contactor_1h_limit = "8";
 
     if (error.empty()) {
       // Use GetParamMap() to get a COPY of the map
@@ -156,6 +158,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
       map.SetValueBool("obdii.7e4", obdii7e4);
       map.SetValueBool("obdii.7e4.dcdc", obdii7e4_dcdc);
       map.SetValueBool("obdii.745.tpms", obdii745_tpms);
+      map["bms.contactor.1h.limit"] = contactor_1h_limit;
 
       // Write all changes in one operation
       MyConfig.SetParamMap("xsq", map);
@@ -196,6 +199,8 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
     rebootnw       = def;
     snprintf(def, sizeof(def), "%d", sq->m_full_km);
     full_km        = def;
+    snprintf(def, sizeof(def), "%d", sq->m_contactor_1h_limit);
+    contactor_1h_limit = def;
     c.head(200);
   }
 
@@ -243,6 +248,8 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
       "<p>Maintenance + trip data. Not recommended for iOS app!</p>");  
   c.input_slider("Restart Network Time", "rebootnw", 3, "min",-1, atof(rebootnw.c_str()), 15, 0, 60, 1,
     "<p>0=off. Auto-restart network on v2 disconnect</p>");
+  c.input_slider("Contactor 1h limit", "contactor_1h_limit", 3, "/h",-1, atof(contactor_1h_limit.c_str()), 8, 1, 100, 1,
+    "<p>Max contactor cycles per hour before alert (default: 8)</p>");
   c.fieldset_end();
 
   c.fieldset_start("OBDII Polling (requires CAN write)");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -256,7 +256,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.input_checkbox("Enable 743 polling", "obdii743", obdii743,
     "<p>e.g. maintenance data</p>");
   c.input_checkbox("Enable 745 polling", "obdii745", obdii745,
-    "<p>e.g. VIN/Doorlock</p>");
+    "<p>e.g. Doorlock</p>");
   c.input_checkbox("Enable 745 TPMS polling", "obdii745_tpms", obdii745_tpms,
     "<p>Full TPMS (pressure/temp/alert). Off=basic (pressure only)</p>");
   c.input_checkbox("Enable 79b polling", "obdii79b", obdii79b,

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -241,7 +241,11 @@ OvmsVehicleSmartEQ::~OvmsVehicleSmartEQ() {
  */
 void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   if (param && param->GetName() == "vehicle")
+    {
     setTPMSValue();   // update TPMS metrics
+    m_ref12V = MyConfig.GetParamValueFloat("vehicle", "12v.ref", 12.6);
+    m_alert12V = MyConfig.GetParamValueFloat("vehicle", "12v.alert", 0.8f);
+    }
   if (param && param->GetName() != "xsq")
     return;
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -321,6 +321,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // set CAN bus transceiver to active or listen-only depending on user selection
   if ( stateWrite != m_enable_write )
     {
+    smartCoolDownPolling();
     smartOBDpolling(m_enable_write);
     }
   // disable caron write mode if normal write mode is enabled to avoid conflicts
@@ -332,6 +333,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // start in listen-only mode if sleep write is enabled and bus is not awake
   if (m_enable_write_sleep && !IsAwakeEQ())
     {
+    smartCoolDownPolling();
     smartOBDpolling(false);
     }
 
@@ -359,6 +361,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
 
   if (do_modify_poll) 
     {
+    smartCoolDownPolling();
     HandleOBDpolling();
     }
   StdMetrics.ms_v_charge_limit_soc->SetValue((float) m_suffsoc, Percentage );

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -155,6 +155,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void smartChargePrepare();
     void smartChargeFinish();
     void smartOBDpolling(bool activate);
+    void smartOBDpollingSingle();
+    void smartCoolDownPolling(int delay_sec = 10);
     void smartCAN2Metrics();
 
     // --- Command overrides ---
@@ -301,8 +303,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void PollReply_EVC_14VBatteryVoltage(const char* data, uint16_t reply_len);
     void PollReply_EVC_14VBatteryVoltageReq(const char* data, uint16_t reply_len);
     void PollReply_EVC_CabinBlower(const char* data, uint16_t reply_len);
-    void PollReply_EVC_VehSpeed(const char* data, uint16_t reply_len);
-    void PollReply_EVC_Odometer(const char* data, uint16_t reply_len);
 
     // --- Poll reply handlers: OBL ---
     void PollReply_OBL_ChargerAC(const char* data, uint16_t reply_len);
@@ -473,6 +473,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     float m_pressure_alert = 70.0f;         // Pressure Alert
     std::string m_hl_canbyte = "";          // canbyte variable for unv
     std::deque<float> m_adc_factor_history; // ring buffer (max 20) for ADC factors
+    float m_ref12V = 12.6f;                 // reference 12V (12.6V)
+    float m_alert12V = 0.8f;                // alert threshold 12V (0.8V)
 
     // --- Internal state variables ---
     bool m_indicator = false;               // activate indicator e.g. 7 times or whatever
@@ -500,9 +502,12 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_obdii_7e4_dcdc;                  // OBDII 7e4 dcdc mode enabled
 
     // --- Poll timing / list ---
+    bool m_static_ids_read = false;         // flag to track if static IDs have been read at least once
     int m_cfg_cell_interval_drv = 60;       // poll interval while driving, default 60 sec.
     int m_cfg_cell_interval_chg = 60;       // poll interval while charging, default 60 sec.
     poll_vector_t m_poll_vector;            // List of PIDs to poll
+    bool m_poll_cooldown = true;            // flag to trigger cooldown timer for poll state change
+    int m_cooldown_ticker = 15;             // cooldown timer for poll state change
 
   // =========================================================================
   // private

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -155,7 +155,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void smartChargePrepare();
     void smartChargeFinish();
     void smartOBDpolling(bool activate);
-    void smartOBDpollingSingle();
     void smartCoolDownPolling(int delay_sec = 10);
     void smartCAN2Metrics();
 


### PR DESCRIPTION
Print BMS Ident Data (PID 0x80) in ED4 scan output (Basic Part, Part Number, HW/SW Version, Manufacturer ID). Add a new web-config field contactor_1h_limit with validation (1–100), default 8, persisted to config key bms.contactor.1h.limit, and exposed as a slider in the Features page to set the max contactor cycles per hour before alert.