### PR TITLE
Fiat eDoblo: poll VIN only when vehicle is on

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,7 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Fiat eDoblo: poll VIN via standard functional OBD-II request when vehicle is on.
 - smart EQ:
     As soon as the 12V trickle charge begins, a timestamp is generated and stored in `m_12v_trickle_charge_times`.
     The counted value is set in `xsq.12v.trickle.count`.

--- a/vehicle/OVMS.V3/components/vehicle_fiatedoblo/src/vehicle_fiatedoblo.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_fiatedoblo/src/vehicle_fiatedoblo.cpp
@@ -44,7 +44,7 @@ static const OvmsPoller::poll_pid_t vehicle_ftdo_polls[]
     // Pollstate 2 - car is charging
     // Pollstate 3 - ping : car is off, not charging and something triggers a wake
     // OBD2 broadcast                                    Off   ON CHRG PING (cycle time in sec)
-    { 0x7e0, 0x7e8, VEHICLE_POLL_TYPE_OBDIIVEHICLE,   0x02, {  0,  10, 15, 25 }, 0, ISOTP_STD }, // VIN
+    { 0x7df,    0, VEHICLE_POLL_TYPE_OBDIIVEHICLE,   0x02, {  0,  10,  0,  0 }, 0, ISOTP_STD }, // VIN, only responds when ready/on
 
     // Battery details
     { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd815, {  0,  5,   1, 999 }, 0, ISOTP_STD }, // Battery voltage
@@ -67,9 +67,6 @@ static const OvmsPoller::poll_pid_t vehicle_ftdo_polls[]
     { 0x6a2, 0x682, VEHICLE_POLL_TYPE_READDATA, 0xd8ce, {  0,  30,   30,   0 }, 0, ISOTP_STD }, // DC-DC converter temperature
     { 0x6a2, 0x682, VEHICLE_POLL_TYPE_READDATA, 0xd8e1, {  0,  30,   30,   0 }, 0, ISOTP_STD }, // on-board charger temperature
     { 0x6a2, 0x682, VEHICLE_POLL_TYPE_READDATA, 0xd8f9, {  0,  30,   30,   0 }, 0, ISOTP_STD }, // Traction cicuit coolant temperature * 10
-
-    // { 0x7df, 0, VEHICLE_POLL_TYPE_OBDIIVEHICLE,   0x01, {  0,  10, 1, 999 }, 0, ISOTP_STD }, // VIN length
-    // { 0x7df, 0, VEHICLE_POLL_TYPE_OBDIIVEHICLE,   0x02, {  0,  10, 1, 999 }, 0, ISOTP_STD }, // VIN maybe like this or with other POLL type data received... or with poll below
 
     POLL_LIST_END
   };
@@ -95,6 +92,7 @@ void OvmsVehicleFiatEDoblo::Ticker60(uint32_t ticker)
     {
       StandardMetrics.ms_v_env_on->SetValue(false);
       StandardMetrics.ms_v_pos_speed->SetValue(0);
+      PollState_Charging();
     }
 }
 
@@ -322,10 +320,20 @@ void OvmsVehicleFiatEDoblo::IncomingPollReply(const OvmsPoller::poll_job_t &job,
 void OvmsVehicleFiatEDoblo::IncomingVINPoll(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length)
 {
   if(job.pid == 0x02) {
-    if(job.mlremain > 13) {
+    size_t skip = 0;
+    if(job.mloffset == 0 || (length > 0 && data[0] == 0x01)) {
       m_vin.clear();
+      // Mode 09 PID 02 normally starts with 0x01: one VIN data item follows.
+      if(length > 0 && data[0] == 0x01) {
+        skip = 1;
+      }
+      else if(length > 0) {
+        ESP_LOGW(TAG, "unexpected VIN data item count: %u", data[0]);
+      }
     }
-    m_vin.append((char*)data, length);
+    if(length > skip) {
+      m_vin.append((char*)data + skip, length - skip);
+    }
     if(job.mlremain == 0) {
       ESP_LOGV(TAG, "received VIN: %s", m_vin.c_str());
       StdMetrics.ms_v_vin->SetValue(m_vin);


### PR DESCRIPTION
## Problem

On the tested e-Berlingo / Stellantis EMP2 vehicle, the VIN is available through the standard OBD-II Mode 09 PID 02 functional request on CAN1 (`7DF 0902`), while the vehicle is fully ready/on (`v.e.on = yes`).

The FTDO module previously polled VIN using a physical ECU request (`7e0 -> 7e8`) and also attempted VIN polling in non-ready poll states. That did not match the observed vehicle behavior.

## Root cause / code path

`vehicle_ftdo_polls` defines the FTDO poll list and poll-state timing. `IncomingVINPoll()` assembles the multi-frame Mode 09 PID 02 response into `v.vin`.

## Fix

- Change FTDO VIN polling to standard functional OBD-II:
  - TX `0x7df`
  - RX module `0` so the poller accepts the standard `0x7e8`-`0x7ef` functional response range
  - `VEHICLE_POLL_TYPE_OBDIIVEHICLE`, PID `0x02`
- Poll VIN only in the ON poll state:
  - `{ 0, 10, 0, 0 }`
- When the ON-only frame timeout marks `v.e.on = false`, return the poll state to Charging so ON-only polls stop after the vehicle is no longer ready/on.
- Skip the initial Mode 09 PID 02 record/count byte when assembling `v.vin`.

## Validation performed

Runtime validation on an OVMS module configured as FTDO:
- With vehicle off:
  - `v.e.on no`
  - `v.vin` unset
- With vehicle ready/on:
  - `v.e.on yes`
  - `v.vin` populated from the functional request