### PR TITLE
smartEQ: Restructure BMS metrics and adjust polling

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -180,7 +180,7 @@ xsq.v.reset.speed                      Average trip speed (reset) [km/h]
 xsq.v.start.time                       Time since start [hh:mm]
 xsq.v.start.distance                   Trip distance since start [km]
 xsq.adc.factor                         Current ADC factor for 12V calculation [float]
-xsq.adc.factor.history                 Last calculated ADC factors (ring buffer) - persistent
+xsq.adc.factor.history                 Last calculated ADC factors (ring buffer)
 xsq.poll.state                         Current poll state (OFF/ON/RUNNING/CHARGING)
 xsq.ed4.values                         ED4scan: number of cells to show
 xsq.ddt4all.canbyte                    DDT4all CAN response bytes [hex string]
@@ -234,8 +234,7 @@ xsq.bms.id.sw.version                  BMS Software Version (SoftwareNumber hex)
 xsq.bms.id.basic.parts                 BMS BasicPartList (PN/HW/Approval hex)
 xsq.bms.id.mfr                         BMS Manufacturer Identification Code
 xsq.12v.trickle.count                  12V trickle charge counted in 24h, reset to 0 after 24h. Alert if count == 3 in 24h [count] - persistent
-xsq.12v.undervolt.history              12V undervoltage history [<timestamp>=<12V>]
-xsq.12v.undervolt.history.vec          12V undervoltage history vector (<12V>) - persistent
+xsq.12v.undervolt.history              12V undervoltage history vector (<12V>)
 =========================== ==============
 
 -------------------------

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -210,7 +210,7 @@ xsq.obl.misc                           OBL miscellaneous data vector: [0]=freq(H
 xsq.obl.leakdiag                       OBL leakage diagnostic status
 xsq.bms.prod.data                      BMS production data formatted (serial, MM/YYYY)
 xsq.bms.temps                          BMS temperature sensors vector [°C]
-xsq.bms.voltages                       BMS voltage values vector: [0]=cell_min(V), [1]=cell_max(V), [2]=cell_mean(V), [3]=cell_sum(V), [4]=pack_volt(V), [5]=traction_link_volt(V), [6]=12v_bms_clamp30(V), [7]=ocv_12V(V)
+xsq.bms.voltages                       BMS voltage values vector: [0]=cell_min(V), [1]=cell_max(V), [2]=cell_mean(V), [3]=cell_sum(V), [4]=pack_volt(V), [5]=traction_link_volt(V), [6]=12v_bms_clamp30(V), [7]=Open Circuit 12V(V)
 xsq.bms.contactor.cycles               HV contactor cycles vector: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count - persistent
 xsq.bms.soc.values                     SOC values vector [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display [%]
 xsq.bms.soc.recal.state                SOC recalibration state

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/docs/index.rst
@@ -210,7 +210,7 @@ xsq.obl.misc                           OBL miscellaneous data vector: [0]=freq(H
 xsq.obl.leakdiag                       OBL leakage diagnostic status
 xsq.bms.prod.data                      BMS production data formatted (serial, MM/YYYY)
 xsq.bms.temps                          BMS temperature sensors vector [°C]
-xsq.bms.voltages                       BMS voltage values vector: [0]=cell_min(V), [1]=cell_max(V), [2]=cell_mean(V), [3]=link_volt(V), [4]=pack_volt(V), [5]=ocv_volt(V), [6]=12v_system(V)
+xsq.bms.voltages                       BMS voltage values vector: [0]=cell_min(V), [1]=cell_max(V), [2]=cell_mean(V), [3]=cell_sum(V), [4]=pack_volt(V), [5]=traction_link_volt(V), [6]=12v_bms_clamp30(V), [7]=ocv_12V(V)
 xsq.bms.contactor.cycles               HV contactor cycles vector: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count - persistent
 xsq.bms.soc.values                     SOC values vector [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display [%]
 xsq.bms.soc.recal.state                SOC recalibration state

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -449,7 +449,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_SOC(const char* data, uint16_t reply_len)
     ocv = 0.0f;
   if(cap_loss < 0.0f || cap_loss > 100.0f)
     cap_loss = 0.0f;
-  mt_bms_voltages->SetElemValue(5, ocv);  // ocv_voltage
+  mt_bms_voltages->SetElemValue(7, ocv);  // ocv_voltage
   mt_bms_soc_values->SetElemValue(0, soc);                              // kernel SOC
   mt_bms_soc_values->SetElemValue(1, (real_soc_min + real_soc_max) / 2.0f);  // real SOC
   mt_bms_soc_values->SetElemValue(2, real_soc_min);                     // SOC min
@@ -692,11 +692,10 @@ void OvmsVehicleSmartEQ::PollReply_BMS_BattState(const char* data, uint16_t repl
 
   mt_bms_voltages->SetElemValue(0, v_cell_min);   // cv_min
   mt_bms_voltages->SetElemValue(1, v_cell_max);   // cv_max
-  mt_bms_voltages->SetElemValue(2, (v_cell_min + v_cell_max) / 2.0f);  // cv_mean
-
-  mt_bms_voltages->SetElemValue(3, v_link);       // link
+  mt_bms_voltages->SetElemValue(2, (v_cell_min + v_cell_max) / 2.0f);  // cv_mean  
+  mt_bms_voltages->SetElemValue(3, cv_sum_raw);   // cv_sum (HV)
   mt_bms_voltages->SetElemValue(4, v_pack_term);  // contactor
-  mt_bms_voltages->SetElemValue(5, cv_sum_raw);   // cv_sum (HV)
+  mt_bms_voltages->SetElemValue(5, v_link);       // traction link 12V
 
   // P = V × I (in kW)
   float pack_power_kw = (v_pack_term * i_pack) / 1000.0f;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -812,10 +812,12 @@ void OvmsVehicleSmartEQ::PollReply_BCM_TPMS_InputCapt(const char* data, uint16_t
     {
     // Pressure: big-endian 16 bit *0.75 kPa
     uint16_t praw = CAN_UINT(8 + (i*2));
-    m_tpms_pressure[i] = (float)praw != 0xffff ? (float)praw * 0.75f : 0.0f;
+    if (praw != 0xffff)
+      m_tpms_pressure[i] = (float)praw * 0.75f;    // only valid values, 0xffff = invalid
     // Temperature: raw byte + offset -30.0
     uint16_t traw = (uint16_t)(uint8_t)CAN_BYTE(16 + i);
-    m_tpms_temperature[i] = traw != 0xffff ? (float)traw - 30.0f : 0.0f;
+    if (traw != 0xffff)
+      m_tpms_temperature[i] = (float)traw - 30.0f; // only valid values, 0xffff = invalid
     m_tpms_lowbatt[i] = static_cast<bool>((raw >> i) & 0x01);
     }
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -562,7 +562,9 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandPreset(int verbosity, 
     "obdii_7e4",
     "obdii_7e4_modify",
     "basic_tpms",
-    "calc.adcfactor.samples"
+    "calc.adcfactor.samples",
+    "cell_interval_drv",
+    "cell_interval_chg",
   };
 
   int removed_count = 0;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -392,7 +392,7 @@ void OvmsVehicleSmartEQ::smartSleep()
 
 void OvmsVehicleSmartEQ::smartChargeStart()
 {
-  smartCoolDownPolling(20);
+  smartCoolDownPolling(15);
   if (m_charge_finished)
     {
     ResetChargingValues();

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -274,6 +274,9 @@ void OvmsVehicleSmartEQ::ReCalcADCfactor(float can12V, OvmsWriter* writer) {
       MyConfig.SetParamValueBool("xsq", "calc.adcfactor", false);
     }
     if (writer) writer->printf("New ADC factor stored: %.3f (prev %.3f, history size %u)\n", adc_factor_new, adc_factor_prev, (unsigned)n);
+    // Send data log XSQ-ADC-FactorLog
+    // V1: <new factor>,<prev factor>
+    MyNotify.NotifyStringf("data", "xsq.adc.log.factor", "XSQ-ADC-FactorLog,1,%d,%.3f,%.3f", 86400 * 30, adc_factor_new, adc_factor_prev);
   #else
     ESP_LOGD(TAG, "ADC support not enabled");
     if (writer) writer->puts("ADC support not enabled");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -318,48 +318,21 @@ void OvmsVehicleSmartEQ::DoorOpenState() {
 
 void OvmsVehicleSmartEQ::smart12VHistory()
 {
-  // On first call after reboot: restore previous entries from persistent vec metric
-  if (m_12v_undervolt_history.empty())
-    {
-    size_t vn = mt_12v_undervolt_history_vec->GetSize();
-    for (size_t i = 0; i < vn && i < 10; ++i)
-      {
-      float v = mt_12v_undervolt_history_vec->GetElemValue(i);
-      if (v > 0.0f)
-        {
-        char entry[16];
-        snprintf(entry, sizeof(entry), "reboot=%.2fV", v);
-        m_12v_undervolt_history.push_back(entry);
-        }
-      }
-    }
-  float volt = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  time_t ts = (time_t)StdMetrics.ms_m_timeutc->AsInt();
-  if (ts < 86400)  // UTC not yet synced (still at/near 1970-01-01)
-    {
-    ESP_LOGD(TAG, "smart12VHistory: UTC time not synced, skipping entry");
-    m_12v_alerted = false;
-    return;
-    }
-  struct tm t;
-  localtime_r(&ts, &t);
-  char buf[32];
-  strftime(buf, sizeof(buf)-8, "%Y-%m-%dT%H:%M:%S", &t);
-  snprintf(buf + 19, sizeof(buf) - 19, "=%.2fV", volt);
-  m_12v_undervolt_history.push_back(buf);
+  float volt  = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
+  float bms12v = mt_bms_voltages->GetElemValue(6);  // 12V BMS clamp 30
+  float usm12v = mt_evc_dcdc->GetElemValue(3);      // 12V USM voltage
+  m_12v_undervolt_history.push_back(volt);
   if (m_12v_undervolt_history.size() > 10)
     m_12v_undervolt_history.pop_front();
-  std::string hist_str;
-  float hist_vec[10];
+  float hist[10];
   size_t n = m_12v_undervolt_history.size();
-  for (size_t i=0; i<n; ++i)
-    {
-    if (i > 0) hist_str += '|';
-    hist_str += m_12v_undervolt_history[i];
-    hist_vec[i] = atof(strchr(m_12v_undervolt_history[i].c_str(), '=') + 1);
-    }
-  mt_12v_undervolt_history->SetValue(hist_str);
-  mt_12v_undervolt_history_vec->SetElemValues(0, n, hist_vec);
+  for (size_t i = 0; i < n; ++i)
+    hist[i] = m_12v_undervolt_history[i];
+  if (n > 0)
+    mt_12v_undervolt_history->SetElemValues(0, n, hist);
+  // Send data log XSQ-12V-undervoltagelog
+  // V1: <12Vvoltage>,<USM12V>,<BMS12V>
+  MyNotify.NotifyStringf("data", "xsq.12v.log.undervoltage", "XSQ-12V-undervoltagelog,1,%d,%.2f,%.2f,%.2f", 86400 * 30, volt, usm12v, bms12v);
 }
 
 void OvmsVehicleSmartEQ::smartOn()

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -125,16 +125,8 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
   if (m_obdii_745_tpms && IsOnEQ()) // full TPMS mode with individual pressure/temp/alert status for each wheel
     m_poll_vector.insert(m_poll_vector.end(), obdii_745_tpms_polls, endof_array(obdii_745_tpms_polls));
   
-  if (m_obdii_79b_cell) // 79b PIDs cell V/R/T values with configurable intervals
-    {
-    for (const auto& p79bcell : obdii_79b_cell_vrt_polls) 
-      {
-      OvmsPoller::poll_pid_t p79bcell_mod = p79bcell;
-      p79bcell_mod.polltime[2] = m_cfg_cell_interval_drv;
-      p79bcell_mod.polltime[3] = m_cfg_cell_interval_chg;
-      m_poll_vector.push_back(p79bcell_mod);
-      }
-    }
+  if (m_obdii_79b_cell) // 79b PIDs cell V/R/T values
+    m_poll_vector.insert(m_poll_vector.end(), obdii_79b_cell_vrt_polls, endof_array(obdii_79b_cell_vrt_polls));
     
   if (m_obdii_7e4_dcdc) // 7e4 PIDs DCDC 
     m_poll_vector.insert(m_poll_vector.end(), obdii_7e4_dcdc_polls, endof_array(obdii_7e4_dcdc_polls));

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
@@ -253,7 +253,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  Manufacturer ID:         %s\n", mt_bms_mfr_id->AsString().c_str());
 
   writer->puts("\n--- SOC Kernel Data (PID 0x08) ---");
-  writer->printf("  Open Circuit Voltage:    %.2f V\n", mt_bms_voltages->GetElemValue(5));
   writer->printf("  Real SOC (Min):          %.2f%%\n", mt_bms_soc_values->GetElemValue(2));
   writer->printf("  Real SOC (Max):          %.2f%%\n", mt_bms_soc_values->GetElemValue(3));
   writer->printf("  Kernel SOC:              %.2f%%\n", mt_bms_soc_values->GetElemValue(0));
@@ -261,6 +260,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  Initial Capacity:        %.2f Ah\n", mt_bms_cap->GetElemValue(1));
   writer->printf("  Estimated Capacity:      %.2f Ah\n", mt_bms_cap->GetElemValue(2));
   writer->printf("  Voltage State:           %s\n", mt_bms_voltage_state->AsString().c_str());
+  writer->printf("  OCV 12V Voltage:         %.2f V\n", mt_bms_voltages->GetElemValue(7));
   
   writer->puts("\n--- SOC Recalibration (PID 0x25) ---");
   writer->printf("  Recalibration State:     %s\n", mt_bms_soc_recal_state->AsString().c_str());
@@ -270,13 +270,14 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->puts("\n--- Battery State (PID 0x07) ---");
   writer->printf("  Cell Voltage Min:        %.3f V\n", mt_bms_voltages->GetElemValue(0));
   writer->printf("  Cell Voltage Max:        %.3f V\n", mt_bms_voltages->GetElemValue(1));
-  writer->printf("  Cell Voltage Mean:       %.3f V\n", mt_bms_voltages->GetElemValue(2));
-  writer->printf("  Link Voltage:            %.2f V\n", mt_bms_voltages->GetElemValue(3));
+  writer->printf("  Cell Voltage Mean:       %.3f V\n", mt_bms_voltages->GetElemValue(2));  
+  writer->printf("  Cell Voltage sum:        %.2f V\n", mt_bms_voltages->GetElemValue(3));
   writer->printf("  Pack Voltage:            %.2f V\n", mt_bms_voltages->GetElemValue(4));
   writer->printf("  Pack Current:            %.2f A\n", StdMetrics.ms_v_bat_current->AsFloat());
   writer->printf("  Pack Power:              %.2f kW\n", StdMetrics.ms_v_bat_power->AsFloat());
   writer->printf("  Contactor State:         %s\n", mt_bms_HVcontactStateTXT->AsString().c_str());
   writer->printf("  Vehicle Mode:            %s\n", mt_bms_EVmode_txt->AsString().c_str());
+  writer->printf("  Traction Link Voltage:   %.2f V\n", mt_bms_voltages->GetElemValue(5));
   writer->printf("  BMS 12V Voltage:         %.2f V\n", mt_bms_voltages->GetElemValue(6));
 
   writer->puts("\n--- EVC Data (0x7EC) ---");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_notify.cpp
@@ -260,7 +260,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandED4scan(int verbosity,
   writer->printf("  Initial Capacity:        %.2f Ah\n", mt_bms_cap->GetElemValue(1));
   writer->printf("  Estimated Capacity:      %.2f Ah\n", mt_bms_cap->GetElemValue(2));
   writer->printf("  Voltage State:           %s\n", mt_bms_voltage_state->AsString().c_str());
-  writer->printf("  OCV 12V Voltage:         %.2f V\n", mt_bms_voltages->GetElemValue(7));
+  writer->printf("  Open Circuit 12V:        %.2f V\n", mt_bms_voltages->GetElemValue(7));
   
   writer->puts("\n--- SOC Recalibration (PID 0x25) ---");
   writer->printf("  Recalibration State:     %s\n", mt_bms_soc_recal_state->AsString().c_str());

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -38,21 +38,21 @@
 static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,300,10,10 }, 0, ISOTP_STD },   // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,10,10,10 }, 0, ISOTP_STD },    // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,0,300,300 }, 0, ISOTP_STD },   // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,0,300,300 }, 0, ISOTP_STD },   // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,0,3600,0 }, 0, ISOTP_STD },    // Battery Health (SOH)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,298,33,33 }, 0, ISOTP_STD },   // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,294,294,94 }, 0, ISOTP_STD },  // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,0,298,298 }, 0, ISOTP_STD },   // SOC
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,0,0,98 }, 0, ISOTP_STD },      // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,0,6665,0 }, 0, ISOTP_STD },    // Battery Health (SOH)
 };
 
-//   -> HandleOBDpolling() will add the following PIDs with modified intervals m_cfg_cell_interval_drv/m_cfg_cell_interval_chg
+//   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,60,60,60 }, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,60,60,60 }, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,60,60,60 }, 0, ISOTP_STD },    // Battery Temperatures (27 sensors)    
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,0,303,103 }, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,0,3603,603 }, 0, ISOTP_STD },  // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,304,304,104 }, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
@@ -62,39 +62,39 @@ static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, { 0,0,60,0 }, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, { 0,0,60,0 }, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, { 0,0,293,0 }, 0, ISOTP_STD },        // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, { 0,0,293,0 }, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,8,0,8 }, 0, ISOTP_STD },    // Charging plug detected (B_PlugConnected_bcb_status_S)  
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,60,60,16 }, 0, ISOTP_STD }, // rqHV_Energy
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,300,60,0 }, 0, ISOTP_STD }, // Cabin blower command
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,9,0,9 }, 0, ISOTP_STD },       // Charging plug detected (B_PlugConnected_bcb_status_S)  
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,598,119,59 }, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,122,122,0 }, 0, ISOTP_STD },   // Cabin blower command
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,300,60,60 }, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,10,10,10 }, 0, ISOTP_STD },  // DCDC activation request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,300,30,30 }, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,300,15,15 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,300,20,20 }, 0, ISOTP_STD }, // 14V DCDC current measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,300,20,20 }, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,60,15,15 }, 0, ISOTP_STD },  // USM 14V voltage (CAN)
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,300,15,15 }, 0, ISOTP_STD }, // Battery voltage 14V
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,294,59,59 }, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,12,12,12 }, 0, ISOTP_STD },  // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,294,37,37 }, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,291,31,31 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,291,31,31 }, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,294,31,31 }, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,58,17,17 }, 0, ISOTP_STD },  // USM 14V voltage (CAN) - needed for ADC calculation
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,291,29,29 }, 0, ISOTP_STD }, // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,300,300,300 }, 0, ISOTP_STD },  // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,0,60,0 }, 0, ISOTP_STD },   // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,0,60,0 }, 0, ISOTP_STD },   // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,0,60,0 }, 0, ISOTP_STD },   // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,0,3600,0 }, 0, ISOTP_STD }, // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,0,3600,0 }, 0, ISOTP_STD }, // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,0,3600,0 }, 0, ISOTP_STD }, // maintenance level
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,906,906,906 }, 0, ISOTP_STD }, // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
@@ -107,28 +107,28 @@ static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, { 0,0,0,4 }, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_Max Current limitation
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_DC Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_HF Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, { 0,0,0,60 }, 0, ISOTP_STD }, // rqJB2AC_LF Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, { 0,0,0,11 }, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, { 0,0,0,303 }, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, { 0,0,0,72 }, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, { 0,0,0,304 }, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, { 0,0,0,305 }, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, { 0,0,0,306 }, 0, ISOTP_STD }, // rqJB2AC_DC Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, { 0,0,0,307 }, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, { 0,0,0,308 }, 0, ISOTP_STD }, // rqJB2AC_HF Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, { 0,0,0,309 }, 0, ISOTP_STD }, // rqJB2AC_LF Current
 };
 //   -> HandleOBDpolling() will add the following PIDs once m_static_ids_read is false and IsOnEQ() is true
 static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, { 0,3600,3600,0 }, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,3600,3600,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,3600,3600,0 }, 0, ISOTP_STD },    // Frame Traceability Information
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,3600,3600,0 }, 0, ISOTP_STD },    // req.VIN
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, { 0,6666,6666,0 }, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,6667,6667,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,6668,6668,0 }, 0, ISOTP_STD },    // Frame Traceability Information
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,6669,6669,0 }, 0, ISOTP_STD },    // req.VIN
 };

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -62,8 +62,8 @@ static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, { 0,0,293,0 }, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, { 0,0,293,0 }, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, { 0,0,152,0 }, 0, ISOTP_STD },        // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, { 0,0,154,0 }, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -101,7 +101,7 @@ static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, { 0,0,0,4 }, 0, ISOTP_STD },  // rqChargerAC
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, { 0,0,0,10 }, 0, ISOTP_STD },  // rqChargerAC
 };
 
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -39,7 +39,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
   float volt = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  float bms12v = mt_bms_voltages->AsFloat(6) + 0.3f;      // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
+  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;      // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
   float usm12v = mt_evc_dcdc->GetElemValue(3);            // 12V USM voltage
   if((volt > 6.0f && m_ref12V > 6.0f && m_ref12V-volt > m_alert12V) ||
      (m_can_active && bms12v > 6.0f && m_ref12V > 6.0f && m_ref12V-bms12v > m_alert12V) ||

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -189,6 +189,8 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
       {
       if (--m_ADCfactor_recalc_timer == 0) 
         {
+        m_check12vadc = false;            // disable further checks for 12V voltage difference
+        m_enable_calcADCfactor = false;   // disable further recalculation until next reboot        
         m_ADCfactor_recalc = false;
         m_ADCfactor_recalc_timer = 2;
         // calculate new ADC factor         

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -40,7 +40,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   // when 12V voltage is critically low, then switch to sleep mode immediately
   float volt = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
   float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;      // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
-  float usm12v = mt_evc_dcdc->GetElemValue(3);            // 12V USM voltage
+  float usm12v = mt_evc_dcdc->GetElemValue(3);                 // 12V USM voltage
   if((volt > 6.0f && m_ref12V > 6.0f && m_ref12V-volt > m_alert12V) ||
      (m_can_active && bms12v > 6.0f && m_ref12V > 6.0f && m_ref12V-bms12v > m_alert12V) ||
      (m_can_active && usm12v > 6.0f && m_ref12V > 6.0f && m_ref12V-usm12v > m_alert12V))
@@ -59,8 +59,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     else if (!m_12v_alerted) // alert only once when undervoltage is detected, to prevent log flooding
       {
       m_12v_alerted = true;  
-      smart12VHistory();
-      ESP_LOGD(TAG, "12V undervoltage History updated:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      smart12VHistory();     // log undervoltage event in history metric and send data log
       }
     }
   else if (m_12v_alerted)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -39,12 +39,16 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
   float volt = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  if(volt > 6.0f && m_ref12V > 0.0f && m_ref12V-volt > m_alert12V)
+  float bms12v = mt_bms_voltages->AsFloat(6) + 0.3f;      // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
+  float usm12v = mt_evc_dcdc->GetElemValue(3);            // 12V USM voltage
+  if((volt > 6.0f && m_ref12V > 6.0f && m_ref12V-volt > m_alert12V) ||
+     (m_can_active && bms12v > 6.0f && m_ref12V > 6.0f && m_ref12V-bms12v > m_alert12V) ||
+     (m_can_active && usm12v > 6.0f && m_ref12V > 6.0f && m_ref12V-usm12v > m_alert12V))
     {
     if(m_poll_state != POLLSTATE_OFF) // if not already in sleep mode, then switch to sleep mode immediately
       {      
       smartCoolDownPolling(60);
-      ESP_LOGW(TAG, "12V undervoltage detected: %.2fV (reference: %.2fV)", volt, m_ref12V);
+      ESP_LOGW(TAG, "12V undervoltage detected:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
       mt_poll_state->SetValue("Off (12V undervoltage)");
       }
     else if(m_cooldown_ticker <= 10) // if not already in cooldown, then restart 60sec. cooldown
@@ -56,12 +60,13 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       {
       m_12v_alerted = true;  
       smart12VHistory();
-      ESP_LOGD(TAG, "12V undervoltage History updated: %.2fV)", volt);
+      ESP_LOGD(TAG, "12V undervoltage History updated:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
       }
     }
   else if (m_12v_alerted)
     {
     m_12v_alerted = false; // reset alert flag when voltage is back to normal
+    ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
     }
 
   if (m_ddt4all_exec >= 1)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -533,14 +533,12 @@ void OvmsVehicleSmartEQ::WebCfgBattery(PageEntry_t& p, PageContext_t& c)
   std::string error;
   //  suffsoc          	Sufficient SOC [%] (Default: 0=disabled)
   //  suffrange        	Sufficient range [km] (Default: 0=disabled)
-  std::string suffrange, suffsoc, cell_interval_drv, cell_interval_chg;
+  std::string suffrange, suffsoc;
 
   if (c.method == "POST") {
     // process form submission:
     suffrange = c.getvar("suffrange");
     suffsoc   = c.getvar("suffsoc");
-    cell_interval_drv = c.getvar("cell_interval_drv");
-    cell_interval_chg = c.getvar("cell_interval_chg");
 
     // check:
     if (!suffrange.empty()) {
@@ -559,8 +557,6 @@ void OvmsVehicleSmartEQ::WebCfgBattery(PageEntry_t& p, PageContext_t& c)
       auto map = MyConfig.GetParamMap("xsq");
       map["suffrange"] = suffrange;
       map["suffsoc"] = suffsoc;
-      map["cell_interval_drv"] = cell_interval_drv;
-      map["cell_interval_chg"] = cell_interval_chg;
       MyConfig.SetParamMap("xsq", map);
 
       c.head(200);
@@ -579,8 +575,6 @@ void OvmsVehicleSmartEQ::WebCfgBattery(PageEntry_t& p, PageContext_t& c)
     // read configuration:
     suffrange = MyConfig.GetParamValue("xsq", "suffrange", "0");
     suffsoc   = MyConfig.GetParamValue("xsq", "suffsoc", "0");
-    cell_interval_drv = MyConfig.GetParamValue("xsq", "cell_interval_drv", "60");
-    cell_interval_chg = MyConfig.GetParamValue("xsq", "cell_interval_chg", "60");
 
     c.head(200);
   }
@@ -598,16 +592,6 @@ void OvmsVehicleSmartEQ::WebCfgBattery(PageEntry_t& p, PageContext_t& c)
   c.input_slider("Sufficient SOC", "suffsoc", 3, "%",-1, atof(suffsoc.c_str()), 80, 0, 100, 1,
     "<p>0=off. Notify/stop at this SOC</p>");
 
-  c.fieldset_end();
-  
-  c.fieldset_start("BMS Cell Monitoring");
-  c.input_slider("Update interval driving", "cell_interval_drv", 3, "s",-1, atof(cell_interval_drv.c_str()),
-    60, 0, 300, 1,
-    "<p>Default 60s, 0=off</p>");
-  c.input_slider("Update interval charging", "cell_interval_chg", 3, "s",-1, atof(cell_interval_chg.c_str()),
-    60, 0, 300, 1,
-    "<p>Default 60s, 0=off</p>");
-  
   c.fieldset_end();
 
   c.print("<hr>");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -121,9 +121,9 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   // EVC 12V values: Index 0=dcdc_volt_req, 1=dcdc_volt, 2=dcdc_power, 3=usm_volt, 4=batt_volt_can, 5=batt_volt_req, 6=dcdc_amps, 7=dcdc_load
   mt_evc_dcdc                   = MyMetrics.InitVector<float>("xsq.evc.12v.dcdc", SM_STALE_MID, nullptr, Other);
   mt_evc_dcdc->SetElemValue(7, 0.0f);           // Pre-allocate 8 entries
-  mt_evc_traceability           = MyMetrics.InitString("xsq.evc.traceability", SM_STALE_MAX, "");
+  mt_evc_traceability           = MyMetrics.InitString("xsq.evc.traceability", SM_STALE_NONE, "");
   mt_evc_plug_detected          = MyMetrics.InitBool("xsq.evc.plug.detected", SM_STALE_MIN, false);
-  mt_12v_trickle_charge_count   = MyMetrics.InitInt("xsq.12v.trickle.count", SM_STALE_MAX, 0, Other, true);
+  mt_12v_trickle_charge_count   = MyMetrics.InitInt("xsq.12v.trickle.count", SM_STALE_NONE, 0, Other, true);
   // 0x793 OBL charger metrics
   mt_obl_fastchg                = MyMetrics.InitBool("xsq.obl.fastchg", SM_STALE_MIN, false);
   mt_obl_main_volts             = MyMetrics.InitVector<float>("xsq.obl.volts", SM_STALE_HIGH, nullptr, Volts);
@@ -139,8 +139,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_obl_main_leakage_diag      = MyMetrics.InitString("xsq.obl.leakdiag", SM_STALE_MID, "", Other);
   // 0x7BB BMS metrics
   mt_bms_voltages               = MyMetrics.InitVector<float>("xsq.bms.voltages", SM_STALE_MID, nullptr, Volts);
-  mt_bms_voltages->SetElemValue(6, 0.0f);       // Pre-allocate: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor, [5]=cv_sum, [6]=12v_system
-  mt_bms_contactor_cycles       = MyMetrics.InitVector<int>("xsq.bms.contactor.cycles", SM_STALE_HIGH, nullptr, Other, true);
+  mt_bms_voltages->SetElemValue(8, 0.0f);       // Pre-allocate: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=cv_sum, [4]=contactor, [5]=traction link 12V, [6]=12v_bms_clamp30, [7]=ocv_12V
+  mt_bms_contactor_cycles       = MyMetrics.InitVector<int>("xsq.bms.contactor.cycles", SM_STALE_NONE, nullptr, Other, true);
   if(mt_bms_contactor_cycles->GetSize() < 5)
     mt_bms_contactor_cycles->SetElemValue(4, 0);  // Pre-allocate: [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
   mt_bms_soc_values             = MyMetrics.InitVector<float>("xsq.bms.soc.values", SM_STALE_MID, nullptr, Percentage);
@@ -162,14 +162,14 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_fusi_mode_txt          = MyMetrics.InitString("xsq.bms.fusi",SM_STALE_MID, "", Other);
   mt_bms_safety_mode_txt        = MyMetrics.InitString("xsq.bms.safety",SM_STALE_MID, "", Other);
   // BMS production data (PID 0x90)
-  mt_bms_prod_data              = MyMetrics.InitString("xsq.bms.prod.data", SM_STALE_MAX, "");
+  mt_bms_prod_data              = MyMetrics.InitString("xsq.bms.prod.data", SM_STALE_NONE, "");
   // BMS identification data (PID 0x80)
-  mt_bms_ident_data             = MyMetrics.InitString("xsq.bms.id.ident.data", SM_STALE_MAX, "",  Other);
-  mt_bms_part_no                = MyMetrics.InitString("xsq.bms.id.part.no", SM_STALE_MAX, "",  Other);
-  mt_bms_hw_version             = MyMetrics.InitString("xsq.bms.id.hw.version", SM_STALE_MAX, "",  Other);
-  mt_bms_sw_version             = MyMetrics.InitString("xsq.bms.id.sw.version", SM_STALE_MAX, "",  Other);
-  mt_bms_mfr_id                 = MyMetrics.InitInt("xsq.bms.id.mfr", SM_STALE_MAX, 0,   Other);
-  mt_bms_basic_parts            = MyMetrics.InitString("xsq.bms.id.basic.parts", SM_STALE_MAX, "",  Other);
+  mt_bms_ident_data             = MyMetrics.InitString("xsq.bms.id.ident.data", SM_STALE_NONE, "",  Other);
+  mt_bms_part_no                = MyMetrics.InitString("xsq.bms.id.part.no", SM_STALE_NONE, "",  Other);
+  mt_bms_hw_version             = MyMetrics.InitString("xsq.bms.id.hw.version", SM_STALE_NONE, "",  Other);
+  mt_bms_sw_version             = MyMetrics.InitString("xsq.bms.id.sw.version", SM_STALE_NONE, "",  Other);
+  mt_bms_mfr_id                 = MyMetrics.InitInt("xsq.bms.id.mfr", SM_STALE_NONE, 0,   Other);
+  mt_bms_basic_parts            = MyMetrics.InitString("xsq.bms.id.basic.parts", SM_STALE_NONE, "",  Other);
 
   // Start CAN bus in CAN_MODE_ACTIVE mode
   RegisterCanBus(1, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);
@@ -256,8 +256,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // Note: GetValueBool/Int/Float treat empty string as "not set" and return the default.
   OvmsConfigParam* map = MyConfig.CachedParam("xsq");
   
-  int cell_interval_drv   = 60;
-  int cell_interval_chg   = 60;
   bool stateWrite         = m_enable_write;
   bool obdii_743          = true;
   bool obdii_745          = true;
@@ -299,8 +297,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     m_cfg_preset_version   = map->GetValueInt("cfg.preset.ver", 0);
     m_suffsoc              = map->GetValueInt("suffsoc", 0);
     m_suffrange            = map->GetValueInt("suffrange", 0);
-    cell_interval_drv      = map->GetValueInt("cell_interval_drv", 60);
-    cell_interval_chg      = map->GetValueInt("cell_interval_chg", 60);
     m_above_cycles         = map->GetValueInt("bms.alert.above.cycles", 50000);
     m_contactor_1h_limit   = map->GetValueInt("bms.contactor.1h.limit", 8);
     
@@ -339,8 +335,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     }
 
   bool do_modify_poll = (
-    (cell_interval_drv != m_cfg_cell_interval_drv) ||
-    (cell_interval_chg != m_cfg_cell_interval_chg) ||
     (obdii_79b != m_obdii_79b) ||
     (obdii_79b_cell != m_obdii_79b_cell) ||
     (obdii_743 != m_obdii_743) ||
@@ -349,9 +343,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     (obdii_7e4 != m_obdii_7e4) ||
     (obdii_7e4_dcdc != m_obdii_7e4_dcdc)
   );
-  
-  m_cfg_cell_interval_drv = cell_interval_drv;
-  m_cfg_cell_interval_chg = cell_interval_chg;
+
   m_obdii_79b = obdii_79b;
   m_obdii_79b_cell = obdii_79b_cell;
   m_obdii_743 = obdii_743;
@@ -482,7 +474,7 @@ void OvmsVehicleSmartEQ::CalculateRangeSpeed()
   {
   float bat_power  = StdMetrics.ms_v_bat_power->AsFloat();      // kW (pos=discharge, neg=charge)
   float cap_full   = mt_bms_cap->GetElemValue(0);               // Ah - full usable capacity
-  float v_link     = mt_bms_voltages->GetElemValue(3);          // V  - HV link voltage
+  float v_link     = mt_bms_voltages->GetElemValue(5);          // V  - HV link voltage
   float range_full = StdMetrics.ms_v_bat_range_full->AsFloat(); // km at 100% SOC
 
   if (cap_full <= 0 || v_link <= 0 || range_full <= 0)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -64,8 +64,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
 
   mt_canbyte                    = MyMetrics.InitString("xsq.ddt4all.canbyte", SM_STALE_MAX, "", Other);
   mt_adc_factor                 = MyMetrics.InitFloat("xsq.adc.factor", SM_STALE_MAX, 0, Other);
-  mt_adc_factor->SetValue(MyConfig.GetParamValueFloat("system.adc", "factor12v", 0.0f));  
-  mt_adc_factor_history         = MyMetrics.InitVector<float>("xsq.adc.factor.history", SM_STALE_MAX, nullptr, Other,true);
+  mt_adc_factor->SetValue(MyConfig.GetParamValueFloat("system.adc", "factor12v", 0.0f));
+  mt_adc_factor_history         = MyMetrics.InitVector<float>("xsq.adc.factor.history", SM_STALE_MAX, nullptr, Other);
   mt_12v_undervolt_history      = MyMetrics.InitVector<float>("xsq.12v.undervolt.history", SM_STALE_MAX, nullptr, Other);
   mt_poll_state                 = MyMetrics.InitString("xsq.poll.state", SM_STALE_MAX, "UNKNOWN", Other);  
   mt_ed4_values                 = MyMetrics.InitInt("xsq.ed4.values", SM_STALE_MAX, 10);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -66,7 +66,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_adc_factor                 = MyMetrics.InitFloat("xsq.adc.factor", SM_STALE_MAX, 0, Other);
   mt_adc_factor->SetValue(MyConfig.GetParamValueFloat("system.adc", "factor12v", 0.0f));  
   mt_adc_factor_history         = MyMetrics.InitVector<float>("xsq.adc.factor.history", SM_STALE_MAX, nullptr, Other,true);
-  mt_12v_undervolt_history      = MyMetrics.InitVector<float>("xsq.12v.undervolt.history.vec", SM_STALE_MAX, nullptr, Other,true);
+  mt_12v_undervolt_history      = MyMetrics.InitVector<float>("xsq.12v.undervolt.history", SM_STALE_MAX, nullptr, Other);
   mt_poll_state                 = MyMetrics.InitString("xsq.poll.state", SM_STALE_MAX, "UNKNOWN", Other);  
   mt_ed4_values                 = MyMetrics.InitInt("xsq.ed4.values", SM_STALE_MAX, 10);
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -66,8 +66,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_adc_factor                 = MyMetrics.InitFloat("xsq.adc.factor", SM_STALE_MAX, 0, Other);
   mt_adc_factor->SetValue(MyConfig.GetParamValueFloat("system.adc", "factor12v", 0.0f));  
   mt_adc_factor_history         = MyMetrics.InitVector<float>("xsq.adc.factor.history", SM_STALE_MAX, nullptr, Other,true);
-  mt_12v_undervolt_history      = MyMetrics.InitString("xsq.12v.undervolt.history", SM_STALE_MAX, "", Other);
-  mt_12v_undervolt_history_vec  = MyMetrics.InitVector<float>("xsq.12v.undervolt.history.vec", SM_STALE_MAX, nullptr, Other,true);
+  mt_12v_undervolt_history      = MyMetrics.InitVector<float>("xsq.12v.undervolt.history.vec", SM_STALE_MAX, nullptr, Other,true);
   mt_poll_state                 = MyMetrics.InitString("xsq.poll.state", SM_STALE_MAX, "UNKNOWN", Other);  
   mt_ed4_values                 = MyMetrics.InitInt("xsq.ed4.values", SM_STALE_MAX, 10);
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -101,7 +101,9 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_pos_odometer_trip          = MyMetrics.InitFloat("xsq.odometer.trip", SM_STALE_MID, 0, Kilometers);
 
   mt_tpms_low_batt               = MyMetrics.InitVector<short> ("xsq.tpms.lowbatt", SM_STALE_MID, nullptr, Other);
-  mt_tpms_missing_tx             = MyMetrics.InitVector<short> ("xsq.tpms.missing", SM_STALE_MID, nullptr, Other);
+  mt_tpms_missing_tx             = MyMetrics.InitVector<short> ("xsq.tpms.missing", SM_STALE_MID, nullptr, Other);  
+  mt_tpms_low_batt->SetElemValue(3, 0);
+  mt_tpms_missing_tx->SetElemValue(3, 0);
   // Pre-allocate TPMS vectors for 4 wheels to avoid heap fragmentation
   if(StdMetrics.ms_v_tpms_pressure->GetSize() < 4)
     {
@@ -109,8 +111,20 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
     StdMetrics.ms_v_tpms_pressure->SetElemValue(3, 0.0f);
     StdMetrics.ms_v_tpms_alert->SetElemValue(3, 0);
     }
-  mt_tpms_low_batt->SetElemValue(3, 0);
-  mt_tpms_missing_tx->SetElemValue(3, 0);
+  if(StdMetrics.ms_v_tpms_pressure->GetSize() == 4)
+    {
+    for(int i=0; i<4; i++)
+      {
+      m_tpms_pressure[i] = StdMetrics.ms_v_tpms_pressure->GetElemValue(i);
+      }
+    }
+  if(StdMetrics.ms_v_tpms_temp->GetSize() == 4)
+    {
+    for(int i=0; i<4; i++)
+      {
+      m_tpms_temperature[i] = StdMetrics.ms_v_tpms_temp->GetElemValue(i);
+      }
+    }
 
   mt_dummy_pressure              = MyMetrics.InitFloat("xsq.tpms.dummy", SM_STALE_NONE, 210, kPa);  // Dummy pressure for TPMS alert testing
   // 0x765 BCM metrics

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -333,8 +333,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     OvmsMetricString        *mt_canbyte;                // DDT4all canbyte
     OvmsMetricFloat         *mt_adc_factor;             // calculated ADC factor for 12V measurement
     OvmsMetricVector<float> *mt_adc_factor_history;     // last 10 calculated ADC factors for 12V measurement
-    OvmsMetricString        *mt_12v_undervolt_history;  // last 10 12V undervolt measurements ("YYYY-MM-DDTHH:MM:SS=XX.XXV|...")
-    OvmsMetricVector<float> *mt_12v_undervolt_history_vec;  // last 10 12V undervolt measurements as vector for graphing
+    OvmsMetricVector<float> *mt_12v_undervolt_history;  // last 10 12V undervolt measurements as vector for graphing
     OvmsMetricString        *mt_poll_state;             // Poller state
     OvmsMetricInt           *mt_ed4_values;             // ED4scan: number of cells to show
     OvmsMetricString        *mt_reset_time;             // Time since last reset (hh:mm)
@@ -466,8 +465,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     float m_pressure_warning = 40.0f;       // Pressure Warning
     float m_pressure_alert = 70.0f;         // Pressure Alert
     std::string m_hl_canbyte = "";          // canbyte variable for unv
-    std::deque<float> m_adc_factor_history; // ring buffer (max 10) for ADC factors
-    std::deque<std::string> m_12v_undervolt_history; // ring buffer (max 10) for 12V undervolt history: "YYYY-MM-DDTHH:MM:SS=XX.XXV"
+    std::deque<float> m_adc_factor_history;     // ring buffer (max 10) for ADC factors
+    std::deque<float> m_12v_undervolt_history;  // ring buffer (max 10) for 12V undervoltage measurements
     float m_ref12V = 12.6f;                 // reference 12V (12.6V)
     float m_alert12V = 0.8f;                // alert threshold 12V (0.8V)
     bool m_12v_alerted = false;             // 12V undervolt alert triggered

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -385,7 +385,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     OvmsMetricInt           *mt_12v_trickle_charge_count;    // Number of 12V trickle activations in the last 24h
 
     // --- Custom metrics: BMS ---
-    OvmsMetricVector<float> *mt_bms_voltages;                // Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=cv_sum, [4]=contactor, [5]=traction link 12V, [6]=12v_bms_clamp30, [7]=ocv_12V
+    OvmsMetricVector<float> *mt_bms_voltages;                // Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=cv_sum, [4]=contactor, [5]=traction link 12V, [6]=12v_bms_clamp30, [7]=Open Circuit 12V
     OvmsMetricVector<int>   *mt_bms_contactor_cycles;        // [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
     OvmsMetricVector<float> *mt_bms_soc_values;              // SOC values: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
     OvmsMetricString        *mt_bms_soc_recal_state;         // SOC Recalibration State

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -33,8 +33,14 @@
 #ifndef __VEHICLE_SMARTEQ_H__
 #define __VEHICLE_SMARTEQ_H__
 
-#define VERSION "2.1.2"
-#define PRESET_VERSION 20260621 // Configuration preset version
+
+// --- Constants ---
+#define VERSION "2.2.0"
+#define PRESET_VERSION 20260623 // Configuration preset version
+#define DEFAULT_BATTERY_CAPACITY 16700 // <- net 16700 Wh, gross 17600 Wh
+#define MAX_POLL_DATA_LEN 126
+#define CELLCOUNT 96
+#define SQ_CANDATA_TIMEOUT 10   // seconds until car goes to sleep without CAN activity
 
 #include "ovms_log.h"
 
@@ -314,12 +320,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void PollReply_obd_mt_km(const char* data, uint16_t reply_len);
     void PollReply_obd_mt_level(const char* data, uint16_t reply_len);
 
-    // --- Constants ---
-    #define DEFAULT_BATTERY_CAPACITY 16700 // <- net 16700 Wh, gross 17600 Wh
-    #define MAX_POLL_DATA_LEN 126
-    #define CELLCOUNT 96
-    #define SQ_CANDATA_TIMEOUT 10 // seconds until car goes to sleep without CAN activity
-
     // --- Internal buffer ---
     std::string   m_rxbuf;
 
@@ -385,7 +385,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     OvmsMetricInt           *mt_12v_trickle_charge_count;    // Number of 12V trickle activations in the last 24h
 
     // --- Custom metrics: BMS ---
-    OvmsMetricVector<float> *mt_bms_voltages;                // Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=link, [4]=contactor
+    OvmsMetricVector<float> *mt_bms_voltages;                // Voltages: [0]=cv_min, [1]=cv_max, [2]=cv_mean, [3]=cv_sum, [4]=contactor, [5]=traction link 12V, [6]=12v_bms_clamp30, [7]=ocv_12V
     OvmsMetricVector<int>   *mt_bms_contactor_cycles;        // [0]=max, [1]=now, [2]=consumed, [3]=diff, [4]=1h_count
     OvmsMetricVector<float> *mt_bms_soc_values;              // SOC values: [0]=kernel, [1]=real, [2]=min, [3]=max, [4]=display
     OvmsMetricString        *mt_bms_soc_recal_state;         // SOC Recalibration State
@@ -499,8 +499,6 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
 
     // --- Poll timing / list ---
     bool m_static_ids_read = false;         // flag to track if static IDs have been read at least once
-    int m_cfg_cell_interval_drv = 60;       // poll interval while driving, default 60 sec.
-    int m_cfg_cell_interval_chg = 60;       // poll interval while charging, default 60 sec.
     poll_vector_t m_poll_vector;            // List of PIDs to poll
     bool m_poll_cooldown = true;            // flag to trigger cooldown timer for poll state change
     int m_cooldown_ticker = 15;             // cooldown timer for poll state change


### PR DESCRIPTION
Rework BMS voltage metric layout and related logic, and tune OBD/CAN polling. Changes include:

- Reorganized xsq.bms.voltages vector to include: [0]=cell_min, [1]=cell_max, [2]=cell_mean, [3]=cell_sum (HV), [4]=contactor, [5]=traction link 12V, [6]=12v_bms_clamp30, [7]=ocv_12V and pre-allocate the new size.
- Updated all code sites that read/write mt_bms_voltages (poll replies, ED4scan output, CalculateRangeSpeed, ticker checks) to use the new indices, and added OCV 12V reporting.
- Improved 12V undervoltage detection by considering module, BMS clamp and USM 12V values and enhanced logging/messages.
- Adjusted metric staleness for several metrics (traceability, production/ID strings, contactor cycles, trickle count) to SM_STALE_NONE where appropriate.
- Added/centralized constants (VERSION bump to 2.2.0, PRESET_VERSION bump, DEFAULT_BATTERY_CAPACITY, MAX_POLL_DATA_LEN, CELLCOUNT, SQ_CANDATA_TIMEOUT) in header and removed duplicate defines.
- Tuned many poll timing values across obdii/OBDIIEXTENDED PID tables to different intervals and removed the previous per-cell-interval modification logic (removed UI/config for cell_interval_drv/chg and simplified PID insertion).
- Minor web UI cleanup: removed cell-interval fields from battery config form.

These changes align metric layout, improve 12V handling, and refine polling cadence for reliability and consistency.