### PR TITLE
Fiat eDoblo: add BMS pack temperature polling

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,7 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Fiat e-Doblo: add BMS polling for average cell voltage and min/max/average battery pack temperatures.
 - smart EQ:
     As soon as the 12V trickle charge begins, a timestamp is generated and stored in `m_12v_trickle_charge_times`.
     The counted value is set in `xsq.12v.trickle.count`.

--- a/vehicle/OVMS.V3/components/vehicle_fiatedoblo/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_fiatedoblo/docs/index.rst
@@ -21,8 +21,8 @@ SOC Display                 Yes (incl. battery capacity)
 Range Display               tba
 GPS Location                Yes (from GPS module)
 Speed Display               tba
-Temperature Display         tba
-BMS v+t Display             tba
+Temperature Display         Partial
+BMS v+t Display             Partial
 TPMS Display                tba
 Charge Status Display       tba
 Charge Interruption Alerts  tba
@@ -30,5 +30,5 @@ Charge Control              tba
 Cabin Pre-heat/cool Control tba
 Lock/Unlock Vehicle         tba
 Valet Mode Control          ??
-Others                      12V battery, SoH, HV Battery voltage, odometer, front+read doors and trunk open status, footbrake (only pressed yes/no status), handbrake, VIN, battery current (+power), onboard charger temp, DC-DC temperature
+Others                      12V battery, SoH, HV Battery voltage, odometer, front+read doors and trunk open status, footbrake (only pressed yes/no status), handbrake, VIN, battery current (+power), min/max/avg cell voltage, min/max/avg pack temperature, onboard charger temp, DC-DC temperature
 =========================== ==============

--- a/vehicle/OVMS.V3/components/vehicle_fiatedoblo/src/vehicle_fiatedoblo.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_fiatedoblo/src/vehicle_fiatedoblo.cpp
@@ -51,6 +51,10 @@ static const OvmsPoller::poll_pid_t vehicle_ftdo_polls[]
     { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd816, {  0,  5,   1, 999 }, 0, ISOTP_STD }, // Battery current
     { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd86f, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // min cell voltage (mV)
     { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd870, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // max cell voltage (mV)
+    { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd43d, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // avg cell voltage (mV)
+    { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd87d, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // min battery pack temperature (°C + 40)
+    { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd817, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // max battery pack temperature (°C + 40)
+    { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd877, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // avg battery pack temperature (°C + 40)
     // { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd410, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // SOC calibrated (/512 -> %) - not used, as the CAN frame 0x3a8 is also transmitting the value
     //                                                  0xd440 are single cell details, we don't care about them for now...
     // { 0x6b4, 0x694, VEHICLE_POLL_TYPE_READDATA,      0xd810, {  0,  30,   1, 999 }, 0, ISOTP_STD }, // SOC, not used, using calibrated one
@@ -358,12 +362,13 @@ void OvmsVehicleFiatEDoblo::UpdatePower()
  */
 void OvmsVehicleFiatEDoblo::IncomingBatteryPoll(const OvmsPoller::poll_job_t &job, uint8_t* data, uint8_t length)
 {
-  int value2 = (int)((uint16_t)data[0] << 8) + data[1];
+  int value2;
   float kwh;
   float soh;
   
   switch (job.pid) {
   case 0xd815: // bat voltage
+    value2 = (int)((uint16_t)data[0] << 8) + data[1];
     StandardMetrics.ms_v_bat_voltage->SetValue((float)value2 / 16.0);
     UpdatePower();
     break;
@@ -385,14 +390,34 @@ void OvmsVehicleFiatEDoblo::IncomingBatteryPoll(const OvmsPoller::poll_job_t &jo
     break;
 
   case 0xd86f: // min cell voltage ok
+    value2 = (int)((uint16_t)data[0] << 8) + data[1];
     StandardMetrics.ms_v_bat_pack_vmin->SetValue(value2 / 1000.0);
     break;
     
   case 0xd870: // max cell voltage ok
+    value2 = (int)((uint16_t)data[0] << 8) + data[1];
     StandardMetrics.ms_v_bat_pack_vmax->SetValue(value2 / 1000.0);      
     break;
 
+  case 0xd43d: // average cell voltage
+    value2 = (int)((uint16_t)data[0] << 8) + data[1];
+    StandardMetrics.ms_v_bat_pack_vavg->SetValue(value2 / 1000.0);
+    break;
+
+  case 0xd87d: // min battery pack temperature
+    StandardMetrics.ms_v_bat_pack_tmin->SetValue((int)data[0] - 40);
+    break;
+
+  case 0xd817: // max battery pack temperature
+    StandardMetrics.ms_v_bat_pack_tmax->SetValue((int)data[0] - 40);
+    break;
+
+  case 0xd877: // average battery pack temperature
+    StandardMetrics.ms_v_bat_pack_tavg->SetValue((int)data[0] - 40);
+    break;
+
   case 0xd865: // kWh
+    value2 = (int)((uint16_t)data[0] << 8) + data[1];
     kwh = (float)value2 / 64.0;
     StandardMetrics.ms_v_bat_capacity->SetValue(kwh);
     break;


### PR DESCRIPTION
## Problem

The FTDO profile already polls BMS min/max cell voltage, HV voltage/current, SOH, and available energy, but standard BMS pack temperature metrics and average cell voltage remain empty.

## Reproduction / observation

On the current FTDO vehicle profile, the following standard metrics are present but unset:

```text
v.b.p.temp.avg
v.b.p.temp.max
v.b.p.temp.min
v.b.p.voltage.avg
```

A read-only UDS scan against the e-Berlingo BMS while `v.e.on = yes` showed the BMS supports these identifiers via `0x6b4 -> 0x694`, UDS service `0x22`:

```text
D817 highest_temperature len=1 data=40  -> 24°C
D87D lowest_temperature  len=1 data=3f  -> 23°C
D877 average_temperature len=1 data=3f  -> 23°C
D43D avg_cell_voltage    len=2 data=0f56 -> 3.926V
```

CAN status remained clean after polling: no RX/TX errors, no overflows, no failed TX frames.

## Root cause / code path

FTDO BMS diagnostic polling is defined in `vehicle_ftdo_polls` and decoded in `OvmsVehicleFiatEDoblo::IncomingBatteryPoll()`. The relevant BMS DIDs were simply not included/decoded yet.

## Fix

Add BMS polling and decoding for:

- `0xd43d` -> `v.b.p.voltage.avg`
- `0xd87d` -> `v.b.p.temp.min`
- `0xd817` -> `v.b.p.temp.max`
- `0xd877` -> `v.b.p.temp.avg`

Also update FTDO docs and change history.

## Validation performed

- Runtime read-only UDS validation on Citroën e-Berlingo / FTDO-compatible vehicle with `v.e.on = yes`.
- Confirmed target metrics were empty before implementation.
- Built firmware from clean `origin/master` branch:

```sh
cd vehicle/OVMS.V3
source ~/.espressif/ovms-idf-v3.3-env.sh
make BATCH_BUILD=1 defconfig SDKCONFIG_DEFAULTS=support/sdkconfig.default.hw31
make BATCH_BUILD=1 -j$(sysctl -n hw.ncpu)
```
