### PR TITLE
Fiat eDoblo: detect charge pilot and charging

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,7 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- Fiat e-Doblo: add CAN based charge pilot and active charging detection.
 - smart EQ:
     As soon as the 12V trickle charge begins, a timestamp is generated and stored in `m_12v_trickle_charge_times`.
     The counted value is set in `xsq.12v.trickle.count`.

--- a/vehicle/OVMS.V3/components/vehicle_fiatedoblo/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_fiatedoblo/docs/index.rst
@@ -24,11 +24,11 @@ Speed Display               tba
 Temperature Display         tba
 BMS v+t Display             tba
 TPMS Display                tba
-Charge Status Display       tba
+Charge Status Display       Partial
 Charge Interruption Alerts  tba
 Charge Control              tba
 Cabin Pre-heat/cool Control tba
 Lock/Unlock Vehicle         tba
 Valet Mode Control          ??
-Others                      12V battery, SoH, HV Battery voltage, odometer, front+read doors and trunk open status, footbrake (only pressed yes/no status), handbrake, VIN, battery current (+power), onboard charger temp, DC-DC temperature
+Others                      12V battery, SoH, HV Battery voltage, odometer, front+read doors and trunk open status, footbrake (only pressed yes/no status), handbrake, VIN, battery current (+power), charge pilot, charging status, onboard charger temp, DC-DC temperature
 =========================== ==============

--- a/vehicle/OVMS.V3/components/vehicle_fiatedoblo/src/vehicle_fiatedoblo.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_fiatedoblo/src/vehicle_fiatedoblo.cpp
@@ -172,12 +172,6 @@ void OvmsVehicleFiatEDoblo::IncomingFrameCan1(CAN_frame_t* p_frame)
       if(d[1] != 0x06)
         {
           
-          if(newSoC > StandardMetrics.ms_v_bat_soc->AsFloat())
-            {
-              PollState_Charging(); // until we find the signal with the charging status we use the indication of increasing SoC, even though it might be wrong during recuperation
-              StandardMetrics.ms_v_charge_inprogress->SetValue(true);
-              ESP_LOGD(TAG, "charging started SoC: %f (0x%2x 0x%2x 0x%2x 0x%2x  0x%2x 0x%2x 0x%2x 0x%2x)", newSoC, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);            
-            }
           if(newSoC < 1)
             {
               ESP_LOGW(TAG, "received small SoC: %f (0x%2x 0x%2x 0x%2x 0x%2x  0x%2x 0x%2x 0x%2x 0x%2x)", newSoC, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
@@ -230,15 +224,12 @@ void OvmsVehicleFiatEDoblo::IncomingFrameCan1(CAN_frame_t* p_frame)
     break;
   case 0x4a2:
     {
-      // not fully correct, as bit 6 in byte 1 reflects the connection status (0x40 for unplugged, 0x00 for type2 connected, but maybe close enough)
-      if(d[1] & 0x40)
-        {
-          StandardMetrics.ms_v_door_chargeport->SetValue(false);
-        }
-      else
-        {
-          StandardMetrics.ms_v_door_chargeport->SetValue(true);
-        }                                                         
+      // Observed on e-Berlingo: byte 1 == 0x00 while the EVSE pilot is available,
+      // 0x80 with no pilot / wallbox stopped, 0x40 transiently while unplugging.
+      bool pilot = ((d[1] & 0xc0) == 0x00);
+      StandardMetrics.ms_v_charge_pilot->SetValue(pilot);
+      if (!pilot)
+        StandardMetrics.ms_v_charge_inprogress->SetValue(false);
     }
     break;
   case 0x412:
@@ -259,7 +250,6 @@ void OvmsVehicleFiatEDoblo::IncomingFrameCan1(CAN_frame_t* p_frame)
       StandardMetrics.ms_v_env_footbrake->SetValue(((d[0] & 0x20) > 0) ? 100.0 : 0.0); // we have in this bit only a binary footbrake status, no details.
 
       /* TODO:
-         StandardMetrics.ms_v_charge_pilot->SetValue(d[1] & 0x08);
          StandardMetrics.ms_v_env_locked->SetValue(d[2] & 0x08);
          StandardMetrics.ms_v_env_valet->SetValue(d[2] & 0x10);
          StandardMetrics.ms_v_env_headlights->SetValue(d[2] & 0x20);
@@ -274,7 +264,17 @@ void OvmsVehicleFiatEDoblo::IncomingFrameCan1(CAN_frame_t* p_frame)
     break;
   case 0x5c3:
     {
-      // Byte 2 could be related to the charge current in bits 0011 1100
+      // Active AC charging has been observed with byte 0 == 0xd4/0xd5 while pilot is present.
+      // Stopped / idle states have byte 0 == 0x00.
+      if ((d[0] == 0xd4 || d[0] == 0xd5) && StandardMetrics.ms_v_charge_pilot->AsBool())
+        {
+          PollState_Charging();
+          StandardMetrics.ms_v_charge_inprogress->SetValue(true);
+        }
+      else if (d[0] == 0x00)
+        {
+          StandardMetrics.ms_v_charge_inprogress->SetValue(false);
+        }
       break;
     }
   }


### PR DESCRIPTION
## Problem

The FTDO profile currently derives `v.c.charging` from increasing SoC. Runtime captures show this can leave charging true after charging has stopped and can be triggered by SoC/status changes unrelated to active charging. `v.c.pilot` is not filled.

## Reproduction / observation

Read-only passive CAN captures were taken on a Citroën e-Berlingo / FTDO-compatible vehicle for these states:

- cable unplugged, charge port open
- cable plugged, wallbox available, not charging
- active AC charging
- wallbox stopped while cable remained connected
- cable unplugged after wallbox stop

Observed stable patterns:

```text
State                                  0x4A2             0x5C3
unplugged / no pilot                   mostly 00 80      00 00 03 20 ...
plugged, EVSE pilot available          mostly 00 00      00 00 03 20 ...
active charging                        00 00             d4/d5 ... dynamic
wallbox stopped, cable still connected 00 80             00 00 03 25 ...
```

This shows `0x4A2` byte 1 indicates EVSE pilot availability, not simply the physical cable latch, and `0x5C3` byte 0 distinguishes active AC charging from stopped/idle states.

## Root cause / code path

`OvmsVehicleFiatEDoblo::IncomingFrameCan1()` used the SoC frame `0x3a8` as a charging heuristic and did not populate `v.c.pilot`. The relevant passive CAN frames are already handled in the same function (`0x4a2`, `0x5c3`), so this is the correct place to decode these metrics.

## Fix

- Set `v.c.pilot` from `0x4a2` byte 1:
  - pilot present when high status bits are clear (`(byte1 & 0xc0) == 0`)
  - no pilot for observed `0x80` and transient `0x40`
- Set `v.c.charging` from `0x5c3`:
  - true for observed active charging byte 0 `0xd4` / `0xd5` while pilot is present
  - false for observed stopped/idle byte 0 `0x00`
- Remove the SoC-increase heuristic for `v.c.charging`.
- No `v.c.state` / `v.c.substate` mapping is added in this PR.

## Validation performed

- Passive runtime captures across the states above, saved to SD card and analyzed locally.
- Built firmware from clean `origin/master` branch:

```sh
cd vehicle/OVMS.V3
source ~/.espressif/ovms-idf-v3.3-env.sh
make BATCH_BUILD=1 -j$(sysctl -n hw.ncpu)
```
