### PR TITLE
smartEQ : Filter invalid telemetry spikes

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -118,8 +118,10 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       if (raw_temp != 0x7F) 
         {
         can_bat_temp = _temp;
-        }      
-      can_bat_voltage = (float)((CAN_UINT(3) >> 5) & 0x3FF) / 2.0f;
+        }
+      float _volt = (float)((CAN_UINT(3) >> 5) & 0x3FF) / 2.0f;
+      can_bat_voltage = _volt < 450.0f ? _volt : 0.0f; // ignore invalid voltage reading > 450V
+      can_bat_voltage = 
       can_charge_climit = (c >> 20) & 0x3Fu;        
       break;
       }
@@ -130,8 +132,9 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
     case 0x5D7: // Speed, ODO
       {
       REQ_DLC(6);
-      // Apply scaling 
-      can_speed = (float)CAN_UINT(0) / 100.0f;
+      // Apply scaling
+      float _speed = (float)CAN_UINT(0) / 100.0f;
+      can_speed = _speed < 200.0f ? _speed : 0.0f; // ignore invalid speed reading > 200km/h  
       can_odometer = (float)(CAN_UINT32(2)>>4) / 100.0f;
       can_odometer_trip = (float)(CAN_UINT(4)>>4) / 100.0f;
       break;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -113,15 +113,12 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       {
       REQ_DLC(5);
       uint8_t raw_temp = (c >> 13) & 0x7Fu;
-      float _temp = (float)raw_temp - 40.0f;      
-      // Ignore invalid sensor reading (0x7F = 127 → 87°C after offset)
-      if (raw_temp != 0x7F) 
-        {
-        can_bat_temp = _temp;
-        }
+      float _temp = (float)raw_temp - 40.0f;
+      if (_temp < 85.0f)
+        can_bat_temp = _temp;    // Ignore invalid sensor reading
       float _volt = (float)((CAN_UINT(3) >> 5) & 0x3FF) / 2.0f;
-      can_bat_voltage = _volt < 450.0f ? _volt : 0.0f; // ignore invalid voltage reading > 450V
-      can_bat_voltage = 
+      if (_volt < 450.0f) 
+        can_bat_voltage = _volt; // ignore invalid voltage reading > 450V
       can_charge_climit = (c >> 20) & 0x3Fu;        
       break;
       }
@@ -134,7 +131,8 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       REQ_DLC(6);
       // Apply scaling
       float _speed = (float)CAN_UINT(0) / 100.0f;
-      can_speed = _speed < 200.0f ? _speed : 0.0f; // ignore invalid speed reading > 200km/h  
+      if (_speed < 200.0f) 
+        can_speed = _speed;    // ignore invalid speed reading > 200km/h
       can_odometer = (float)(CAN_UINT32(2)>>4) / 100.0f;
       can_odometer_trip = (float)(CAN_UINT(4)>>4) / 100.0f;
       break;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -699,7 +699,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_BattState(const char* data, uint16_t repl
 
   // P = V × I (in kW)
   float pack_power_kw = (v_pack_term * i_pack) / 1000.0f;
-  StdMetrics.ms_v_bat_voltage->SetValue(v_pack_term);
+  //StdMetrics.ms_v_bat_voltage->SetValue(v_pack_term);
   StdMetrics.ms_v_bat_current->SetValue(i_pack * -1.0f); // invert to charge(+)/discharge(-) convention
   StdMetrics.ms_v_bat_power->SetValue(pack_power_kw);
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -58,13 +58,16 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       }
     else if (!m_12v_alerted) // alert only once when undervoltage is detected, to prevent log flooding
       {
-      m_12v_alerted = true;  
-      smart12VHistory();     // log undervoltage event in history metric and send data log
+      m_12v_alerted = true;
+      m_12v_alerted_ticker = 120; // alert reset cooldown for 120 seconds
+      ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      smart12VHistory();         // log undervoltage event in history metric and send data log
       }
     }
-  else if (m_12v_alerted && (volt > 6.0f  && m_ref12V-volt <= m_alert12V))
+  else if (m_12v_alerted && m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0 && (volt > 6.0f && m_ref12V-volt <= m_alert12V))
     {
-    m_12v_alerted = false; // reset alert flag when voltage is back to normal
+    m_12v_alerted = false;     // reset alert flag when voltage is back to normal
+    m_12v_alerted_ticker = -1; // reset alert ticker
     ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
     }
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -41,7 +41,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
   float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;   // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
   float usm12v = mt_evc_dcdc->GetElemValue(3);              // 12V USM voltage
-  bool  ref12V_valid = m_ref12V > 6.0f;                     // evaluate reference once per tick
+  bool  ref12V_valid = m_ref12V > 11.0f;                    // evaluate reference once per tick
 
   if (ref12V_valid && (
       (volt > 6.0f && m_ref12V - volt > m_alert12V) ||
@@ -59,21 +59,24 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       m_poll_cooldown = true;
       m_cooldown_ticker = 60;
       }
-    else if (!m_12v_alerted)     // alert once per undervoltage event to prevent log flooding
+    if (!m_12v_alerted)           // alert once per undervoltage event to prevent log flooding
       {
       m_12v_alerted = true;
-      m_12v_alerted_ticker = 60; // 60 ticks debounce before alert can reset
+      m_12v_alerted_ticker = 150; // 150 ticks debounce before alert can reset
       ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
-      smart12VHistory();         // log undervoltage event in history metric and send data log
+      smart12VHistory();          // log undervoltage event in history metric and send data log
       }
     }
-  else if (m_12v_alerted && volt > 6.0f && m_ref12V - volt <= m_alert12V &&
-           m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0)
+  else if (m_12v_alerted && ref12V_valid && 
+          volt > 6.0f && m_ref12V - volt <= m_alert12V)
     {
-    m_12v_alerted = false;
-    m_12v_alerted_ticker = -1;
-    ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
-    smart12VHistory();          // log undervoltage event in history metric and send data log
+    if (m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0)
+      {
+      m_12v_alerted = false;
+      m_12v_alerted_ticker = -1;
+      ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      smart12VHistory();          // log undervoltage event in history metric and send data log
+      }
     }
 
   if (m_ddt4all_exec >= 1)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -38,37 +38,42 @@ static const char *TAG = "v-smarteq";
 void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker) 
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
-  float volt = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;      // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
-  float usm12v = mt_evc_dcdc->GetElemValue(3);                 // 12V USM voltage
-  if((volt > 6.0f && m_ref12V > 6.0f && m_ref12V-volt > m_alert12V) ||
-     (m_can_active && bms12v > 6.0f && m_ref12V > 6.0f && m_ref12V-bms12v > m_alert12V) ||
-     (m_can_active && usm12v > 6.0f && m_ref12V > 6.0f && m_ref12V-usm12v > m_alert12V))
+  float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
+  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;   // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
+  float usm12v = mt_evc_dcdc->GetElemValue(3);              // 12V USM voltage
+  bool  ref12V_valid = m_ref12V > 6.0f;                     // evaluate reference once per tick
+
+  if (ref12V_valid && (
+      (volt > 6.0f && m_ref12V - volt > m_alert12V) ||
+      (m_can_active && bms12v > 6.0f && m_ref12V - bms12v > m_alert12V) ||
+      (m_can_active && usm12v > 6.0f && m_ref12V - usm12v > m_alert12V)))
     {
-    if(m_poll_state != POLLSTATE_OFF) // if not already in sleep mode, then switch to sleep mode immediately
-      {      
+    if (m_poll_state != POLLSTATE_OFF) // if not already in sleep mode, then switch to sleep mode immediately
+      {
       smartCoolDownPolling(60);
       ESP_LOGW(TAG, "12V undervoltage detected:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
       mt_poll_state->SetValue("Off (12V undervoltage)");
       }
-    else if(m_cooldown_ticker <= 10) // if not already in cooldown, then restart 60sec. cooldown
+    else if (m_cooldown_ticker <= 10) // cooldown expired or nearly expired - restart to maintain sleep mode
       {
       m_poll_cooldown = true;
       m_cooldown_ticker = 60;
       }
-    else if (!m_12v_alerted) // alert only once when undervoltage is detected, to prevent log flooding
+    else if (!m_12v_alerted)     // alert once per undervoltage event to prevent log flooding
       {
       m_12v_alerted = true;
-      m_12v_alerted_ticker = 120; // alert reset cooldown for 120 seconds
+      m_12v_alerted_ticker = 60; // 60 ticks debounce before alert can reset
       ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
       smart12VHistory();         // log undervoltage event in history metric and send data log
       }
     }
-  else if (m_12v_alerted && m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0 && (volt > 6.0f && m_ref12V-volt <= m_alert12V))
+  else if (m_12v_alerted && volt > 6.0f && m_ref12V - volt <= m_alert12V &&
+           m_12v_alerted_ticker > 0 && --m_12v_alerted_ticker == 0)
     {
-    m_12v_alerted = false;     // reset alert flag when voltage is back to normal
-    m_12v_alerted_ticker = -1; // reset alert ticker
+    m_12v_alerted = false;
+    m_12v_alerted_ticker = -1;
     ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+    smart12VHistory();          // log undervoltage event in history metric and send data log
     }
 
   if (m_ddt4all_exec >= 1)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -470,6 +470,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     float m_ref12V = 12.6f;                 // reference 12V (12.6V)
     float m_alert12V = 0.8f;                // alert threshold 12V (0.8V)
     bool m_12v_alerted = false;             // 12V undervolt alert triggered
+    int m_12v_alerted_ticker = -1;          // cooldown ticker for 12V undervolt alert reset
 
     // --- Internal state variables ---
     bool m_indicator = false;               // activate indicator e.g. 7 times or whatever


### PR DESCRIPTION
Ignore implausible CAN voltage and speed readings before updating cached values, and stop the BMS poller from overwriting battery voltage with the polled pack value. Also add a cooldown-based reset for the 12V undervoltage alert so the event is logged once per incident and emits clearer trigger/clear log messages.