### PR TITLE
smartEQ: Fix 12V voltage readings and polling logic

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -892,7 +892,7 @@ void OvmsVehicleSmartEQ::PollReply_EVC_DCDC_Volt(const char* data, uint16_t repl
   // POSITIVE RESPONSE FORMAT: 62 30 24 <Byte>
   REQUIRE_LEN(1);
   uint8_t raw = CAN_BYTE(0);
-  float value = 4.0f + raw * 0.1f;     // offset 4.0, step 0.1
+  float value = 4.0f + raw * 0.1f;      // offset 4.0, step 0.1
   mt_evc_dcdc->SetElemValue(1, value);  // dcdc_volt
   StdMetrics.ms_v_charge_12v_voltage->SetValue(value);
 }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -405,9 +405,14 @@ void OvmsVehicleSmartEQ::xsq_calc_adc(int verbosity, OvmsWriter* writer, OvmsCom
       {
       writer->puts("Error: vehicle 12V DC-DC converter not active");
       return;
+      }
+    if (smarteq->m_poll_cooldown) 
+      {
+      writer->puts("Error: vehicle 12V DC-DC polling not active");
+      return;
       } 
         
-    float can12V = StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f);   // DCDC voltage = mt_evc_dcdc->GetElemValue(1)
+    float can12V = (smarteq->mt_evc_dcdc->GetElemValue(1) + smarteq->mt_evc_dcdc->GetElemValue(3) + smarteq->mt_evc_dcdc->GetElemValue(4)) / 3;   // DCDC 12V
     if (can12V < 13.1f) 
       {
       writer->puts("Error: vehicle 12V is not charging, 12V voltage is not stable for ADC calibration!");

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -39,19 +39,19 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
   float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.3f;   // 12V BMS clamp 30 + 0.3V to compensate for the clamp voltage drop
-  float usm12v = mt_evc_dcdc->GetElemValue(3);              // 12V USM voltage
+  float bms12v = mt_bms_voltages->GetElemValue(6);          // 12V BMS clamp 30
+  float voltcan = mt_evc_dcdc->GetElemValue(4);             // 12V voltage can
   bool  ref12V_valid = m_ref12V > 11.0f;                    // evaluate reference once per tick
 
   if (ref12V_valid && (
       (volt > 6.0f && m_ref12V - volt > m_alert12V) ||
       (m_can_active && bms12v > 6.0f && m_ref12V - bms12v > m_alert12V) ||
-      (m_can_active && usm12v > 6.0f && m_ref12V - usm12v > m_alert12V)))
+      (m_can_active && voltcan > 6.0f && m_ref12V - voltcan > m_alert12V)))
     {
     if (m_poll_state != POLLSTATE_OFF) // if not already in sleep mode, then switch to sleep mode immediately
       {
       smartCoolDownPolling(60);
-      ESP_LOGW(TAG, "12V undervoltage detected:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      ESP_LOGW(TAG, "12V undervoltage detected:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, voltcan, m_ref12V);
       mt_poll_state->SetValue("Off (12V undervoltage)");
       }
     else if (m_cooldown_ticker <= 10) // cooldown expired or nearly expired - restart to maintain sleep mode
@@ -63,7 +63,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       {
       m_12v_alerted = true;
       m_12v_alerted_ticker = 150; // 150 ticks debounce before alert can reset
-      ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      ESP_LOGW(TAG, "12V undervoltage alert triggered:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, voltcan, m_ref12V);
       smart12VHistory();          // log undervoltage event in history metric and send data log
       }
     }
@@ -74,7 +74,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
       {
       m_12v_alerted = false;
       m_12v_alerted_ticker = -1;
-      ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, usm12v, m_ref12V);
+      ESP_LOGI(TAG, "12V undervoltage cleared:  %.2fV Module, %.2fV BMS, %.2fV USM (reference: %.2fV)", volt, bms12v, voltcan, m_ref12V);
       smart12VHistory();          // log undervoltage event in history metric and send data log
       }
     }
@@ -178,9 +178,9 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
     }
 
   #ifdef CONFIG_OVMS_COMP_ADC
-  if((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ())
+  if(!m_poll_cooldown && ((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ()))
     {
-    float can12V = StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f);   // DCDC voltage = mt_evc_dcdc->GetElemValue(1)
+    float can12V = mt_bms_voltages->GetElemValue(6);   // BMS 12V clamp 30 voltage
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
     if(m_check12vadc && can12V >= 13.1f)
       {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -39,7 +39,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
   {
   // when 12V voltage is critically low, then switch to sleep mode immediately
   float volt   = StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f);
-  float bms12v = mt_bms_voltages->GetElemValue(6);          // 12V BMS clamp 30
+  float bms12v = mt_bms_voltages->GetElemValue(6) + 0.25f;  // 12V BMS clamp 30 + 0.25V offset
   float voltcan = mt_evc_dcdc->GetElemValue(4);             // 12V voltage can
   bool  ref12V_valid = m_ref12V > 11.0f;                    // evaluate reference once per tick
 
@@ -180,7 +180,7 @@ void OvmsVehicleSmartEQ::Ticker60(uint32_t ticker)
   #ifdef CONFIG_OVMS_COMP_ADC
   if(!m_poll_cooldown && ((IsOnEQ() || IsChargingEQ()) || Is12VchargeEQ()))
     {
-    float can12V = mt_bms_voltages->GetElemValue(6);   // BMS 12V clamp 30 voltage
+    float can12V = (mt_evc_dcdc->GetElemValue(1) + mt_evc_dcdc->GetElemValue(3) + mt_evc_dcdc->GetElemValue(4)) / 3;   // DCDC 12V
     // check for 12V voltage difference between CAN and ADC when the car is rebooted, to detect if ADC factor recalibration is needed
     if(m_check12vadc && can12V >= 13.1f)
       {


### PR DESCRIPTION
Corrects 12V voltage calculations in the ticker:
- Changes USM voltage source from index 3 to 4 (CAN voltage)
- Renames variable from usm12v to voltcan for clarity
- Adds polling cooldown check to Ticker60 ADC check