### PR TITLE
smartEQ: refactor CommandWakeup()

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -225,6 +225,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
+    smartCoolDownPolling(20); // 20 seconds cooldown to allow the vehicle to wake up
     m_cmd_wakeup = true;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -85,7 +85,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
 
   if (enable && !IsOnHVACEQ()) 
     {
-    CommandWakeup();
     uint8_t data[4] = {0x40, 0x01, 0x00, 0x00};
     canbus *obd;
     obd = m_can1;
@@ -93,7 +92,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
       {
       if (IsOnHVACEQ())
         {
-        StdMetrics.ms_v_env_awake->SetValue(true);
         ESP_LOGD(TAG, "Climate control is now on");
         break;
         }
@@ -101,6 +99,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
 
+    vTaskDelay(200 / portTICK_PERIOD_MS);
     if (IsOnHVACEQ())
       {
       // if true, climate will be restarted after 5 minutes by Ticker1, if false, climate will not be restarted after 5 minutes
@@ -197,7 +196,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandHomelink(int button, i
       return OvmsVehicle::CommandHomelink(button, durationms);
   }
 }
-
+// this command is not implemented by the EQ, but we can use it to trigger a simulated wakeup
 OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
   if(!IsCANwrite())
     {
@@ -211,22 +210,22 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
 
   if(!IsAwakeEQ()) 
     {
-    uint8_t data[4] = {0x40, 0x00, 0x00, 0x00};
+    uint8_t data[8] = {0xc3, 0x00, 0x00, 0x00, 0x14, 0x70, 0x96, 0x85};
     canbus *obd;
     obd = m_can1;
 
-    for (int i = 0; i < 15; i++) 
+    for (int i = 0; i < 5; i++) 
       {
       if (IsAwakeEQ()) 
         {
         res = Success;
         break;
         }      
-      obd->WriteStandard(0x634, 4, data);
+      obd->WriteStandard(0x350, 8, data);
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
-    StdMetrics.ms_v_env_awake->SetValue(true);
+    m_cmd_wakeup = true;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 
   else 
@@ -250,11 +249,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandLock(const char* pin) 
 
   if(m_indicator) 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000","30082002"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000","30082002"}, false, false);
     }
   else 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010000","30010000","30010000","30010000","30010000"}, false, false);
     }
     
   if(res == Success)  
@@ -291,11 +290,11 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandUnlock(const char* pin
 
   if(m_indicator) 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001","30082002"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001","30082002"}, false, false);
     }
   else 
     {
-    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001"}, false, true);
+    res = CommandCanVector(0x745, 0x765, {"30010001","30010001","30010001","30010001","30010001"}, false, false);
     }
 
   if(res == Success) 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -213,6 +213,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
     uint8_t data[8] = {0xc3, 0x00, 0x00, 0x00, 0x14, 0x70, 0x96, 0x85};
     canbus *obd;
     obd = m_can1;
+    smartCoolDownPolling(30); // 30 seconds cooldown to allow the vehicle to wake up
 
     for (int i = 0; i < 5; i++) 
       {
@@ -225,7 +226,6 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandWakeup() {
       vTaskDelay(200 / portTICK_PERIOD_MS);
       }
     res = Success;
-    smartCoolDownPolling(20); // 20 seconds cooldown to allow the vehicle to wake up
     m_cmd_wakeup = true;
     ESP_LOGI(TAG, "Vehicle is now awake");
     } 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -77,11 +77,11 @@ OvmsVehicle::vehicle_command_t  OvmsVehicleSmartEQ::CommandCanVector(uint32_t tx
 
   OvmsVehicle::vehicle_command_t res = Fail;
   res = wakeup ? CommandWakeup() : Success;
-  
+
+  vTaskDelay(200 / portTICK_PERIOD_MS);
   if (res == Success)
     {
-    vTaskDelay(1500 / portTICK_PERIOD_MS);
-    if (!IsAwakeEQ()) 
+    if (wakeup && !can_awake) 
       {
       ESP_LOGE(TAG, "vehicle not awake");
       m_ddt4all_exec = 5; // reduce cooldown on error

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ddt4all.cpp
@@ -79,28 +79,28 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 0:
     {
       // indicator 5x on
-      CommandCanVector(0x745, 0x765, {"30082002","30082002"}, false, true);
+      CommandCanVector(0x745, 0x765, {"30082002","30082002"}, false, false);
       res = Success;
       break;
     }
     case 1:
     {
       // open trunk
-      CommandCanVector(0x745, 0x765, {"300500","300500","300500","300500","300500"}, false, true);
+      CommandCanVector(0x745, 0x765, {"300500","300500","300500","300500","300500"}, false, false);
       res = Success;
       break;
     }
     case 2:
     {
       // AUTO_WIPE false
-      CommandCanVector(0x74d, 0x76d, {"2E033C00"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033C00"}, false, false);
       res = Success;
       break;
     }
     case 3:
     {
       // AUTO_WIPE true
-      CommandCanVector(0x74d, 0x76d, {"2E033C80"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033C80"}, false, false);
       res = Success;
       break;
     }
@@ -148,70 +148,70 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 6:
     {
       // BIPBIP_Lock false
-      CommandCanVector(0x745, 0x765, {"3B1400"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B1400"}, false, false);
       res = Success;
       break;
     }
     case 7:
     {
       // BIPBIP_Lock true
-      CommandCanVector(0x745, 0x765, {"3B1480"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B1480"}, false, false);
       res = Success;
       break;
     }
     case 8:
     {
       // REAR_WIPER_LINK false
-      CommandCanVector(0x745, 0x765, {"3B5800"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5800"}, false, false);
       res = Success;
       break;
     }
     case 9:
     {
       // REAR_WIPER_LINK true
-      CommandCanVector(0x745, 0x765, {"3B5880"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5880"}, false, false);
       res = Success;
       break;
     }
     case 10:
     {
       // RKE_Backdoor_open false
-      CommandCanVector(0x745, 0x765, {"3B7800"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7800"}, false, false);
       res = Success;
       break;
     }
     case 11:
     {
       // RKE_Backdoor_open true
-      CommandCanVector(0x745, 0x765, {"3B7880"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7880"}, false, false);
       res = Success;
       break;
     }
     case 12:
     {
       // Precond_by_key 00
-      CommandCanVector(0x745, 0x765, {"3B7700"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7700"}, false, false);
       res = Success;
       break;
     }
     case 13:
     {
       // Precond_by_key 03
-      CommandCanVector(0x745, 0x765, {"3B7703"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7703"}, false, false);
       res = Success;
       break;
     }
     case 14:
     {
       // ECOMODE_PRE_Restart false
-      CommandCanVector(0x745, 0x765, {"3B7600"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7600"}, false, false);
       res = Success;
       break;
     }
     case 15:
     {
       // ECOMODE_PRE_Restart true
-      CommandCanVector(0x745, 0x765, {"3B7680"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7680"}, false, false);
       res = Success;
       break;
     }
@@ -232,42 +232,42 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 18:
     {
       // ONLY_DRL_OFF_CF false
-      CommandCanVector(0x74d, 0x76d, {"2E045F00"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E045F00"}, false, false);
       res = Success;
       break;
     }
     case 19:
     {
       // ONLY_DRL_OFF_CF true
-      CommandCanVector(0x74d, 0x76d, {"2E045F80"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E045F80"}, false, false);
       res = Success;
       break;
     }
     case 20:
     {
       // Welcome_Goodbye_CF false
-      CommandCanVector(0x74d, 0x76d, {"2E033400"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033400"}, false, false);
       res = Success;
       break;
     }
     case 21:
     {
       // Welcome_Goodbye_CF true
-      CommandCanVector(0x74d, 0x76d, {"2E033480"}, false, true);
+      CommandCanVector(0x74d, 0x76d, {"2E033480"}, false, false);
       res = Success;
       break;
     }    
     case 22:
     {      
       // Default variant, tailgate open true, Precond_by_key 00
-      CommandCanVector(0x745, 0x765, {"3B7880","3B7700"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7880","3B7700"}, false, false);
       res = Success;
       break;
     }
     case 23:
     {      
       // Default variant, tailgate open false, Precond_by_key 03
-      CommandCanVector(0x745, 0x765, {"3B7800","3B7703"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B7800","3B7703"}, false, false);
       res = Success;
       break;
     }
@@ -303,28 +303,28 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 32:
     {
       // key reminder false
-      CommandCanVector(0x745, 0x765, {"3B5E00"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5E00"}, false, false);
       res = Success;
       break;
     }
     case 33:
     {
       // key reminder true
-      CommandCanVector(0x745, 0x765, {"3B5E80"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5E80"}, false, false);
       res = Success;
       break;
     }
     case 34:
     {
       // long tempo display false
-      CommandCanVector(0x745, 0x765, {"3B5700"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5700"}, false, false);
       res = Success;
       break;
     }
     case 35:
     {
       // long tempo display true
-      CommandCanVector(0x745, 0x765, {"3B5780"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B5780"}, false, false);
       res = Success;
       break;
     }
@@ -387,28 +387,28 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 46:
     {
       // Auto Light false
-      CommandCanVector(0x745, 0x765, {"2E104200"}, false, true);
+      CommandCanVector(0x745, 0x765, {"2E104200"}, false, false);
       res = Success;
       break;
     }
     case 47:
     {
       // Auto Light true
-      CommandCanVector(0x745, 0x765, {"2E104201"}, false, true);
+      CommandCanVector(0x745, 0x765, {"2E104201"}, false, false);
       res = Success;
       break;
     }
     case 48:
     {
       // Light by EMM false
-      CommandCanVector(0x745, 0x765, {"3B4F00"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B4F00"}, false, false);
       res = Success;
       break;
     }
     case 49:
     {
       // Light by EMM true
-      CommandCanVector(0x745, 0x765, {"3B4F80"}, false, true);
+      CommandCanVector(0x745, 0x765, {"3B4F80"}, false, false);
       res = Success;
       break;
     }
@@ -572,7 +572,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandDDT4all(int number, Ov
     case 745:
     {
       std::string hexbytes = mt_canbyte->AsString();
-      CommandCanVector(0x745, 0x765, {hexbytes}, false, true);
+      CommandCanVector(0x745, 0x765, {hexbytes}, false, false);
       res = Success;
       break;
     }

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -89,6 +89,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     can_awake = false;
     can_env_on = false;
     can_battery_on = false;
+    m_cmd_wakeup = false;
     smartCAN2Metrics();
     }
 
@@ -109,6 +110,8 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
 
 void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker) 
   {
+  if (m_cmd_wakeup)
+    m_cmd_wakeup = false;   // reset wakeup command after ~10s
   // if awake state has changed, then update metric to prevent desync
   if (IsAwakeEQ() != StdMetrics.ms_v_env_awake->AsBool(false))
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -227,14 +227,14 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // --- Inline state helpers ---
     bool UsesTpmsSensorMapping() override { return true; } // using m_tpms_index[]
     bool IsOffEQ() { return m_poll_state == POLLSTATE_OFF; }
-    bool IsAwakeEQ() { return can_awake || can_charge_inprogress || can_env_on || can_hvac; }
+    bool IsAwakeEQ() { return can_awake || can_charge_inprogress || can_env_on || can_hvac || m_cmd_wakeup; }
     bool IsHVonEQ() { return can_battery_on && IsAwakeEQ(); }
     bool IsOnEQ() { return can_env_on; }
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
     bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
     bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) >= 13.1f || 
-                                  (StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f ) || 
+                                  (m_can_active && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f ) || 
                                   (m_can_active && can_charging12v); }
 
   // =========================================================================
@@ -449,6 +449,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_12v_charge_state = false;        // 12V charge state
     bool m_extendedStats = false;           // extended stats for trip and maintenance data
     bool m_enable_calcADCfactor = false;    // enable calculation of ADC factor
+    bool m_cmd_wakeup = false;              // wakeup command issued
     int m_reboot_ticker = 0;                // ticker for network restart
     int m_reboot_time = 30;                 // Restart Network time
     int m_TPMS_FL = 0;                      // TPMS Sensor Front Left


### PR DESCRIPTION
Waking it up has had no effect so far.
The `wakeup` command will simulate a wakeup for the code; polling remains disabled.