### PR TITLE
smarteq : use ts poll delay in poller

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -189,7 +189,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       {
       REQ_DLC(4);
       float _soc = (float) CAN_BYTE(3);
-      if (_soc <= 100.0f) can_soc = _soc; // SOC
+      if (_soc <= 100.0f && _soc >= 0.1f) can_soc = _soc; // SOC
       can_chargeport = (CAN_BYTE(0) & 0x20) != 0; // ChargingPlugConnected
       can_duration_full = (((c >> 22) & 0x3FFu) < 0x3FF) ? (c >> 22) & 0x3FFu : 0;
       float _range_est = ((c >> 12) & 0x3FFu); // VehicleAutonomy

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -85,6 +85,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
 
   if (enable && !IsOnHVACEQ()) 
     {
+    CommandWakeup();
     uint8_t data[4] = {0x40, 0x01, 0x00, 0x00};
     canbus *obd;
     obd = m_can1;
@@ -96,10 +97,9 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
         break;
         }
       obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(500 / portTICK_PERIOD_MS);
+      vTaskDelay(1000 / portTICK_PERIOD_MS);
       }
-
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+      
     if (IsOnHVACEQ())
       {
       // if true, climate will be restarted after 5 minutes by Ticker1, if false, climate will not be restarted after 5 minutes

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_cmds_override.cpp
@@ -96,10 +96,10 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandClimateControlEQ(bool 
         break;
         }
       obd->WriteStandard(0x634, 4, data);
-      vTaskDelay(200 / portTICK_PERIOD_MS);
+      vTaskDelay(500 / portTICK_PERIOD_MS);
       }
 
-    vTaskDelay(200 / portTICK_PERIOD_MS);
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
     if (IsOnHVACEQ())
       {
       // if true, climate will be restarted after 5 minutes by Ticker1, if false, climate will not be restarted after 5 minutes

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -37,98 +37,105 @@
 
 static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, { 0,298,33,33 }, 0, ISOTP_STD },   // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, { 0,294,294,94 }, 0, ISOTP_STD },  // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, { 0,0,298,298 }, 0, ISOTP_STD },   // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,0,0,98 }, 0, ISOTP_STD },      // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, { 0,0,6665,0 }, 0, ISOTP_STD },    // Battery Health (SOH)
+  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different sleep times before start polling for each pollstate
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },   // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD },  // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,298,298 }, { 0,0,10,10 } }}, 0, ISOTP_STD },   // SOC
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,98 }, { 0,0,0,155 } }}, 0, ISOTP_STD },      // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,0,6665,0 }, { 0,0,155,0 } }}, 0, ISOTP_STD },    // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, { 0,0,302,102 }, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, { 0,0,3601,601 }, 0, ISOTP_STD },  // Cell Resistance P2      (Cells 49-96)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, { 0,304,304,104 }, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,304,304,104 }, { 0,30,30,30 } }}, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, { 0,8,8,8 }, 0, ISOTP_STD },         // Doorlock EEPROM
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, { 0,0,152,0 }, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, { 0,0,154,0 }, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,152,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,154,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, { 0,9,0,9 }, 0, ISOTP_STD },       // Charging plug detected (B_PlugConnected_bcb_status_S)  
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, { 0,598,119,59 }, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, { 0,122,122,0 }, 0, ISOTP_STD },   // Cabin blower command
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },       // Charging plug detected (B_PlugConnected_bcb_status_S)  
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,598,119,59 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,122,122,122 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, { 0,294,59,59 }, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, { 0,12,12,12 }, 0, ISOTP_STD },  // DCDC activation request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, { 0,294,37,37 }, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, { 0,291,31,31 }, 0, ISOTP_STD }, // 14V DCDC voltage measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, { 0,291,31,31 }, 0, ISOTP_STD }, // 14V DCDC current measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, { 0,294,31,31 }, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, { 0,58,17,17 }, 0, ISOTP_STD },  // USM 14V voltage (CAN) - needed for ADC calculation
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, { 0,291,29,29 }, 0, ISOTP_STD }, // Battery voltage 14V
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,294,59,59 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },  // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,294,37,37 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,291,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,294,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },  // USM 14V voltage (CAN) - needed for ADC calculation
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, { 0,906,906,906 }, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, { 0,306,306,0 }, 0, ISOTP_STD },   // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, { 0,0,6633,0 }, 0, ISOTP_STD },    // maintenance level
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,906,906,906 }, { 0,17,17,17 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
 static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, { 0,0,0,10 }, 0, ISOTP_STD },  // rqChargerAC
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, {.ts={ { 0,0,0,10 }, { 0,0,0,0 } }}, 0, ISOTP_STD },  // rqChargerAC
 };
 
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, { 0,0,0,9 }, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, { 0,0,0,10 }, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, { 0,0,0,11 }, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, { 0,0,0,303 }, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, { 0,0,0,72 }, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, { 0,0,0,304 }, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, { 0,0,0,305 }, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, { 0,0,0,306 }, 0, ISOTP_STD }, // rqJB2AC_DC Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, { 0,0,0,307 }, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, { 0,0,0,308 }, 0, ISOTP_STD }, // rqJB2AC_HF Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, { 0,0,0,309 }, 0, ISOTP_STD }, // rqJB2AC_LF Current
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,303 }, { 0,0,0,51 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,72 }, { 0,0,0,31 } }}, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,304 }, { 0,0,0,52 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, {.ts={ { 0,0,0,305 }, { 0,0,0,53 } }}, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, {.ts={ { 0,0,0,306 }, { 0,0,0,54 } }}, 0, ISOTP_STD }, // rqJB2AC_DC Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, {.ts={ { 0,0,0,307 }, { 0,0,0,55 } }}, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, {.ts={ { 0,0,0,308 }, { 0,0,0,56 } }}, 0, ISOTP_STD }, // rqJB2AC_HF Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, {.ts={ { 0,0,0,309 }, { 0,0,0,57 } }}, 0, ISOTP_STD }, // rqJB2AC_LF Current
 };
 //   -> HandleOBDpolling() will add the following PIDs once m_static_ids_read is false and IsOnEQ() is true
 static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
 {
-  // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, { 0,6666,6666,0 }, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, { 0,6667,6667,0 }, 0, ISOTP_STD },    // BMS Production Number Supplier Read
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, { 0,6668,6668,0 }, 0, ISOTP_STD },    // Frame Traceability Information
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, { 0,6669,6669,0 }, 0, ISOTP_STD },    // req.VIN
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6667,6667,0 }, { 0,13,13,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6668,6668,0 }, { 0,14,14,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6669,6669,0 }, { 0,11,11,0 } }}, 0, ISOTP_STD },    // req.VIN
 };

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -38,104 +38,106 @@
 static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different sleep times before start polling for each pollstate
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },     // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,298,298 }, { 0,0,10,10 } }}, 0, ISOTP_STD },   // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,98 }, { 0,0,0,155 } }}, 0, ISOTP_STD },      // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,0,6665,0 }, { 0,0,155,0 } }}, 0, ISOTP_STD },    // Battery Health (SOH)
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different delay time before start polling for each pollstate
+  // e.g. interval 60 with shift 10 is polled at n*60 + 10.
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,300,30,30 }, { 0,8,8,8 } }}, 0, ISOTP_STD },     // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,300,300,60 }, { 0,10,10,10 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,300,300 }, { 0,0,27,27 } }}, 0, ISOTP_STD },   // SOC
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,100 }, { 0,0,0,155 } }}, 0, ISOTP_STD },     // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,3600,3600,0 }, { 0,60,60,0 } }}, 0, ISOTP_STD }, // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,304,304,104 }, { 0,30,30,30 } }}, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,300,300,100 }, { 0,25,25,25 } }}, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,300,300,100 }, { 0,25,25,25 } }}, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,600,600,600 }, { 0,40,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,600,600,600 }, { 0,40,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,300,300,100 }, { 0,30,30,30 } }}, 0, ISOTP_STD },    // Battery Temperatures (27 sensors)    
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,152,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,154,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,150,0 }, { 0,0,34,0 } }}, 0, ISOTP_STD },        // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,150,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Charging plug detected (B_PlugConnected_bcb_status_S)  
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,598,119,59 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,122,122,122 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,600,120,60 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,120,120,120 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
 static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,294,59,59 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },     // DCDC activation request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,294,37,37 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // 14V DCDC voltage measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,291,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,294,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },     // USM 14V voltage (CAN) - needed for ADC calculation
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // Battery voltage 14V
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  // AWAKE short interval needed for trickle charging (HVAC on)
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,10,10,10 }, { 0,5,5,5 } }}, 0, ISOTP_STD },    // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,30,30,30 }, { 0,19,19,19 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,20,20,20 }, { 0,8,8,14 } }}, 0, ISOTP_STD },   // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,30,30,30 }, { 0,20,20,20 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,30,30,30 }, { 0,21,21,21 } }}, 0, ISOTP_STD }, // rqDCDC_Power
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,30,30,30 }, { 0,22,22,22 } }}, 0, ISOTP_STD }, // rqDCDC_Load
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,20,20,20 }, { 0,6,6,11 } }}, 0, ISOTP_STD },   // USM 14V voltage (CAN) - needed for ADC calculation
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,20,20,20 }, { 0,7,7,13 } }}, 0, ISOTP_STD },   // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,906,906,906 }, { 0,17,17,17 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance level
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,600,600,600 }, { 0,31,31,31 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,600,300,0 }, { 0,32,32,0 } }}, 0, ISOTP_STD },    // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,600,300,0 }, { 0,33,33,0 } }}, 0, ISOTP_STD },    // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,600,300,0 }, { 0,34,34,0 } }}, 0, ISOTP_STD },    // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,6661,6661,0 }, { 0,63,63,0 } }}, 0, ISOTP_STD },  // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,6661,6661,0 }, { 0,64,64,0 } }}, 0, ISOTP_STD },  // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,6661,6661,0 }, { 0,65,65,0 } }}, 0, ISOTP_STD },  // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
 static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, {.ts={ { 0,0,0,10 }, { 0,0,0,0 } }}, 0, ISOTP_STD },  // rqChargerAC
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x7303, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqChargerAC
 };
 
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph31_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph1_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph2_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },   // rqJB2AC Mains active power consumed
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,303 }, { 0,0,0,51 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,72 }, { 0,0,0,31 } }}, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,304 }, { 0,0,0,52 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, {.ts={ { 0,0,0,305 }, { 0,0,0,53 } }}, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, {.ts={ { 0,0,0,306 }, { 0,0,0,54 } }}, 0, ISOTP_STD }, // rqJB2AC_DC Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, {.ts={ { 0,0,0,307 }, { 0,0,0,55 } }}, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, {.ts={ { 0,0,0,308 }, { 0,0,0,56 } }}, 0, ISOTP_STD }, // rqJB2AC_HF Current
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, {.ts={ { 0,0,0,309 }, { 0,0,0,57 } }}, 0, ISOTP_STD }, // rqJB2AC_LF Current
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,5 }, { 0,0,0,6 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph1_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph2_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph3_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,13 }, { 0,0,0,13 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,601 }, { 0,0,0,58 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,601 }, { 0,0,0,59 } }}, 0, ISOTP_STD }, // rqJB2AC_Max Current limitation
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,601 }, { 0,0,0,61 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5064, {.ts={ { 0,0,0,601 }, { 0,0,0,62 } }}, 0, ISOTP_STD }, // rqJB2AC_Leakage Diag
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5065, {.ts={ { 0,0,0,601 }, { 0,0,0,63 } }}, 0, ISOTP_STD }, // rqJB2AC_DC Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5066, {.ts={ { 0,0,0,601 }, { 0,0,0,64 } }}, 0, ISOTP_STD }, // rqJB2AC_HF10kHz Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5067, {.ts={ { 0,0,0,601 }, { 0,0,0,65 } }}, 0, ISOTP_STD }, // rqJB2AC_HF Current
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5068, {.ts={ { 0,0,0,601 }, { 0,0,0,66 } }}, 0, ISOTP_STD }, // rqJB2AC_LF Current
 };
 //   -> HandleOBDpolling() will add the following PIDs once m_static_ids_read is false and IsOnEQ() is true
 static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
 {
-  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },   // DataRead.Identification.RenaultR2
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6667,6667,0 }, { 0,13,13,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6668,6668,0 }, { 0,14,14,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6669,6669,0 }, { 0,11,11,0 } }}, 0, ISOTP_STD },    // req.VIN
+  // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ { 0,6662,6662,0 }, { 0,66,66,0 } }}, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6662,6662,0 }, { 0,67,67,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6662,6662,0 }, { 0,68,68,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6662,6662,0 }, { 0,69,69,0 } }}, 0, ISOTP_STD },    // req.VIN
 };

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -40,11 +40,11 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different delay time before start polling for each pollstate
   // e.g. interval 60 with shift 10 is polled at n*60 + 10.
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,300,30,30 }, { 0,8,8,8 } }}, 0, ISOTP_STD },     // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,300,300,60 }, { 0,10,10,10 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,300,300 }, { 0,0,27,27 } }}, 0, ISOTP_STD },   // SOC
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,100 }, { 0,0,0,155 } }}, 0, ISOTP_STD },     // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,3600,3600,0 }, { 0,60,60,0 } }}, 0, ISOTP_STD }, // Battery Health (SOH)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,300,30,30 }, { 0,8,8,8 } }}, 0, ISOTP_STD },         // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,300,300,60 }, { 0,10,10,10 } }}, 0, ISOTP_STD },     // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,300,300,300 }, { 0,27,27,27 } }}, 0, ISOTP_STD },    // SOC more detailed
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,100 }, { 0,0,0,155 } }}, 0, ISOTP_STD },         // SOC Recalibration
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,3600,3600,0 }, { 0,60,60,0 } }}, 0, ISOTP_STD },     // Battery Health (SOH)
 };
 
 //   -> HandleOBDpolling() will add the following PIDs
@@ -61,14 +61,14 @@ static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] =
 static const OvmsPoller::poll_pid_t obdii_745_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Doorlock EEPROM
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,8,8,8 }, { 0,2,2,2 } }}, 0, ISOTP_STD },             // Doorlock EEPROM
 };
 
 static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,150,0 }, { 0,0,34,0 } }}, 0, ISOTP_STD },        // TPMS input capture
-  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,150,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },        // TPMS counters/status (missing transmitters)
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x74, {.ts={ { 0,0,150,0 }, { 0,0,34,0 } }}, 0, ISOTP_STD },          // TPMS input capture
+  { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x79, {.ts={ { 0,0,150,0 }, { 0,0,35,0 } }}, 0, ISOTP_STD },          // TPMS counters/status (missing transmitters)
 };
 
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -39,8 +39,8 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 {
   // { tx, rx, type, pid, {OFF,AWAKE,ON,CHARGING}, bus, protocol }  <- old style, replaced by ts array below
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }  <- new style, allows different sleep times before start polling for each pollstate
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },   // Battery State
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD },  // HV Contactor Cycles
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x07, {.ts={ { 0,298,33,33 }, { 0,4,4,4 } }}, 0, ISOTP_STD },     // Battery State
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,294,294,94 }, { 0,15,15,15 } }}, 0, ISOTP_STD }, // HV Contactor Cycles
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,0,298,298 }, { 0,0,10,10 } }}, 0, ISOTP_STD },   // SOC
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,98 }, { 0,0,0,155 } }}, 0, ISOTP_STD },      // SOC Recalibration
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,0,6665,0 }, { 0,0,155,0 } }}, 0, ISOTP_STD },    // Battery Health (SOH)
@@ -50,10 +50,10 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
 static const OvmsPoller::poll_pid_t obdii_79b_cell_vrt_polls[] = 
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 1 (Cells 1-48) 
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },   // Battery Voltages Part 2 (Cells 49-96)  
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P1      (Cells 1-48)   
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },   // Cell Resistance P2      (Cells 49-96)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x41, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 1 (Cells 1-48) 
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x42, {.ts={ { 0,0,302,102 }, { 0,0,20,20 } }}, 0, ISOTP_STD },    // Battery Voltages Part 2 (Cells 49-96)  
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x10, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P1      (Cells 1-48)   
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x11, {.ts={ { 0,0,601,601 }, { 0,0,40,40 } }}, 0, ISOTP_STD },    // Cell Resistance P2      (Cells 49-96)
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {.ts={ { 0,304,304,104 }, { 0,30,30,30 } }}, 0, ISOTP_STD }, // Battery Temperatures (27 sensors)    
 };
 
@@ -73,7 +73,7 @@ static const OvmsPoller::poll_pid_t obdii_745_tpms_polls[] =
 static const OvmsPoller::poll_pid_t obdii_7e4_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },       // Charging plug detected (B_PlugConnected_bcb_status_S)  
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x339D, {.ts={ { 0,9,9,9 }, { 0,2,2,2 } }}, 0, ISOTP_STD },          // Charging plug detected (B_PlugConnected_bcb_status_S)  
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x320C, {.ts={ { 0,598,119,59 }, { 0,45,45,45 } }}, 0, ISOTP_STD },  // rqHV_Energy HV bat capacity
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x34CB, {.ts={ { 0,122,122,122 }, { 0,15,15,25 } }}, 0, ISOTP_STD }, // Cabin blower command
 };
@@ -83,25 +83,25 @@ static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3495, {.ts={ { 0,294,59,59 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Load
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },  // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,12,12,12 }, { 0,3,3,3 } }}, 0, ISOTP_STD },     // DCDC activation request
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,294,37,37 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // 14V DCDC voltage measure
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,291,31,31 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // 14V DCDC voltage measure
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,291,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3494, {.ts={ { 0,294,31,31 }, { 0,18,18,18 } }}, 0, ISOTP_STD }, // rqDCDC_Power
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },  // USM 14V voltage (CAN) - needed for ADC calculation
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD }, // Battery voltage 14V
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3301, {.ts={ { 0,58,17,17 }, { 0,5,5,7 } }}, 0, ISOTP_STD },     // USM 14V voltage (CAN) - needed for ADC calculation
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2005, {.ts={ { 0,291,29,29 }, { 0,5,5,7 } }}, 0, ISOTP_STD },    // Battery voltage 14V
 };
 
 static const OvmsPoller::poll_pid_t obdii_743_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x200C, {.ts={ { 0,906,906,906 }, { 0,17,17,17 } }}, 0, ISOTP_STD }, // extern temp byte 2+3
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip Distance km 
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,17 } }}, 0, ISOTP_STD },   // OBD start Trip time s
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data days
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance data usual km
-  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },    // maintenance level
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A0, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip Distance km 
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2104, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x01A2, {.ts={ { 0,306,306,0 }, { 0,17,17,0 } }}, 0, ISOTP_STD },    // OBD start Trip time s
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0204, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data days
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0203, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance data usual km
+  { 0x743, 0x763, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x0188, {.ts={ { 0,0,6633,0 }, { 0,0,58,0 } }}, 0, ISOTP_STD },      // maintenance level
 };
 
 //   -> HandleOBDpolling() will add the slow_charger_polls/fast_charger_polls PIDs when m_poll_on_charge is true, and remove them when m_poll_on_charge is false
@@ -114,13 +114,13 @@ static const OvmsPoller::poll_pid_t slow_charger_polls[] =
 static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph12_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph23_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph31_RMS_V
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph1_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph2_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD }, // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503F, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph12_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5041, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph23_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5042, {.ts={ { 0,0,0,9 }, { 0,0,0,5 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph31_RMS_V
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph1_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph2_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,10 }, { 0,0,0,6 } }}, 0, ISOTP_STD },   // rqJB2AC_Ph3_RMS_A
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,11 }, { 0,0,0,7 } }}, 0, ISOTP_STD },   // rqJB2AC Mains active power consumed
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,303 }, { 0,0,0,51 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,72 }, { 0,0,0,31 } }}, 0, ISOTP_STD },  // rqJB2AC_Max Current limitation
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,304 }, { 0,0,0,52 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance
@@ -134,7 +134,7 @@ static const OvmsPoller::poll_pid_t fast_charger_polls[] =
 static const OvmsPoller::poll_pid_t obdii_onetime_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<sleep>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },    // DataRead.Identification.RenaultR2
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x80, {.ts={ {  0,6666,6666,0 }, { 0,12,12,0 } }}, 0, ISOTP_STD },   // DataRead.Identification.RenaultR2
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x90, {.ts={ { 0,6667,6667,0 }, { 0,13,13,0 } }}, 0, ISOTP_STD },    // BMS Production Number Supplier Read
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x84, {.ts={ { 0,6668,6668,0 }, { 0,14,14,0 } }}, 0, ISOTP_STD },    // Frame Traceability Information
   { 0x745, 0x765, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x81, {.ts={ { 0,6669,6669,0 }, { 0,11,11,0 } }}, 0, ISOTP_STD },    // req.VIN

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -218,7 +218,7 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   StdMetrics.ms_v_bat_12v_voltage_alert->SetValue(false);      // set 12V alert to false
   StdMetrics.ms_v_env_charging12v->SetValue(false);            // set 12V charging state to false
   StdMetrics.ms_v_env_aux12v->SetValue(false);
-  StdMetrics.ms_v_env_hvac->SetValue(false);  
+  StdMetrics.ms_v_env_hvac->SetValue(false);
 
   if (mt_pos_odometer_trip_total->AsFloat(0) < 1.0f)           // reset at boot
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -546,7 +546,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     float can_speed = 0.0f;
     float can_odometer = 0.0f;
     float can_odometer_trip = 0.0f;
-    float can_soc = 0.0f;
+    float can_soc = StdMetrics.ms_v_bat_soc->AsFloat(0.0f);
     float can_range_est = 0.0f;
     float can_range_full = 0.0f;
     float can_range_ideal = 0.0f;


### PR DESCRIPTION
Migrate all smarteq OBD poll definitions in `eq_poller.h` from legacy `{OFF,AWAKE,ON,CHARGING}` timing arrays to the new `.ts` format with explicit per-state poll intervals plus startup sleep delays. This also retunes several PID timings (including charging, DCDC, TPMS, and one-time/static ID polls) to stagger requests and improve polling behavior after state transitions.