### PR TITLE
smartEQ: Adjust 12V alert/ref defaults

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -468,8 +468,24 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandPreset(int verbosity, 
   {
     auto m = MyConfig.GetParamMap("vehicle");
     bool changed = false;
-    if (m.find("12v.alert") == m.end())
-      { m["12v.alert"] = "0.8"; changed = true; }
+    auto it_ref = m.find("12v.ref");    
+    auto it_alert = m.find("12v.alert");
+    if (PRESET_VERSION == PRESET_VERSION_12VREF) 
+    {
+      m["12v.ref"] = "12.5";
+      m["12v.alert"] = "0.9";
+      changed = true;
+    }
+    if (it_ref == m.end())
+      {
+      m["12v.ref"] = "12.5";
+      changed = true;
+      }
+    if (it_alert == m.end())
+      {
+      m["12v.alert"] = "0.9";
+      changed = true;
+      }
     if (need_stream)
       { m["stream"] = "10"; changed = true; }
     // TPMS migration: read from already-loaded map_xsq
@@ -629,7 +645,8 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandSetDefault(int verbosi
   // vehicle section
   auto map_vehicle = MyConfig.GetParamMap("vehicle");
   map_vehicle["stream"] = "10";
-  map_vehicle["12v.alert"] = "0.8";
+  map_vehicle["12v.ref"] = "12.5";
+  map_vehicle["12v.alert"] = "0.9";
   MyConfig.SetParamMap("vehicle", map_vehicle);
 
   // ota section

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -257,8 +257,8 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   if (param && param->GetName() == "vehicle")
     {
     setTPMSValue();   // update TPMS metrics
-    m_ref12V = MyConfig.GetParamValueFloat("vehicle", "12v.ref", 12.6f);
-    m_alert12V = MyConfig.GetParamValueFloat("vehicle", "12v.alert", 0.8f);
+    m_ref12V = MyConfig.GetParamValueFloat("vehicle", "12v.ref", 12.5f);
+    m_alert12V = MyConfig.GetParamValueFloat("vehicle", "12v.alert", 0.9f);
     }
   if (param && param->GetName() != "xsq")
     return;

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -33,14 +33,14 @@
 #ifndef __VEHICLE_SMARTEQ_H__
 #define __VEHICLE_SMARTEQ_H__
 
-
 // --- Constants ---
 #define VERSION "2.2.0"
-#define PRESET_VERSION 20260623 // Configuration preset version
+#define PRESET_VERSION 20260706        // Configuration preset version
+#define PRESET_VERSION_12VREF 20260706 // Configuration preset version for 12V reference migration, defined separately to allow setting 12V reference migration
 #define DEFAULT_BATTERY_CAPACITY 16700 // <- net 16700 Wh, gross 17600 Wh
 #define MAX_POLL_DATA_LEN 126
 #define CELLCOUNT 96
-#define SQ_CANDATA_TIMEOUT 10   // seconds until car goes to sleep without CAN activity
+#define SQ_CANDATA_TIMEOUT 10          // seconds until car goes to sleep without CAN activity
 
 #include "ovms_log.h"
 
@@ -468,8 +468,8 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     std::string m_hl_canbyte = "";          // canbyte variable for unv
     std::deque<float> m_adc_factor_history;     // ring buffer (max 10) for ADC factors
     std::deque<float> m_12v_undervolt_history;  // ring buffer (max 10) for 12V undervoltage measurements
-    float m_ref12V = 12.6f;                 // reference 12V (12.6V)
-    float m_alert12V = 0.8f;                // alert threshold 12V (0.8V)
+    float m_ref12V = 12.5f;                 // reference 12V (12.5V)
+    float m_alert12V = 0.9f;                // alert threshold 12V (0.9V)
     bool m_12v_alerted = false;             // 12V undervolt alert triggered
     int m_12v_alerted_ticker = -1;          // cooldown ticker for 12V undervolt alert reset
 


### PR DESCRIPTION
Lower the 12V reference voltage default from 12.6V to 12.5V and raise the alert threshold from 0.8V to 0.9V. Also ensures 12v.ref is written during preset initialization. Updates PRESET_VERSION to 20260706.