### PR TITLE
smartEQ: Tune charging poll rates and metric updates

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -1003,7 +1003,18 @@ void OvmsVehicleSmartEQ::PollReply_OBL_ChargerAC(const char* data, uint16_t repl
   }
   UpdateChargeMetrics();
 }
-
+// #1 poll fast charger 3-phase
+void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_V(const char* data, uint16_t reply_len, int idx) {
+  REQUIRE_LEN(2);
+  mt_obl_main_volts->SetElemValue(idx, CAN_UINT(0) / 2.0);
+}
+//#2 poll fast charger 3-phase
+void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_A(const char* data, uint16_t reply_len, int idx) {
+  REQUIRE_LEN(2);
+  float value = ((CAN_UINT(0) * 0.625) - 2000) / 10.0;
+  mt_obl_main_amps->SetElemValue(idx, value);
+}
+//#3 poll + charge metrics update #1, #2, #3
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Power(const char* data, uint16_t reply_len) {
   // POSITIVE RESPONSE FORMAT: 62 50 4A <Byte> <Byte>
   // Spec: offset -20000.0, bytescount 2, unit W
@@ -1014,21 +1025,6 @@ void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Power(const char* data, uint16_t re
   mt_obl_main_CHGpower->SetElemValue(0, power_kw);
   mt_obl_main_CHGpower->SetElemValue(1, 0);
   UpdateChargeMetrics();
-}
-
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_A(const char* data, uint16_t reply_len, int idx) {
-  REQUIRE_LEN(2);
-  float value = ((CAN_UINT(0) * 0.625) - 2000) / 10.0;
-  mt_obl_main_amps->SetElemValue(idx, value);
-  if (idx == 2)
-    UpdateChargeMetrics();
-}
-
-void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_Ph_RMS_V(const char* data, uint16_t reply_len, int idx) {
-  REQUIRE_LEN(2);
-  mt_obl_main_volts->SetElemValue(idx, CAN_UINT(0) / 2.0);
-  if (idx == 2)
-    UpdateChargeMetrics();
 }
 
 void OvmsVehicleSmartEQ::PollReply_OBL_JB2AC_LeakageDiag(const char* data, uint16_t reply_len) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -84,7 +84,7 @@ static const OvmsPoller::poll_pid_t obdii_7e4_dcdc_polls[] =
 {
   // { tx, rx, type, pid, {.ts={ {OFF,AWAKE,ON,CHARGING}, {<delayed_start>OFF,AWAKE,ON,CHARGING} }}, bus, protocol }
   // AWAKE short interval needed for trickle charging (HVAC on)
-  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,10,10,10 }, { 0,5,5,5 } }}, 0, ISOTP_STD },    // DCDC activation request
+  { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3022, {.ts={ { 0,10,10,10 }, { 0,5,5,9 } }}, 0, ISOTP_STD },    // DCDC activation request
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3023, {.ts={ { 0,30,30,30 }, { 0,19,19,19 } }}, 0, ISOTP_STD }, // 14V DCDC voltage request
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3024, {.ts={ { 0,20,20,20 }, { 0,8,8,14 } }}, 0, ISOTP_STD },   // 14V DCDC voltage measure
   { 0x7E4, 0x7EC, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x3025, {.ts={ { 0,30,30,30 }, { 0,20,20,20 } }}, 0, ISOTP_STD }, // 14V DCDC current measure
@@ -122,7 +122,7 @@ static const OvmsPoller::poll_pid_t fast_charger_polls[] =
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x2001, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph1_RMS_A
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503A, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph2_RMS_A
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x503B, {.ts={ { 0,0,0,5 }, { 0,0,0,7 } }}, 0, ISOTP_STD },    // rqJB2AC_Ph3_RMS_A
-  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,13 }, { 0,0,0,13 } }}, 0, ISOTP_STD },  // rqJB2AC Mains active power consumed
+  { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x504A, {.ts={ { 0,0,0,5 }, { 0,0,0,8 } }}, 0, ISOTP_STD },    // rqJB2AC Mains active power consumed
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5049, {.ts={ { 0,0,0,601 }, { 0,0,0,58 } }}, 0, ISOTP_STD }, // rqJB2AC_Mains phase frequency
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5070, {.ts={ { 0,0,0,601 }, { 0,0,0,59 } }}, 0, ISOTP_STD }, // rqJB2AC_Max Current limitation
   { 0x792, 0x793, VEHICLE_POLL_TYPE_OBDIIEXTENDED, 0x5062, {.ts={ { 0,0,0,601 }, { 0,0,0,61 } }}, 0, ISOTP_STD }, // rqJB2AC_Ground Resistance


### PR DESCRIPTION
Refactors fast charger phase voltage/current poll handlers to stop triggering `UpdateChargeMetrics()` on phase index 2 and instead update metrics from the JB2AC power reply path. This aligns charge metric refresh with the active power signal.

Also adjusts poll timing: DCDC activation request (0x3022) delayed charging interval is changed from 5s to 9s, and JB2AC mains active power (0x504A) polling is increased from 13s to 5s/8s for normal/delayed charging schedules.