### PR TITLE
vwegolf: set v.e.on and v.e.awake

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -8,6 +8,8 @@ Open Vehicle Monitor System v3 - Change log
     means we don't see the VIN frames but at least we're not crashing
     over and over.
 - Fiat eDoblo: added passive lock status from CAN 0x612.
+- VW e-Golf: populate v.e.awake and v.e.on, derived from the terminal (KL_15, 0x3C0)
+    and drivetrain-READY (0x391) frames.
 - VW e-Golf: added remote climate control (preconditioning) over KCAN BAP via the J533 connector.
     Start/stop from the app or the standard climatecontrol command. The car runs its stored
     climate profile: OVMS does not set the temperature, it follows the setpoint configured in

--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -14,6 +14,9 @@ Open Vehicle Monitor System v3 - Change log
     Start/stop from the app or the standard climatecontrol command. The car runs its stored
     climate profile: OVMS does not set the temperature, it follows the setpoint configured in
     the MIB. Requires the KCAN (J533) wiring described in the user guide.
+- VW e-Golf: v.e.parktime no longer clamped — the 0x6B7 CAN park-time field is 17-bit
+    (saturates at ~36.5 h), so the saturated max is ignored and OVMS's native (uncapped)
+    park-time counter is used instead.
 
 
 2026-07-18 MB   3.3.006  OTA release

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vwegolf.dbc
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vwegolf.dbc
@@ -18,7 +18,7 @@ NS_ :
 
 BS_:
 
-BU_: OVMS BMS ESP Gateway BCM ChargeCtrl ClimaECU Instruments AmbientSensor GearModule
+BU_: OVMS BMS ESP Gateway BCM ChargeCtrl ClimaECU Instruments AmbientSensor GearModule Powertrain
 
 // ---------------------------------------------------------------------------
 // KCAN (500 kbps) — convenience/comfort bus, accessible via J533 harness
@@ -125,6 +125,18 @@ BO_ 391 GearSelector: 8 GearModule
 BO_ 1716 VIN_Broadcast: 8 Gateway
  SG_ VIN_FrameIndex : 0|8@1+ (1,0) [0|2] "" OVMS
 
+// Clamp/terminal status (0x3C0). d[2] carries the terminal bits: KL_S (accessory)
+// and KL_15 (ignition). KL_15 = car awake / switched on by the user -> ms_v_env_awake.
+BO_ 960 ClampStatus: 8 Gateway
+ SG_ KlS_Accessory : 16|1@1+ (1,0) [0|1] "" OVMS
+ SG_ Kl15_Ignition : 17|1@1+ (1,0) [0|1] "" OVMS
+
+// OBD_01 (0x391). d[7] bit 5 = OBD_Driving_Cycle: the drivetrain READY flag, set only
+// when the car is drivable. ms_v_env_on = KL_15 && READY. d[5] = accelerator pedal.
+BO_ 913 OBD_01: 8 Powertrain
+ SG_ OBD_Driving_Cycle : 61|1@1+ (1,0) [0|1] "" OVMS
+ SG_ OBD_Abs_Pedal_Pos : 40|8@1+ (0.392,0) [0|100] "%" OVMS
+
 // ---------------------------------------------------------------------------
 // BAP extended frames on KCAN (29-bit IDs, node 0x25 = clima ECU)
 // These are multi-frame BAP messages, not conventional CAN signals.
@@ -165,6 +177,7 @@ CM_ BU_ ClimaECU "Climatronic / Standklima ECU — remote pre-conditioning via B
 CM_ BU_ Instruments "Instrument cluster — range estimates derived from BMS model";
 CM_ BU_ AmbientSensor "Ambient temperature sensor cluster (solar + outside air)";
 CM_ BU_ GearModule "Gear selector module (Waehlhebel)";
+CM_ BU_ Powertrain "Powertrain / motor controller — terminal status and OBD readiness broadcasts";
 
 CM_ BO_ 949 "KCAN. Secondary clima running indicator from clima ECU. Byte[0] bit 7. Confirmed Captures 1 and 2.";
 CM_ BO_ 1516 "KCAN. Secondary clima status byte from clima ECU. Observed 0x04=idle, 0x07=active. Full decode not confirmed.";

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -620,10 +620,14 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
 
             // Park time: 17-bit field at bit offset 20, factor 1 s.
             // d[2] bits [7:4] → result bits [3:0], d[3] → [11:4], d[4] bits [4:0] → [16:12].
+            // The field saturates at its 17-bit max (0x1FFFF ≈ 36.5 h); ignore that
+            // clamped value so v.e.parktime falls back to OVMS's native (uncapped) counter.
             tmp_u32 = ((uint32_t)(d[2] & 0xf0) >> 4) | ((uint32_t)(d[3]) << 4) |
                       ((uint32_t)(d[4] & 0x1f) << 12);
-            StandardMetrics.ms_v_env_parktime->SetValue(tmp_u32);
-            ESP_LOGV(TAG, "0x06B7 parktime=%u", tmp_u32);
+            if (tmp_u32 != 0x1FFFF) {
+                StandardMetrics.ms_v_env_parktime->SetValue(tmp_u32);
+                ESP_LOGV(TAG, "0x06B7 parktime=%u", tmp_u32);
+            }
 
             tmp_u8 = ((uint8_t)(d[7] & 0xff) << 0) |
                      0;  // outerTemp Faktor 0.5 Offset -50, Minimum -50, Maximum 75 [°C] Initial 77

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -633,6 +633,20 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
             ESP_LOGV(TAG, "0x06B7 outside=%.1f°C", tmp_f32);
             break;
         }
+        case 0x391:  // OBD_01: drivetrain READY status
+        {
+            // d[7] bit 5 is OBD_Driving_Cycle: it goes high only once the drivetrain is fully
+            // up and the car is ready to drive; it stays clear during charging, remote climate
+            // and while the ignition is merely on but not yet READY. The frame keeps
+            // broadcasting after the ignition goes off and the bit stays latched high for
+            // several seconds into the power-down, so it is combined with KL_15 for v.e.on
+            // rather than used on its own. if only ignition is turned on again this bit is cleared.
+            // (d[5] carries the accelerator pedal position, OBD_Abs_Pedal_Pos - not mapped.)
+            m_drivetrain_ready = (d[7] & 0x20) != 0;
+            StandardMetrics.ms_v_env_on->SetValue(m_kl15_on && m_drivetrain_ready);
+            ESP_LOGV(TAG, "0x391 READY=%u", m_drivetrain_ready);
+            break;
+        }
         case 0x3C0:  // clamp status received
         {
             // the following are from d[2]
@@ -644,6 +658,12 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
             // KL_Infotainment Faktor 1 Offset 0, Minimum 0, Maximum 1 [] Initial 0
             // Remotestart_KL15_Anf Faktor 1 Offset 0, Minimum 0, Maximum 1 [] Initial 0
             // Remotestart_Motor_Start Faktor 1 Offset 0, Minimum 0, Maximum 1 [] Initial 0
+            // KL_15 (terminal 15 = ignition) means the car is awake and switched on by the
+            // user; drivable (v.e.on) additionally requires the drivetrain to report READY.
+            m_kl15_on = (d[2] & 0x02) != 0;
+            StandardMetrics.ms_v_env_awake->SetValue(m_kl15_on);
+            StandardMetrics.ms_v_env_on->SetValue(m_kl15_on && m_drivetrain_ready);
+            ESP_LOGV(TAG, "0x3C0 KL_15=%u KL_S=%u", m_kl15_on, d[2] & 0x01);
             break;
         }
         case 0x3B5: {
@@ -714,6 +734,15 @@ void OvmsVehicleVWeGolf::Ticker1(uint32_t ticker) {
     bool just_went_idle = (m_bus_idle_ticks == VWEGOLF_BUS_TIMEOUT_SECS);
     ESP_LOGV(TAG, "Ticker1: bus_idle=%u alive=%d ocu=%d", m_bus_idle_ticks, bus_alive,
              m_ocu_active);
+
+    // When the bus goes silent the car is asleep: clear the awake / drivable state as a
+    // backstop in case the terminal frames stopped before signalling the off transition.
+    if (!bus_alive) {
+        m_kl15_on = false;
+        m_drivetrain_ready = false;
+        StandardMetrics.ms_v_env_awake->SetValue(false);
+        StandardMetrics.ms_v_env_on->SetValue(false);
+    }
 
     // Clear OCU node presence on either condition:
     //   1. Bus went idle (no frames for VWEGOLF_BUS_TIMEOUT_SECS) — no one to hear us.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
@@ -99,6 +99,11 @@ class OvmsVehicleVWeGolf : public OvmsVehicle {
     void Ticker1(uint32_t ticker) override;
 
  private:
+    // Awake / drivable state, derived from the terminal (0x3C0 KL_15) and READY
+    // (0x391) frames in IncomingFrameCan3.
+    bool m_kl15_on = false;
+    bool m_drivetrain_ready = false;
+
     // Seconds since the last KCAN (can3) frame arrived. Reset to 0 in IncomingFrameCan3,
     // incremented each second in Ticker1. Bus is alive while < VWEGOLF_BUS_TIMEOUT_SECS.
     // Initialized to timeout so we treat the bus as offline at cold boot.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
@@ -200,6 +200,7 @@ struct StandardMetricsType {
     OvmsMetricFloat*  ms_v_env_cabintemp        = new OvmsMetricFloat("ms_v_env_cabintemp");
     OvmsMetricFloat*  ms_v_env_cabinsetpoint    = new OvmsMetricFloat("ms_v_env_cabinsetpoint");
     OvmsMetricBool*   ms_v_env_on               = new OvmsMetricBool("ms_v_env_on");
+    OvmsMetricBool*   ms_v_env_awake            = new OvmsMetricBool("ms_v_env_awake");
     OvmsMetricBool*   ms_v_env_locked           = new OvmsMetricBool("ms_v_env_locked");
     OvmsMetricBool*   ms_v_env_hvac             = new OvmsMetricBool("ms_v_env_hvac");
     OvmsMetricInt*    ms_v_env_parktime         = new OvmsMetricInt("ms_v_env_parktime");


### PR DESCRIPTION
Problem: `ms_v_env_on` was never set, so the app always showed the car as parked.

Fix: Set `ms_v_env_on` based off READY (drive-able) status and `ms_v_env_awake` based on ignition status.

Also fix park time being limited to 36.5h

Test scenario => `ms_v_env_on`:
- Driving => true
- Ignition on, not drive-able => false
- Parked => false
- Charging (AC) => false
- Climate precondition on battery => false

Test scenario => `ms_v_env_awake`:
- Driving => true
- Ignition on, not drive-able => true
- Parked => false
- Charging (AC) => false
- Climate precondition on battery => false

Reference sources: https://github.com/commaai/opendbc/blob/master/opendbc/dbc/vw_mqb.dbc
Validated against CAN captures.