### PR TITLE
smartEQ : Adjust battery health polling

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_poller.h
@@ -44,7 +44,7 @@ static const OvmsPoller::poll_pid_t obdii_79b_polls[] =
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {.ts={ { 0,300,300,60 }, { 0,10,10,10 } }}, 0, ISOTP_STD },     // HV Contactor Cycles
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x08, {.ts={ { 0,300,300,300 }, { 0,27,27,27 } }}, 0, ISOTP_STD },    // SOC more detailed
   { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x25, {.ts={ { 0,0,0,100 }, { 0,0,0,155 } }}, 0, ISOTP_STD },         // SOC Recalibration
-  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,3600,3600,0 }, { 0,60,60,0 } }}, 0, ISOTP_STD },     // Battery Health (SOH)
+  { 0x79B, 0x7BB, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {.ts={ { 0,300,300,300 }, { 0,57,57,57 } }}, 0, ISOTP_STD },    // Battery Health SOH/CAP
 };
 
 //   -> HandleOBDpolling() will add the following PIDs


### PR DESCRIPTION
Update the smartEQ OBD poll timing for PID 0x61 to query battery health more frequently and relabel it as SOH/CAP.