### PR TITLE
Add notification flood control and web config

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_notifications.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_notifications.cpp
@@ -35,6 +35,10 @@ void OvmsWebServer::HandleCfgNotifications(PageEntry_t& p, PageContext_t& c)
   std::string error;
   std::string vehicle_minsoc, vehicle_stream;
   std::string log_trip_storetime, log_trip_minlength, log_grid_storetime;
+  std::string rl_default_info_rate, rl_default_info_burst;
+  std::string rl_default_alert_rate, rl_default_alert_burst;
+  std::string rl_default_error_rate, rl_default_error_burst;
+  std::string rl_queue_info_max_entries, rl_queue_alert_max_entries, rl_queue_error_max_entries;
   bool report_trip_enable;
   bool debug_tasks, debug_heap_alert;
   std::string report_trip_minlength;
@@ -46,6 +50,15 @@ void OvmsWebServer::HandleCfgNotifications(PageEntry_t& p, PageContext_t& c)
     log_trip_storetime = c.getvar("log_trip_storetime");
     log_trip_minlength = c.getvar("log_trip_minlength");
     log_grid_storetime = c.getvar("log_grid_storetime");
+    rl_default_info_rate = c.getvar("rl_default_info_rate");
+    rl_default_info_burst = c.getvar("rl_default_info_burst");
+    rl_default_alert_rate = c.getvar("rl_default_alert_rate");
+    rl_default_alert_burst = c.getvar("rl_default_alert_burst");
+    rl_default_error_rate = c.getvar("rl_default_error_rate");
+    rl_default_error_burst = c.getvar("rl_default_error_burst");
+    rl_queue_info_max_entries = c.getvar("rl_queue_info_max_entries");
+    rl_queue_alert_max_entries = c.getvar("rl_queue_alert_max_entries");
+    rl_queue_error_max_entries = c.getvar("rl_queue_error_max_entries");
     report_trip_enable = (c.getvar("report_trip_enable") == "yes");
     report_trip_minlength = c.getvar("report_trip_minlength");
     debug_tasks = (c.getvar("debug_tasks") == "yes");
@@ -84,6 +97,62 @@ void OvmsWebServer::HandleCfgNotifications(PageEntry_t& p, PageContext_t& c)
       }
     }
 
+    if (rl_default_info_rate != "") {
+      float v = atof(rl_default_info_rate.c_str());
+      if (v <= 0 || v > 100) {
+        error += "<li data-input=\"rl_default_info_rate\">Info rate must be in range 0.001…100.0 msg/s</li>";
+      }
+    }
+    if (rl_default_info_burst != "") {
+      float v = atof(rl_default_info_burst.c_str());
+      if (v < 1 || v > 1000) {
+        error += "<li data-input=\"rl_default_info_burst\">Info burst must be in range 1…1000</li>";
+      }
+    }
+    if (rl_default_alert_rate != "") {
+      float v = atof(rl_default_alert_rate.c_str());
+      if (v <= 0 || v > 100) {
+        error += "<li data-input=\"rl_default_alert_rate\">Alert rate must be in range 0.001…100.0 msg/s</li>";
+      }
+    }
+    if (rl_default_alert_burst != "") {
+      float v = atof(rl_default_alert_burst.c_str());
+      if (v < 1 || v > 1000) {
+        error += "<li data-input=\"rl_default_alert_burst\">Alert burst must be in range 1…1000</li>";
+      }
+    }
+    if (rl_default_error_rate != "") {
+      float v = atof(rl_default_error_rate.c_str());
+      if (v <= 0 || v > 100) {
+        error += "<li data-input=\"rl_default_error_rate\">Error rate must be in range 0.001…100.0 msg/s</li>";
+      }
+    }
+    if (rl_default_error_burst != "") {
+      float v = atof(rl_default_error_burst.c_str());
+      if (v < 1 || v > 1000) {
+        error += "<li data-input=\"rl_default_error_burst\">Error burst must be in range 1…1000</li>";
+      }
+    }
+
+    if (rl_queue_info_max_entries != "") {
+      int v = atoi(rl_queue_info_max_entries.c_str());
+      if (v < 1 || v > 50000) {
+        error += "<li data-input=\"rl_queue_info_max_entries\">Info queue limit must be in range 1…50000</li>";
+      }
+    }
+    if (rl_queue_alert_max_entries != "") {
+      int v = atoi(rl_queue_alert_max_entries.c_str());
+      if (v < 1 || v > 50000) {
+        error += "<li data-input=\"rl_queue_alert_max_entries\">Alert queue limit must be in range 1…50000</li>";
+      }
+    }
+    if (rl_queue_error_max_entries != "") {
+      int v = atoi(rl_queue_error_max_entries.c_str());
+      if (v < 1 || v > 50000) {
+        error += "<li data-input=\"rl_queue_error_max_entries\">Error queue limit must be in range 1…50000</li>";
+      }
+    }
+
     if (error == "") {
       // success:
       if (vehicle_minsoc == "0")
@@ -114,6 +183,46 @@ void OvmsWebServer::HandleCfgNotifications(PageEntry_t& p, PageContext_t& c)
       else
         MyConfig.SetParamValue("notify", "report.trip.minlength", report_trip_minlength);
 
+      if (rl_default_info_rate == "")
+        MyConfig.DeleteInstance("notify", "rl.default.info.rate");
+      else
+        MyConfig.SetParamValue("notify", "rl.default.info.rate", rl_default_info_rate);
+      if (rl_default_info_burst == "")
+        MyConfig.DeleteInstance("notify", "rl.default.info.burst");
+      else
+        MyConfig.SetParamValue("notify", "rl.default.info.burst", rl_default_info_burst);
+
+      if (rl_default_alert_rate == "")
+        MyConfig.DeleteInstance("notify", "rl.default.alert.rate");
+      else
+        MyConfig.SetParamValue("notify", "rl.default.alert.rate", rl_default_alert_rate);
+      if (rl_default_alert_burst == "")
+        MyConfig.DeleteInstance("notify", "rl.default.alert.burst");
+      else
+        MyConfig.SetParamValue("notify", "rl.default.alert.burst", rl_default_alert_burst);
+
+      if (rl_default_error_rate == "")
+        MyConfig.DeleteInstance("notify", "rl.default.error.rate");
+      else
+        MyConfig.SetParamValue("notify", "rl.default.error.rate", rl_default_error_rate);
+      if (rl_default_error_burst == "")
+        MyConfig.DeleteInstance("notify", "rl.default.error.burst");
+      else
+        MyConfig.SetParamValue("notify", "rl.default.error.burst", rl_default_error_burst);
+
+      if (rl_queue_info_max_entries == "")
+        MyConfig.DeleteInstance("notify", "rl.queue.info.max_entries");
+      else
+        MyConfig.SetParamValue("notify", "rl.queue.info.max_entries", rl_queue_info_max_entries);
+      if (rl_queue_alert_max_entries == "")
+        MyConfig.DeleteInstance("notify", "rl.queue.alert.max_entries");
+      else
+        MyConfig.SetParamValue("notify", "rl.queue.alert.max_entries", rl_queue_alert_max_entries);
+      if (rl_queue_error_max_entries == "")
+        MyConfig.DeleteInstance("notify", "rl.queue.error.max_entries");
+      else
+        MyConfig.SetParamValue("notify", "rl.queue.error.max_entries", rl_queue_error_max_entries);
+
       MyConfig.SetParamValueBool("module", "debug.tasks", debug_tasks);
       MyConfig.SetParamValueBool("module", "debug.heap.alert", debug_heap_alert);
 
@@ -137,6 +246,15 @@ void OvmsWebServer::HandleCfgNotifications(PageEntry_t& p, PageContext_t& c)
     log_trip_storetime = MyConfig.GetParamValue("notify", "log.trip.storetime");
     log_trip_minlength = MyConfig.GetParamValue("notify", "log.trip.minlength");
     log_grid_storetime = MyConfig.GetParamValue("notify", "log.grid.storetime");
+    rl_default_info_rate = MyConfig.GetParamValue("notify", "rl.default.info.rate");
+    rl_default_info_burst = MyConfig.GetParamValue("notify", "rl.default.info.burst");
+    rl_default_alert_rate = MyConfig.GetParamValue("notify", "rl.default.alert.rate");
+    rl_default_alert_burst = MyConfig.GetParamValue("notify", "rl.default.alert.burst");
+    rl_default_error_rate = MyConfig.GetParamValue("notify", "rl.default.error.rate");
+    rl_default_error_burst = MyConfig.GetParamValue("notify", "rl.default.error.burst");
+    rl_queue_info_max_entries = MyConfig.GetParamValue("notify", "rl.queue.info.max_entries");
+    rl_queue_alert_max_entries = MyConfig.GetParamValue("notify", "rl.queue.alert.max_entries");
+    rl_queue_error_max_entries = MyConfig.GetParamValue("notify", "rl.queue.error.max_entries");
     report_trip_enable = MyConfig.GetParamValueBool("notify", "report.trip.enable");
     report_trip_minlength = MyConfig.GetParamValue("notify", "report.trip.minlength");
     debug_tasks = MyConfig.GetParamValueBool("module", "debug.tasks");
@@ -192,6 +310,59 @@ void OvmsWebServer::HandleCfgNotifications(PageEntry_t& p, PageContext_t& c)
     "https://docs.openvehicles.com/en/latest/userguide/notifications.html#grid-history-log"
     "\">user manual</a> for details.</p>",
     "min=\"0\" max=\"365\" step=\"1\"", "days");
+
+  c.fieldset_end();
+
+  c.fieldset_start("Notification Flood Protection");
+
+  c.input("number", "Default info rate", "rl_default_info_rate", rl_default_info_rate.c_str(), "Default: 0.1",
+    "<p>Allowed message rate for <code>info</code> notifications (messages per second).</p>"
+    "<p>e.g. 0.1 = 1 message every 10 seconds, 1 = 1 message per second, 10 = 10 messages per second.</p>",
+    "min=\"0.001\" max=\"100\" step=\"0.001\"", "msg/s");
+  c.input("number", "Default info burst", "rl_default_info_burst", rl_default_info_burst.c_str(), "Default: 3",
+    "<p>Token bucket burst size for <code>info</code>. This is the maximum number of messages that can pass immediately "
+    "during a short spike before throttling starts.</p>"
+    "<p>Functional example: with rate = 0.1 msg/s and burst = 3, up to 3 info messages can be sent right away. "
+    "After that, the bucket refills by 1 token every 10 seconds, so the next message is allowed after about 10 seconds.</p>",
+    "min=\"1\" max=\"1000\" step=\"1\"");
+
+  c.input("number", "Default alert rate", "rl_default_alert_rate", rl_default_alert_rate.c_str(), "Default: 0.2",
+    "<p>Allowed message rate for <code>alert</code> notifications.</p>"
+    "<p>e.g. 0.1 = 1 message every 10 seconds, 1 = 1 message per second, 10 = 10 messages per second.</p>",
+    "min=\"0.001\" max=\"100\" step=\"0.001\"", "msg/s");
+  c.input("number", "Default alert burst", "rl_default_alert_burst", rl_default_alert_burst.c_str(), "Default: 5",
+    "<p>Token bucket burst size for <code>alert</code>. This is the maximum number of messages that can pass immediately "
+    "during a short spike before throttling starts.</p>"
+    "<p>Functional example: with rate = 0.2 msg/s and burst = 5, up to 5 alert messages can be sent right away. "
+    "After that, the bucket refills by 1 token every 5 seconds.</p>",
+    "min=\"1\" max=\"1000\" step=\"1\"");
+
+  c.input("number", "Default error rate", "rl_default_error_rate", rl_default_error_rate.c_str(), "Default: 0.5",
+    "<p>Allowed message rate for <code>error</code> notifications.</p>"
+    "<p>e.g. 0.1 = 1 message every 10 seconds, 1 = 1 message per second, 10 = 10 messages per second.</p>",
+    "min=\"0.001\" max=\"100\" step=\"0.001\"", "msg/s");
+  c.input("number", "Default error burst", "rl_default_error_burst", rl_default_error_burst.c_str(), "Default: 10",
+    "<p>Token bucket burst size for <code>error</code>. This is the maximum number of messages that can pass immediately "
+    "during a short spike before throttling starts.</p>"
+    "<p>Functional example: with rate = 0.5 msg/s and burst = 10, up to 10 error messages can be sent right away. "
+    "After that, the bucket refills by 1 token every 2 seconds.</p>",
+    "min=\"1\" max=\"1000\" step=\"1\"");
+
+  c.input("number", "Info queue limit", "rl_queue_info_max_entries", rl_queue_info_max_entries.c_str(), "Default: 200",
+    "<p>Maximum queued <code>info</code> notifications before new messages are dropped.</p>",
+    "min=\"1\" max=\"50000\" step=\"1\"", "entries");
+  c.input("number", "Alert queue limit", "rl_queue_alert_max_entries", rl_queue_alert_max_entries.c_str(), "Default: 200",
+    "<p>Maximum queued <code>alert</code> notifications before new messages are dropped.</p>",
+    "min=\"1\" max=\"50000\" step=\"1\"", "entries");
+  c.input("number", "Error queue limit", "rl_queue_error_max_entries", rl_queue_error_max_entries.c_str(), "Default: 300",
+    "<p>Maximum queued <code>error</code> notifications before new messages are dropped.</p>",
+    "min=\"1\" max=\"50000\" step=\"1\"", "entries");
+
+  c.input_info("Advanced overrides",
+    "Use notify keys like <code>rl.channel.&lt;caller&gt;.&lt;type&gt;.rate</code> and "
+    "<code>rl.channel.&lt;caller&gt;.&lt;type&gt;.subtype.&lt;subtype&gt;.rate</code> for channel/subtype specific limits. "
+    "Example: set <code>config set notify rl.channel.ovmsv3.alert.rate=0.5</code> to allow up to 1 alert every 2 seconds on ovmsv3, "
+    "and set <code>config set notify rl.channel.ovmsv3.alert.subtype.vehicle.idle.rate=0.1</code> to further limit that subtype to 1 every 10 seconds.");
 
   c.fieldset_end();
 

--- a/vehicle/OVMS.V3/main/ovms_notify.cpp
+++ b/vehicle/OVMS.V3/main/ovms_notify.cpp
@@ -49,11 +49,70 @@ using namespace std;
 
 OvmsNotify       MyNotify       __attribute__ ((init_priority (1820)));
 
+#define NOTIFY_RL_NOTICE_COOLDOWN_MS 60000
+
 // Tracing:
 //  level 0 = no tracing (logging)
 //  level 1 = trace standard (text & data) notifications
 //  level 2 = also trace stream notifications
 #define DO_TRACE(type) (MyNotify.m_trace == 2 || (MyNotify.m_trace == 1 && strcmp((type), "stream") != 0))
+
+namespace
+  {
+  struct NotifyRateLimitConfig
+    {
+    float rate;
+    float burst;
+    };
+
+  static NotifyRateLimitConfig GetNotifyRateLimitConfig(const char* type, const std::string& caller, const std::string& subtype)
+    {
+    NotifyRateLimitConfig cfg;
+    float default_rate = 0.1f;
+    float default_burst = 3.0f;
+
+    if (strcmp(type, "alert") == 0)
+      {
+      default_rate = 0.2f;
+      default_burst = 5.0f;
+      }
+    else if (strcmp(type, "error") == 0)
+      {
+      default_rate = 0.5f;
+      default_burst = 10.0f;
+      }
+
+    std::string default_base = std::string("rl.default.") + type;
+    cfg.rate = MyNotify.GetRateConfig(default_base + ".rate", default_rate);
+    cfg.burst = MyNotify.GetRateConfig(default_base + ".burst", default_burst);
+
+    std::string base = std::string("rl.channel.") + caller + "." + type;
+    cfg.rate = MyNotify.GetRateConfig(base + ".rate", cfg.rate);
+    cfg.burst = MyNotify.GetRateConfig(base + ".burst", cfg.burst);
+
+    std::string subbase = base + ".subtype." + subtype;
+    cfg.rate = MyNotify.GetRateConfig(subbase + ".rate", cfg.rate);
+    cfg.burst = MyNotify.GetRateConfig(subbase + ".burst", cfg.burst);
+
+    if (cfg.rate <= 0.0f)
+      cfg.rate = 0.001f;
+    if (cfg.burst < 1.0f)
+      cfg.burst = 1.0f;
+
+    return cfg;
+    }
+
+  static size_t GetNotifyQueueLimit(const char* type)
+    {
+    if (strcmp(type, "info") == 0)
+      return MyNotify.GetSizeConfig("rl.queue.info.max_entries", 200);
+    if (strcmp(type, "alert") == 0)
+      return MyNotify.GetSizeConfig("rl.queue.alert.max_entries", 200);
+    if (strcmp(type, "error") == 0)
+      return MyNotify.GetSizeConfig("rl.queue.error.max_entries", 300);
+    return 0;
+    }
+  }
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -80,6 +139,17 @@ void notify_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
     {
     OvmsNotifyCallbackEntry* mc = itc->second;
     writer->printf("  %s(%d): verbosity=%d\n", mc->m_caller, mc->m_reader, mc->m_verbosity);
+    }
+
+  writer->printf("Rate limiter buckets: %d\n", MyNotify.m_rl_buckets.size());
+  writer->printf("Queue limits: info=%d alert=%d error=%d\n",
+    MyNotify.GetQueueLimitForType("info"),
+    MyNotify.GetQueueLimitForType("alert"),
+    MyNotify.GetQueueLimitForType("error"));
+  for (auto it=MyNotify.m_rl_buckets.begin(); it!=MyNotify.m_rl_buckets.end(); ++it)
+    {
+    writer->printf("  %s: tokens=%.2f dropped=%" PRIu32 "\n",
+      it->first.c_str(), it->second.tokens, it->second.dropped);
     }
 
   if (MyNotify.m_types.size() > 0)
@@ -282,6 +352,15 @@ OvmsNotifyType::~OvmsNotifyType()
 uint32_t OvmsNotifyType::QueueEntry(OvmsNotifyEntry* entry)
   {
   OvmsRecMutexLock lock(&m_mutex);
+
+  if (MyNotify.QueueLimitExceeded(m_name, m_entries.size()))
+    {
+    ESP_LOGW(TAG, "Drop notification due to queue limit: type=%s", m_name);
+    MyNotify.MaybeEmitRateLimitNotice("queue", m_name, "queue_overflow", 1);
+    delete entry;
+    return 0;
+    }
+
   uint32_t id = m_nextid++;
 
   entry->m_id = id;
@@ -439,6 +518,7 @@ OvmsNotify::OvmsNotify()
   ESP_LOGI(TAG, "Initialising NOTIFICATIONS (1820)");
 
   m_nextreader = 1;
+  m_internal_notice = false;
 
 #ifdef CONFIG_OVMS_DEV_DEBUGNOTIFICATIONS
   m_trace = 1;
@@ -575,6 +655,118 @@ void OvmsNotify::RegisterType(const char* type)
     }
   }
 
+bool OvmsNotify::IsUserFacingType(const char* type)
+  {
+  return (strcmp(type, "info") == 0 || strcmp(type, "alert") == 0 || strcmp(type, "error") == 0);
+  }
+
+float OvmsNotify::GetRateConfig(const std::string& key, float defval)
+  {
+  std::string raw = MyConfig.GetParamValue("notify", key);
+  if (raw.empty())
+    return defval;
+  return atof(raw.c_str());
+  }
+
+size_t OvmsNotify::GetSizeConfig(const std::string& key, size_t defval)
+  {
+  std::string raw = MyConfig.GetParamValue("notify", key);
+  if (raw.empty())
+    return defval;
+  int val = atoi(raw.c_str());
+  if (val < 1)
+    return 1;
+  return val;
+  }
+
+size_t OvmsNotify::GetQueueLimitForType(const char* type)
+  {
+  return GetNotifyQueueLimit(type);
+  }
+
+bool OvmsNotify::QueueLimitExceeded(const char* type, size_t current_entries)
+  {
+  return !m_internal_notice && IsUserFacingType(type) && current_entries >= GetQueueLimitForType(type);
+  }
+
+bool OvmsNotify::ConsumeRateToken(const char* caller, const char* type, const char* subtype)
+  {
+  if (m_internal_notice || !IsUserFacingType(type))
+    return true;
+
+  std::string caller_key = caller ? caller : "unknown";
+  std::string subtype_key = subtype ? subtype : "none";
+  NotifyRateLimitConfig cfg = GetNotifyRateLimitConfig(type, caller_key, subtype_key);
+
+  std::string bucket_key = caller_key + "|" + type + "|" + subtype_key;
+  NotifyBucketState& bs = m_rl_buckets[bucket_key];
+  uint32_t now_ms = esp_log_timestamp();
+
+  if (bs.last_refill_ms == 0)
+    {
+    bs.last_refill_ms = now_ms;
+    bs.tokens = cfg.burst;
+    }
+  else
+    {
+    float elapsed_s = (float)(now_ms - bs.last_refill_ms) / 1000.0f;
+    bs.last_refill_ms = now_ms;
+    bs.tokens += elapsed_s * cfg.rate;
+    if (bs.tokens > cfg.burst)
+      bs.tokens = cfg.burst;
+    }
+
+  if (bs.tokens >= 1.0f)
+    {
+    bs.tokens -= 1.0f;
+    return true;
+    }
+
+  bs.dropped++;
+  return false;
+  }
+
+void OvmsNotify::MaybeEmitRateLimitNotice(const char* caller, const char* type, const char* subtype, uint32_t dropped_now)
+  {
+  if (m_internal_notice || dropped_now == 0)
+    return;
+
+  std::string caller_key = caller ? caller : "unknown";
+  std::string subtype_key = subtype ? subtype : "none";
+  std::string notice_key = caller_key + "|" + type + "|" + subtype_key;
+  uint32_t now_ms = esp_log_timestamp();
+  uint32_t& last_ms = m_rl_notice_suppress[notice_key];
+
+  if (last_ms && (now_ms - last_ms) < NOTIFY_RL_NOTICE_COOLDOWN_MS)
+    return;
+
+  m_rl_notice_suppress[notice_key] = now_ms;
+  m_internal_notice = true;
+  NotifyStringf("alert", "notify.rate_limit",
+    "Notification flood control active: dropped %" PRIu32 " message(s) for channel=%s type=%s subtype=%s",
+    dropped_now, caller_key.c_str(), type, subtype_key.c_str());
+  m_internal_notice = false;
+  }
+
+void OvmsNotify::CollectReaders(OvmsNotifyType* type, const char* subtype, size_t size,
+  std::bitset<NOTIFY_MAX_READERS>& readers, uint32_t& dropped_by_rl, const char*& dropped_caller)
+  {
+  for (OvmsNotifyCallbackMap_t::iterator itc = m_readers.begin(); itc != m_readers.end(); ++itc)
+    {
+    OvmsNotifyCallbackEntry* mc = itc->second;
+    if (!mc->Accepts(type, subtype, size))
+      continue;
+    if (ConsumeRateToken(mc->m_caller, type->m_name, subtype))
+      readers.set(mc->m_reader);
+    else
+      {
+      ++dropped_by_rl;
+      if (dropped_by_rl == 1)
+        dropped_caller = mc->m_caller;
+      }
+    }
+  }
+
 uint32_t OvmsNotify::NotifyString(const char* type, const char* subtype, const char* value)
   {
   OvmsRecMutexLock lock(&m_mutex);
@@ -590,13 +782,14 @@ uint32_t OvmsNotify::NotifyString(const char* type, const char* subtype, const c
 
   // determine all currently active readers accepting the message:
   std::bitset<NOTIFY_MAX_READERS> readers;
+  uint32_t dropped_by_rl = 0;
+  const char* dropped_caller = "mixed";
   size_t size = strlen(value);
-  for (OvmsNotifyCallbackMap_t::iterator itc=m_readers.begin(); itc!=m_readers.end(); ++itc)
-    {
-    OvmsNotifyCallbackEntry* mc = itc->second;
-    if (mc->Accepts(mt, subtype, size))
-      readers.set(mc->m_reader);
-    }
+  CollectReaders(mt, subtype, size, readers, dropped_by_rl, dropped_caller);
+
+  if (dropped_by_rl)
+    MaybeEmitRateLimitNotice(dropped_caller, type, subtype, dropped_by_rl);
+
   if (readers.count() == 0)
     {
     ESP_LOGD(TAG, "Abort: no readers for type '%s' subtype '%s' size %d", type, subtype, size);
@@ -632,15 +825,20 @@ uint32_t OvmsNotify::NotifyCommand(const char* type, const char* subtype, const 
   // get verbosity levels needed by readers accepting the message:
   std::map<int, OvmsNotifyEntryCommand*> verbosity_msgs;
   std::bitset<NOTIFY_MAX_READERS> readers;
+  uint32_t dropped_by_rl = 0;
+  const char* dropped_caller = "mixed";
+  CollectReaders(mt, subtype, 0, readers, dropped_by_rl, dropped_caller);
+
   for (auto itc=m_readers.begin(); itc!=m_readers.end(); itc++)
     {
     OvmsNotifyCallbackEntry* mc = itc->second;
-    if (mc->Accepts(mt, subtype))
-      {
+    if (readers.test(mc->m_reader))
       verbosity_msgs[mc->m_verbosity] = NULL;
-      readers.set(mc->m_reader); // cache acceptance
-      }
     }
+
+  if (dropped_by_rl)
+    MaybeEmitRateLimitNotice(dropped_caller, type, subtype, dropped_by_rl);
+
   if (verbosity_msgs.size() == 0)
     {
     if (DO_TRACE(type))

--- a/vehicle/OVMS.V3/main/ovms_notify.h
+++ b/vehicle/OVMS.V3/main/ovms_notify.h
@@ -171,6 +171,14 @@ class OvmsNotify : public ExternalRamAllocated
     virtual ~OvmsNotify();
 
   public:
+    struct NotifyBucketState
+      {
+      float tokens = 0.0f;
+      uint32_t last_refill_ms = 0;
+      uint32_t dropped = 0;
+      uint32_t last_notice_ms = 0;
+      };
+
     size_t RegisterReader(const char* caller, int verbosity, OvmsNotifyCallback_t callback,
                           bool configfiltered=false, OvmsNotifyFilterCallback_t filtercallback=NULL);
     void RegisterReader(size_t reader, const char* caller, int verbosity, OvmsNotifyCallback_t callback,
@@ -188,17 +196,30 @@ class OvmsNotify : public ExternalRamAllocated
     uint32_t NotifyCommand(const char* type, const char* subtype, const char* cmd);
     uint32_t NotifyCommandf(const char* type, const char* subtype, const char* fmt, ...) __attribute__ ((format (printf, 4, 5)));
     void NotifyErrorCode(uint32_t code, uint32_t data, bool raised, bool force=false);
+    bool IsUserFacingType(const char* type);
+    size_t GetQueueLimitForType(const char* type);
+    bool QueueLimitExceeded(const char* type, size_t current_entries);
+    bool ConsumeRateToken(const char* caller, const char* type, const char* subtype);
+    void MaybeEmitRateLimitNotice(const char* caller, const char* type, const char* subtype, uint32_t dropped_now);
+    float GetRateConfig(const std::string& key, float defval);
+    size_t GetSizeConfig(const std::string& key, size_t defval);
 
   public:
     OvmsNotifyCallbackMap_t m_readers;
     OvmsRecMutex m_mutex;
 
   protected:
+    void CollectReaders(OvmsNotifyType* type, const char* subtype, size_t size,
+      std::bitset<NOTIFY_MAX_READERS>& readers, uint32_t& dropped_by_rl, const char*& dropped_caller);
+
     size_t m_nextreader;
 
   public:
     OvmsNotifyTypeMap_t m_types;
     OvmsNotifyErrorCodeMap_t m_errorcodes;
+    std::map<std::string, NotifyBucketState> m_rl_buckets;
+    std::map<std::string, uint32_t> m_rl_notice_suppress;
+    bool m_internal_notice;
     int m_trace;
   };
 


### PR DESCRIPTION
Code generated by LLM!
So this is an implementation idea that actually works.

Introduce per-channel/per-subtype notification rate limiting with token buckets and queue caps for info/alert/error types, including dropped-message tracking and cooldown-based flood-control alert notices. Add helper methods and status output to inspect limiter buckets and active queue limits.
Expose all new defaults in the web notifications config page with validation and persistence for rate, burst, and queue limit settings, plus guidance for advanced override keys.

#1455 

I’ve run a few tests, and the code seems to work. 
Anyone who wants to modify this code is welcome to do so. 
I am unable to do it myself, as I don't want to get into the subject of notifications.