### PR TITLE
fix(mcp2515): convert INT to level trigger, close RX-wedge root cause

### DIFF
--- a/vehicle/OVMS.V3/components/can/src/can.cpp
+++ b/vehicle/OVMS.V3/components/can/src/can.cpp
@@ -364,6 +364,7 @@ void can_status(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, c
   writer->printf("DBC:       %s\n",(sbus->GetDBC())?sbus->GetDBC()->GetName().c_str():"none");
 
   writer->printf("\nInterrupts:%20" PRId32 "\n",sbus->m_status.interrupts);
+  writer->printf("Isr Ovrflw:%20d\n",sbus->m_status.isr_queue_overrun);
   writer->printf("Rx pkt:    %20" PRId32 "\n",sbus->m_status.packets_rx);
   writer->printf("Rx ovrflw: %20d\n",sbus->m_status.rxbuf_overflow);
   writer->printf("Tx pkt:    %20" PRId32 "\n",sbus->m_status.packets_tx);
@@ -751,12 +752,12 @@ void canbus::LogStatus(CAN_log_type_t type)
       return;
     ESP_LOGE(TAG,
       "%s: intr=%" PRId32 " rxpkt=%" PRId32 " txpkt=%" PRId32 " errflags=%#" PRIx32 " rxerr=%d txerr=%d rxinval=%d"
-      " rxovr=%d txovr=%d txdelay=%" PRId32 " txfail=%" PRId32 " wdgreset=%d errreset=%d txqueue=%" PRId32,
+      " rxovr=%d txovr=%d txdelay=%" PRId32 " txfail=%" PRId32 " wdgreset=%d errreset=%d isrovr=%d txqueue=%" PRId32,
       m_name, m_status.interrupts, m_status.packets_rx, m_status.packets_tx,
       m_status.error_flags, m_status.errors_rx, m_status.errors_tx,
       m_status.invalid_rx, m_status.rxbuf_overflow, m_status.txbuf_overflow,
       m_status.txbuf_delay, m_status.tx_fails, m_status.watchdog_resets,
-      m_status.error_resets, uxQueueMessagesWaiting(m_txqueue));
+      m_status.error_resets, m_status.isr_queue_overrun, uxQueueMessagesWaiting(m_txqueue));
     }
   if (MyCan.HasLogger())
     MyCan.LogStatus(this, type, &m_status);
@@ -773,7 +774,7 @@ bool canbus::StatusChanged()
   uint32_t chksum = m_status.errors_rx + m_status.errors_tx
     + m_status.invalid_rx + m_status.rxbuf_overflow + m_status.txbuf_overflow
     + m_status.error_flags + m_status.txbuf_delay + m_status.tx_fails
-    + m_status.watchdog_resets + m_status.error_resets;
+    + m_status.watchdog_resets + m_status.error_resets + m_status.isr_queue_overrun;
   if (chksum != m_status_chksum)
     {
     m_status_chksum = chksum;

--- a/vehicle/OVMS.V3/components/can/src/can.h
+++ b/vehicle/OVMS.V3/components/can/src/can.h
@@ -157,6 +157,9 @@ typedef struct
   uint16_t watchdog_resets;         // Watchdog reset counter
   uint16_t error_resets;            // Error resolving reset counter
   uint32_t error_time;              // monotonictime of last error state detection
+  uint16_t isr_queue_overrun;       // ISR->task service ping dropped (queue full); not a lost
+                                     // frame -- raw data stays latched in the HW RX buffer, the
+                                     // RX-stall watchdog is the backstop that re-arms the line
   } CAN_status_t;
 
 // CAN error states

--- a/vehicle/OVMS.V3/components/can/src/canformat_crtd.cpp
+++ b/vehicle/OVMS.V3/components/can/src/canformat_crtd.cpp
@@ -108,7 +108,7 @@ std::string canformat_crtd::get(CAN_log_message_t* message)
     case CAN_LogStatus_Statistics:
       snprintf(buf,sizeof(buf),
         "%l" PRId32 ".%06ld %c%s %s intr=%" PRId32 " rxpkt=%" PRId32 " txpkt=%" PRId32 " errflags=%#" PRIx32 " rxerr=%d txerr=%d"
-        " rxinval=%d rxovr=%d txovr=%d txdelay=%" PRId32 " txfail=%" PRId32 " wdgreset=%d errreset=%d txqueue=%" PRId32,
+        " rxinval=%d rxovr=%d txovr=%d txdelay=%" PRId32 " txfail=%" PRId32 " wdgreset=%d errreset=%d isrovr=%d txqueue=%" PRId32,
         message->timestamp.tv_sec, message->timestamp.tv_usec,
         busnumber,
         (message->type == CAN_LogStatus_Error) ? "CER" : "CST",
@@ -117,7 +117,7 @@ std::string canformat_crtd::get(CAN_log_message_t* message)
         message->status.errors_rx, message->status.errors_tx, message->status.invalid_rx,
         message->status.rxbuf_overflow, message->status.txbuf_overflow,
         message->status.txbuf_delay, message->status.tx_fails, message->status.watchdog_resets,
-        message->status.error_resets, uxQueueMessagesWaiting(message->origin->m_txqueue));
+        message->status.error_resets, message->status.isr_queue_overrun, uxQueueMessagesWaiting(message->origin->m_txqueue));
       break;
 
     case CAN_LogInfo_Comment:

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -46,6 +46,31 @@ static IRAM_ATTR void MCP2515_isr(void *pvParameters)
 
   me->m_status.interrupts++;
 
+  // INT is a level signal: the MCP2515 holds it low for as long as any unmasked
+  // CANINTF flag is set, so with GPIO_INTR_LOW_LEVEL configured (see constructor)
+  // this ISR would be re-entered continuously -- an interrupt storm -- for as long
+  // as the line stays low, i.e. until AsynchronousInterruptHandler() has drained
+  // CANINTF over SPI. Mask this pin's interrupt now, before queuing the service
+  // request, so it cannot re-enter while unserviced. Direct register write, not
+  // gpio_intr_disable(): OVMS installs the GPIO ISR service with
+  // ESP_INTR_FLAG_IRAM (main/ovms_peripherals.cpp), so this handler runs in an
+  // IRAM context and may execute while the flash cache is disabled.
+  // gpio_intr_disable() (components/driver/gpio.c) is not IRAM_ATTR in
+  // ESP-IDF v3.3.4 (only gpio_intr_service is) and must not be called from
+  // here -- the direct single-register write below is also cheaper on this
+  // hot ISR path. Re-arming happens in AsynchronousInterruptHandler() once
+  // CANINTF reads back clear.
+  //
+  // Note: gpio_intr_disable() also does gpio_intr_status_clr() (write-1-to-
+  // clear the GPIO status latch) right after int_ena=0; we deliberately skip
+  // that clear here. It's safe: every re-arm path goes through
+  // gpio_intr_enable(), which itself calls gpio_intr_status_clr() BEFORE
+  // setting int_ena (verified in gpio.c), so any stale latch is cleared
+  // exactly at re-enable -- the only moment it matters. Clearing it here at
+  // mask time would be redundant, and pointless while INT is still held low,
+  // since the level-triggered condition would immediately re-latch it.
+  GPIO.pin[me->m_intpin].int_ena = 0;
+
   // we don't know the IRQ source and querying by SPI is too slow for an ISR,
   // so we let AsynchronousInterruptHandler() figure out what to do.
   CAN_queue_msg_t msg = {};
@@ -53,7 +78,20 @@ static IRAM_ATTR void MCP2515_isr(void *pvParameters)
   msg.body.bus = me;
 
   //send callback request to main CAN processor task
-  xQueueSendFromISR(MyCan.m_rxqueue, &msg, &task_woken);
+  if (xQueueSendFromISR(MyCan.m_rxqueue, &msg, &task_woken) != pdTRUE)
+    {
+    // Queue full: the service request was dropped, so nothing will call
+    // AsynchronousInterruptHandler() -> re-arm this bus's GPIO interrupt this time.
+    // This is NOT a lost frame -- the interrupt line is already masked above, so
+    // the raw frame(s) stay safely latched in the MCP2515's own hardware RX
+    // buffers (read over SPI, untouched by this failure) rather than being
+    // dropped. Nothing is silently discarded: count it, and rely on the RX-stall
+    // watchdog (canbus::BusTicker10 / CheckRxStalled(), which polls CANINTF
+    // directly over SPI, independent of GPIO interrupt state) as the backstop --
+    // it will see the still-pending RX flag and call Reset(), whose Start()
+    // unconditionally re-enables this GPIO interrupt as a safety net.
+    me->m_status.isr_queue_overrun++;
+    }
 
   // Yield to minimize latency if we have woken up a higher priority task:
   if (task_woken == pdTRUE)
@@ -98,7 +136,13 @@ if (m_spibus->m_initialized == false) {
   esp_err_t ret = spi_bus_add_device(host,  &m_devcfg, &m_spi);
   assert(ret==ESP_OK);
 
-  gpio_set_intr_type((gpio_num_t)m_intpin, GPIO_INTR_NEGEDGE);
+  // INT is a level signal (held low while any unmasked CANINTF flag is set), not an
+  // edge -- GPIO_INTR_NEGEDGE would miss the interrupt entirely if it is ever dropped
+  // (e.g. ISR->task queue full), permanently wedging the RX path since no further edge
+  // would ever arrive. GPIO_INTR_LOW_LEVEL instead keeps re-asserting for as long as
+  // the source is unserviced; see MCP2515_isr() and AsynchronousInterruptHandler() for
+  // the mask/re-arm handshake that keeps this from storming.
+  gpio_set_intr_type((gpio_num_t)m_intpin, GPIO_INTR_LOW_LEVEL);
   gpio_isr_handler_add((gpio_num_t)m_intpin, MCP2515_isr, (void*)this);
 
   // Initialise in powered down mode
@@ -269,6 +313,13 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
 
   // CANINTE (interrupt enable), all interrupts
   WriteReg(REG_CANINTE, 0b11111111);
+
+  // Safety net: unconditionally re-arm the GPIO level interrupt on every (re)start.
+  // Normally it is re-armed by AsynchronousInterruptHandler() once drained; this
+  // covers the rare case where that path never ran (e.g. ISR->task queue was full
+  // and the service ping got dropped) by restoring a known-good state whenever the
+  // bus is (re)started, including the RX-stall watchdog's Reset()->Start() path.
+  gpio_intr_enable((gpio_num_t)m_intpin);
 
   // And record that we are powered on
   if (GetPowerMode() != On)
@@ -586,9 +637,19 @@ bool mcp2515::AsynchronousInterruptHandler(CAN_frame_t* frame, uint32_t* framesR
   uint8_t errflag = p[1];
   uint8_t txb0ctrl = p[4];
 
+  // Invariant: whoever returns false (drain loop ends) with INT deasserted must
+  // re-arm the GPIO interrupt here -- there are two such exit points below (this
+  // early "nothing pending" return, and the final pin-level check at the bottom
+  // of the function), and both must re-arm. Re-enabling any earlier, while a flag
+  // we have not yet serviced could still be asserted, would let the ISR storm
+  // again immediately. Each mcp2515 instance owns a dedicated INT GPIO (see
+  // ovms_peripherals.cpp: can2/can3 use distinct VSPI_PIN_MCP2515_*_INT pins),
+  // so re-arming this pin can never re-enable while a sibling instance on a
+  // shared line is still asserting -- there is no shared line in this topology.
   if (intstat == 0)
     {
-    // all interrupts handled
+    // All interrupts handled: CANINTF read back clear, so INT is already high.
+    gpio_intr_enable((gpio_num_t)m_intpin);
     return false;
     }
 
@@ -787,8 +848,16 @@ bool mcp2515::AsynchronousInterruptHandler(CAN_frame_t* frame, uint32_t* framesR
     LogStatus(log_status);
     }
 
-  // Read the interrupt pin status and if it's still active (low), require another interrupt handling iteration
-  return !gpio_get_level((gpio_num_t)m_intpin);
+  // Read the interrupt pin status and if it's still active (low), require another
+  // interrupt handling iteration. If it has gone high, this handled interrupt was
+  // the last pending source -- re-arm here too (see invariant comment above; this
+  // is the second, and only other, false-returning exit point of this function).
+  if (gpio_get_level((gpio_num_t)m_intpin))
+    {
+    gpio_intr_enable((gpio_num_t)m_intpin);
+    return false;
+    }
+  return true;
   }
 
 

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
@@ -103,12 +103,12 @@ class mcp2515 : public canbus
   public:
     spi* m_spibus;
     spi_device_handle_t m_spi;
+    int m_intpin;  // public: read by the file-scope ISR (MCP2515_isr) to mask/re-arm its own INT line
 
   protected:
     spi_device_interface_config_t m_devcfg;
     int m_clockspeed;
     int m_cspin;
-    int m_intpin;
     uint8_t m_last_errflag = 0;
     uint8_t m_canctrl_mode;
     OvmsMutex m_write_mutex;


### PR DESCRIPTION
Root-cause fix for the RX wedge that the stall watchdog PR (#1461) detects and recovers from. Builds on that branch.

The MCP2515 INT pin is level-asserted — it stays low as long as any unmasked CANINTF bit is set, it doesn't pulse. The driver registers it as `GPIO_INTR_NEGEDGE`, so the ESP32 only reacts to the high→low transition. If a single service gets lost (concretely: `xQueueSendFromISR` onto a momentarily full rx queue, return value was never checked), RX0IF stays set, INT stays low forever, and no new edge can ever fire: RX is permanently dead with frozen counters. That's exactly the signature I hit twice on-car, and the watchdog confirmed it — CANINTF had RX pending while the ISR count stood still.

Fix, using the standard level-trigger handshake:

- INT GPIO switched to `GPIO_INTR_LOW_LEVEL`
- ISR masks its own pin before returning (direct `GPIO.pin[n].int_ena = 0` write — the `gpio_intr_disable()` call isn't IRAM-safe) and queues the rx task as before, now with the send result checked (failure counted in a new `isr_queue_overrun` status field)
- the rx task's drain loop re-arms the pin via `gpio_intr_enable()` on every drained exit — level semantics mean a frame arriving between the final CANINTF read and re-enable just re-fires immediately, no lost-event window
- `Start()` unconditionally re-arms as a safety net, so any Reset cycle restores a known-good state
- INT pins are per-instance on this board (checked ovms_peripherals.cpp), no shared-line complications; swcan inherits the same pattern

On-car validation: 7M+ frames on can3 at ~1.3k fps with `Wedge Rsts: 0` and `Isr Ovrflw: 0` — the same drive profile that wedged twice on edge-triggered firmware the day before.

Same disclosure as the watchdog PR: AI-assisted development, validated on the real car.
