### PR TITLE
console_telnet: fix build under CONFIG_OVMS_COMP_TELNET

### DIFF
--- a/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.cpp
+++ b/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.cpp
@@ -127,7 +127,7 @@ void OvmsTelnet::NetManInit(std::string event, void* data)
   m_running = true;
 
   ESP_LOGI(tag, "Launching Telnet Server");
-  auto mglock = console->MongooseLock();
+  auto mglock = MongooseLock();
   struct mg_mgr* mgr = MyNetManager.GetMongooseMgr();
   if (!mgr)
     {

--- a/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.h
+++ b/vehicle/OVMS.V3/components/console_telnet/src/console_telnet.h
@@ -32,6 +32,7 @@
 
 #include "libtelnet.h"
 #include "ovms_console.h"
+#include "mongoose_client.h"
 
 struct mg_connection;
 


### PR DESCRIPTION
console_telnet has not compiled since the MongooseClient base-class refactor: console_telnet.h uses MongooseClient as a base without including its header, and OvmsTelnet::NetManInit calls console->MongooseLock() referencing a global `console` that no longer exists. console_ssh was updated at the time (OvmsSSH::NetManInit calls MongooseLock() directly) but console_telnet was missed.

The breakage is masked because CONFIG_OVMS_COMP_TELNET is unset in the default sdkconfig presets, so neither CI nor the normal build ever compiles console_telnet.cpp. Enabling the telnet console currently fails with:

  console_telnet.h:39:3: error: expected class-name before '{' token
  console_telnet.cpp: 'console' was not declared in this scope

Fixes:
- console_telnet.h: include mongoose_client.h (for the MongooseClient base)
- OvmsTelnet::NetManInit: call MongooseLock() directly, as OvmsTelnet is itself a MongooseClient (matches OvmsSSH::NetManInit)