### PR TITLE
docs(vwegolf): add changes.txt entry for remote climate control

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -8,6 +8,10 @@ Open Vehicle Monitor System v3 - Change log
     means we don't see the VIN frames but at least we're not crashing
     over and over.
 - Fiat eDoblo: added passive lock status from CAN 0x612.
+- VW e-Golf: added remote climate control (preconditioning) over KCAN BAP via the J533 connector.
+    Start/stop from the app or the standard climatecontrol command. The car runs its stored
+    climate profile: OVMS does not set the temperature, it follows the setpoint configured in
+    the MIB. Requires the KCAN (J533) wiring described in the user guide.
 
 
 2026-07-18 MB   3.3.006  OTA release


### PR DESCRIPTION
Follow-up to #1430. That PR was merged without a `changes.txt` entry — @dexterbg flagged it while merging:

> Merging now, but I'm pretty sure this needs an entry to the `changes.txt` as well.

This adds the entry to the unreleased section of the change log, documenting the KCAN BAP remote climate (preconditioning) feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)