### PR TITLE
fix(mcp2515): publish power mode before arming INT in Start()

### DIFF
--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -357,19 +357,22 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
   // CANINTE (interrupt enable), all interrupts
   WriteReg(REG_CANINTE, 0b11111111);
 
-  // Safety net: unconditionally re-arm the GPIO level interrupt on every (re)start.
-  // Normally it is re-armed by AsynchronousInterruptHandler() once drained; this
-  // covers the rare case where that path never ran (e.g. ISR->task queue was full
-  // and the service ping got dropped) by restoring a known-good state whenever the
-  // bus is (re)started, including the RX-stall watchdog's Reset()->Start() path.
-  gpio_intr_enable((gpio_num_t)m_intpin);
-
   // And record that we are powered on
   if (GetPowerMode() != On)
     {
     ESP_LOGI(TAG, "%s: Started, SetPowerMode on", this->GetName());
     }
   pcp::SetPowerMode(On);
+
+  // Safety net: unconditionally re-arm the GPIO level interrupt on every (re)start.
+  // Normally it is re-armed by AsynchronousInterruptHandler() once drained; this
+  // covers the rare case where that path never ran (e.g. ISR->task queue was full
+  // and the service ping got dropped) by restoring a known-good state whenever the
+  // bus is (re)started, including the RX-stall watchdog's Reset()->Start() path.
+  // Must stay after the power publish above: Start() is the only re-arm
+  // path — the handler's guard only masks, never re-arms — so arming first
+  // here loses the race on every Start(), causing the indefinite re-wedge loop.
+  gpio_intr_enable((gpio_num_t)m_intpin);
 
   return ESP_OK;
   }


### PR DESCRIPTION
### Problem

#1476 added an entry guard to `mcp2515::AsynchronousInterruptHandler()`:

```c
if (m_mode == CAN_MODE_OFF || GetPowerMode() != On)
  {
  gpio_intr_disable((gpio_num_t)m_intpin);
  return false;
  }
```

That path masks the INT pin and does not re-arm it. The only other `gpio_intr_enable()` sites are further down in the same handler, unreachable once it has fired, and one in `Start()` -- which arms the pin *before* publishing `pcp::SetPowerMode(On)`, with an `ESP_LOGI` in between. `CANINTE` is set to 0xFF just above, so on a live bus INT is already low when the arm happens.

`CAN_rxtask` sits at prio 23 on core 0 blocked on the queue; `Start()` runs on the Events task on core 1. The queued handler wins, observes `GetPowerMode() != On`, masks the pin, and the bus is deaf. The RX-stall watchdog then calls `Reset()` -> `Stop()` -> `Start()`, which re-arms before publishing and loses the same race again -- so the failure is an indefinite loop, not a one-shot.

Affects can2/can3 on any vehicle, edge since 3.3.006-205. can1 is esp32can and unaffected.

### Fix

Publish the power mode before arming the interrupt. The `if (GetPowerMode() != On) ESP_LOGI(...)` block keeps its position relative to the publish, so the log line is unchanged in meaning.

### Evidence

Same module, both MCP2515 buses populated, FCAN and KCAN live.

Before -- `3.3.006-359-g524bd6e63` (master 9f06aa420 merged into my branch; `components/can` and `components/mcp2515` byte-identical to master):

```
can2:  Interrupts: 1     Rx pkt: 0     Wdg Resets: 1, 2, 3 ...
E (51374) can: can2 RX path wedged (hardware RX pending, not serviced) - resetting bus
E (71374) ... 91374 ... 111374 ... 131374 ... 151374 ...   (exactly 20000 ms apart, indefinitely)
```

After -- `3.3.006-360-gb29d808e0` (same tree + this commit):

```
can2:  Interrupts: 307225   Rx pkt: 311816   Wdg Resets: 0   Wdg Timer: 0 sec
can3:  Interrupts: 152663   Rx pkt: 155324   Wdg Resets: 0   Wdg Timer: 0 sec
```

Details and full logs in #1475.

### Why this is safe

- `MyEvents.SignalEvent()` is async on every overload, and there are no in-tree handlers for `power.can*`, so publishing earlier cannot run foreign code inline.
- `BusTicker10`'s RX-stall branch is gated on `m_mode`, which is set far upstream of both orderings, and `canbus::Start()` -> `ClearStatus()` resets both watchdog timers -- so it cannot re-enter `Reset()` during a `Start()` bounded by `MCP2515_TIMEOUT`.
- The remaining publish-to-arm window is a five-entry map scan plus one non-blocking `xQueueSend`, whose critical section also makes the `m_powermode` store visible to the RX task on the other core before the pin is armed. The old window contained a blocking log call.

Deliberately minimal: this does not touch the guard itself, the presence probe, or the drain-loop cap in `can.cpp`.

Native test suite passes. Written with Claude and validated against real CAN traffic on the car.
