### PR TITLE
OTA: browser firmware upload on the "Flash from file" tab (addresses #86)

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -17,6 +17,13 @@ Open Vehicle Monitor System v3 - Change log
 - VW e-Golf: v.e.parktime no longer clamped — the 0x6B7 CAN park-time field is 17-bit
     (saturates at ~36.5 h), so the saturated max is ignored and OVMS's native (uncapped)
     park-time counter is used instead.
+- OTA: Web UI firmware upload — the firmware setup page "Flash from file" tab can now upload a
+    firmware image directly from the browser and flash it to the inactive OTA partition, with no
+    SD card needed. The upload is streamed to flash (not buffered in RAM); the SD-card path flow
+    is unchanged. New endpoint: POST /api/firmware/upload (cookie/apikey authorized). A progress
+    bar tracks the upload, switching to a "finalising" indicator while the module writes the last
+    of the image to flash. The image size is sent (?size=) so only the needed flash is erased
+    (faster start) and an oversized image is rejected up front.
 
 
 2026-07-18 MB   3.3.006  OTA release

--- a/vehicle/OVMS.V3/components/mongoose/include/mg_locals.h
+++ b/vehicle/OVMS.V3/components/mongoose/include/mg_locals.h
@@ -42,6 +42,12 @@
 #define MG_ENABLE_HTTP 1
 #define MG_ENABLE_THREADSAFE_CONN_MBUFS 0 // superseded by MongooseClient API level lock
 
+// Stream multipart request bodies as MG_EV_HTTP_PART_* events instead of
+// buffering the whole request in RAM. Defined here (not in component CFLAGS) so
+// it is seen identically by the mongoose library and by consumers that handle
+// the events (web firmware upload). Used by HttpFirmwareUpload (web_cfg_firmware).
+#define MG_ENABLE_HTTP_STREAMING_MULTIPART 1
+
 // Note: broadcast support not working reliably yet, do not enable for production!
 // #define MG_ENABLE_BROADCAST 1
 // #define MG_CTL_MSG_MESSAGE_SIZE 64    // Note: default is 8K, we only need this to trigger MG_EV_POLL

--- a/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
+++ b/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
@@ -1069,6 +1069,11 @@ OvmsOTA::OvmsOTA()
   m_lastcheckday = -1;
   m_flashstatus = NULL;
   m_flashperc = 0;
+  m_stream_active = false;
+  m_stream_handle = 0;
+  m_stream_target = NULL;
+  m_stream_expected = 0;
+  m_stream_done = 0;
 
   MyConfig.RegisterParam("ota", "OTA setup and status", true, true);
 
@@ -1344,6 +1349,150 @@ const char* OvmsOTA::GetFlashStatus()
 int OvmsOTA::GetFlashPerc()
   {
   return m_flashperc;
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+// Streaming OTA flash writer
+//
+// Shared core used by ota_flash_vfs() and the web upload handler. The three
+// phases must be called in sequence on a single flash session:
+//   StreamFlashBegin()  - select target partition, lock m_flashing, esp_ota_begin
+//   StreamFlashWrite()  - feed image data (any chunk size), repeated
+//   StreamFlashFinish() - esp_ota_end + set boot partition, unlock
+// StreamFlashAbort() may be called instead of Finish to discard an in-progress
+// session (e.g. a dropped upload). A failing Write/Finish aborts and unlocks the
+// session internally, so the caller must not call Finish/Abort again afterwards.
+// Pass expected_size=0 when the image size is unknown up front (in that case the
+// whole target partition is erased and no progress percentage is reported).
+
+esp_err_t OvmsOTA::StreamFlashBegin(size_t expected_size, std::string& errmsg)
+  {
+  if (!m_flashing.Lock(0))
+    {
+    errmsg = "Flash operation already in progress - cannot flash again";
+    return ESP_ERR_INVALID_STATE;
+    }
+
+  const esp_partition_t *running = esp_ota_get_running_partition();
+  const esp_partition_t *target = esp_ota_get_next_update_partition(running);
+
+  if (running == NULL)
+    {
+    errmsg = "Current running image cannot be determined - aborting";
+    m_flashing.Unlock();
+    return ESP_ERR_INVALID_STATE;
+    }
+  if (target == NULL)
+    {
+    errmsg = "Target partition cannot be determined - aborting";
+    m_flashing.Unlock();
+    return ESP_ERR_INVALID_STATE;
+    }
+  if (running == target)
+    {
+    errmsg = "Cannot flash to running image partition";
+    m_flashing.Unlock();
+    return ESP_ERR_INVALID_STATE;
+    }
+  if (expected_size > 0 && expected_size > target->size)
+    {
+    char buf[128];
+    snprintf(buf, sizeof(buf), "target partition too small (%u bytes capacity) - aborting", target->size);
+    errmsg = buf;
+    if (target->size < 0x700000)
+      SendPartitionTypeAlert(true);
+    m_flashing.Unlock();
+    return ESP_ERR_INVALID_SIZE;
+    }
+
+  SetFlashStatus("OTA Stream Flash: Preparing flash partition...");
+  esp_ota_handle_t otah;
+  esp_err_t err = esp_ota_begin(target, (expected_size > 0) ? expected_size : OTA_SIZE_UNKNOWN, &otah);
+  if (err != ESP_OK)
+    {
+    char buf[96];
+    snprintf(buf, sizeof(buf), "ESP32 error #%d when starting OTA operation", err);
+    errmsg = buf;
+    ClearFlashStatus();
+    m_flashing.Unlock();
+    return err;
+    }
+
+  m_stream_handle = otah;
+  m_stream_target = target;
+  m_stream_expected = expected_size;
+  m_stream_done = 0;
+  m_stream_active = true;
+  SetFlashStatus("OTA Stream Flash: Flashing image partition...");
+  return ESP_OK;
+  }
+
+esp_err_t OvmsOTA::StreamFlashWrite(const void* buf, size_t len, std::string& errmsg)
+  {
+  if (!m_stream_active)
+    {
+    errmsg = "No flash session active";
+    return ESP_ERR_INVALID_STATE;
+    }
+  esp_err_t err = esp_ota_write(m_stream_handle, buf, len);
+  if (err != ESP_OK)
+    {
+    char ebuf[96];
+    snprintf(ebuf, sizeof(ebuf), "ESP32 error #%d when writing to flash - state is inconsistent", err);
+    errmsg = ebuf;
+    StreamFlashAbort();
+    return err;
+    }
+  m_stream_done += len;
+  if (m_stream_expected > 0)
+    SetFlashPerc((m_stream_done * 100) / m_stream_expected);
+  return ESP_OK;
+  }
+
+esp_err_t OvmsOTA::StreamFlashFinish(std::string& errmsg)
+  {
+  if (!m_stream_active)
+    {
+    errmsg = "No flash session active";
+    return ESP_ERR_INVALID_STATE;
+    }
+
+  SetFlashStatus("OTA Stream Flash: Finalising flash write");
+  esp_err_t err = esp_ota_end(m_stream_handle);
+  if (err != ESP_OK)
+    {
+    char ebuf[96];
+    snprintf(ebuf, sizeof(ebuf), "ESP32 error #%d finalising OTA operation - state is inconsistent", err);
+    errmsg = ebuf;
+    m_stream_active = false;
+    ClearFlashStatus();
+    m_flashing.Unlock();
+    return err;
+    }
+
+  SetFlashStatus("OTA Stream Flash: Setting boot partition...");
+  err = esp_ota_set_boot_partition(m_stream_target);
+  m_stream_active = false;
+  ClearFlashStatus();
+  m_flashing.Unlock();
+  if (err != ESP_OK)
+    {
+    char ebuf[96];
+    snprintf(ebuf, sizeof(ebuf), "ESP32 error #%d setting boot partition - check before rebooting", err);
+    errmsg = ebuf;
+    return err;
+    }
+  return ESP_OK;
+  }
+
+void OvmsOTA::StreamFlashAbort()
+  {
+  if (!m_stream_active)
+    return;
+  esp_ota_end(m_stream_handle);
+  m_stream_active = false;
+  ClearFlashStatus();
+  m_flashing.Unlock();
   }
 
 static void OTAFlashTask(void *pvParameters)

--- a/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.h
+++ b/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.h
@@ -33,6 +33,7 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include <esp_ota_ops.h>
 #include "ovms_events.h"
 #include "ovms_mutex.h"
 #include "ovms_partitions.h"
@@ -86,12 +87,28 @@ class OvmsOTA
     int GetFlashPerc();
 
   public:
+    // Streaming OTA flash writer (shared by ota_flash_vfs() and the web upload
+    // handler). Call Begin -> Write* -> Finish in sequence; Abort discards an
+    // in-progress session. A failing Write/Finish aborts & unlocks internally.
+    // Pass expected_size=0 when the image size is unknown up front.
+    esp_err_t StreamFlashBegin(size_t expected_size, std::string& errmsg);
+    esp_err_t StreamFlashWrite(const void* buf, size_t len, std::string& errmsg);
+    esp_err_t StreamFlashFinish(std::string& errmsg);
+    void StreamFlashAbort();
+    bool StreamFlashActive() { return m_stream_active; }
+
+  public:
     OvmsMutex m_flashing;
     const char *m_flashstatus;
     int m_flashperc;
     TaskHandle_t m_autotask;
     int m_lastcheckday;
     std::string m_lastnotifyversion;
+    bool m_stream_active;
+    esp_ota_handle_t m_stream_handle;
+    const esp_partition_t* m_stream_target;
+    size_t m_stream_expected;
+    size_t m_stream_done;
 
 #ifdef CONFIG_OVMS_COMP_SDCARD
   protected:

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.cpp
@@ -594,6 +594,38 @@ void OvmsWebServer::EventHandler(mg_connection *nc, int ev, void *p)
       }
       break;
 
+#if MG_ENABLE_HTTP_STREAMING_MULTIPART && defined(CONFIG_OVMS_COMP_OTA)
+    case MG_EV_HTTP_MULTIPART_REQUEST:      // start of a streamed multipart upload
+      {
+        // No handler attached yet: dispatch by URI & re-check auth here, because
+        // multipart requests never pass through FindPage()/PageEntry::Serve().
+        struct http_message *hm = (struct http_message *) p;
+        std::string uri(hm->uri.p, hm->uri.len);
+        if (uri == "/api/firmware/upload") {
+          if (!MyWebServer.AuthorizeMultipart(hm)) {
+            ESP_LOGW(TAG, "Firmware upload: unauthorized");
+            mg_http_send_error(nc, 401, "Unauthorized");
+            nc->flags |= MG_F_SEND_AND_CLOSE;
+          }
+          else {
+            // The client passes the image size as ?size=<bytes> so the OTA layer
+            // erases only what's needed (faster start) instead of the whole partition:
+            size_t size = 0;
+            char sizebuf[24];
+            if (mg_get_http_var(&hm->query_string, "size", sizebuf, sizeof(sizebuf)) > 0)
+              size = (size_t) strtoul(sizebuf, NULL, 10);
+            ESP_LOGI(TAG, "Firmware upload: authorized, receiving image (size=%u)", (unsigned) size);
+            new HttpFirmwareUpload(nc, size);   // attaches itself to nc->user_data
+          }
+        }
+        else {
+          mg_http_send_error(nc, 404, "Not found");
+          nc->flags |= MG_F_SEND_AND_CLOSE;
+        }
+      }
+      break;
+#endif // MG_ENABLE_HTTP_STREAMING_MULTIPART && defined(CONFIG_OVMS_COMP_OTA)
+
     case MG_EV_CLOSE:                       // connection has been closed
       {
         if (handler) {

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.h
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.h
@@ -486,6 +486,39 @@ class HttpCommandStream : public OvmsShell, public MgHandler
 };
 
 
+#ifdef CONFIG_OVMS_COMP_OTA
+/**
+ * HttpFirmwareUpload: receive a streamed multipart firmware upload and flash it
+ *  directly into the inactive OTA partition (no SD card needed).
+ *
+ * Created by EventHandler() on an authorized MG_EV_HTTP_MULTIPART_REQUEST for the
+ *  upload endpoint; it then consumes the MG_EV_HTTP_PART_* events, feeding the
+ *  image to MyOTA.StreamFlash*(). The firmware part is the first part carrying a
+ *  filename; other form fields are ignored.
+ */
+class HttpFirmwareUpload : public MgHandler
+{
+  public:
+    HttpFirmwareUpload(mg_connection* nc, size_t expected_size = 0);
+    ~HttpFirmwareUpload();
+
+  public:
+    int HandleEvent(int ev, void* p);
+
+  protected:
+    void Respond(int code, const std::string& text);
+
+  protected:
+    bool                      m_flashing = false;     // a StreamFlash session is open
+    bool                      m_responded = false;    // HTTP response already sent
+    bool                      m_ok = false;           // image received & flashed
+    size_t                    m_expected = 0;         // image size from ?size= (0 = unknown)
+    size_t                    m_size = 0;             // bytes received for the image
+    std::string               m_target;               // target partition label (on success)
+};
+#endif // CONFIG_OVMS_COMP_OTA
+
+
 
 /**
  * OvmsWebServer: main web framework (static instance: MyWebServer)
@@ -531,6 +564,11 @@ class OvmsWebServer : public ExternalRamAllocated, MongooseClient
     user_session* GetSession(http_message *hm);
     void CheckSessions(void);
     static bool CheckLogin(std::string username, std::string password);
+#ifdef CONFIG_OVMS_COMP_OTA
+    // Authorize a multipart request (e.g. firmware upload). Multipart requests
+    // bypass PageEntry::Serve, so the cookie/apikey auth is re-checked here.
+    bool AuthorizeMultipart(http_message *hm);
+#endif
 
   public:
     WebSocketHandler* CreateWebSocketHandler(mg_connection* nc);

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_firmware.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg_firmware.cpp
@@ -31,6 +31,9 @@
 #ifdef CONFIG_OVMS_COMP_OTA
 #include "ovms_ota.h"
 #include "ovms_utils.h"
+#include "esp_log.h"
+
+static const char *TAG = "webserver-ota";
 
 /**
  * HandleCfgFirmware: OTA firmware update & boot setup (URL /cfg/firmware)
@@ -305,8 +308,32 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
       "<li>Insert the SD card, wait until the module reboots.</li>"
       "<li>Note: after processing the file will be renamed to <code>ovms3.done</code>.</li>"
     "</ol>");
-  c.input_info("Upload",
-    "Not yet implemented. Please copy your update file to an SD card and enter the path below.");
+  // Upload & flash directly (streamed to the OTA partition, no SD card needed).
+  // Mirrors the "File path" control below: an input-group for the file picker
+  // plus a standard offset button row (as input_button() emits) for the action.
+  c.print(
+    "<div class=\"form-group\">\n"
+      "<label class=\"control-label col-sm-3\" for=\"input-flash_upload_name\">Upload &amp; flash:</label>\n"
+      "<div class=\"col-sm-9\">\n"
+        "<div class=\"input-group\">\n"
+          "<input type=\"text\" class=\"form-control\" id=\"input-flash_upload_name\" placeholder=\"No file selected\" readonly>\n"
+          "<div class=\"input-group-btn\">\n"
+            "<button type=\"button\" class=\"btn btn-default\" id=\"fw-choose-btn\">Browse&hellip;</button>\n"
+          "</div>\n"
+        "</div>\n"
+        "<input type=\"file\" id=\"input-flash_upload\" accept=\".bin\" style=\"display: none\">\n"
+        "<span class=\"help-block\">\n"
+          "<p>Select a firmware <code>ovms3.bin</code> from this device and flash it directly to the "
+          "module &ndash; no SD card needed. Do not interrupt the upload.</p>\n"
+        "</span>\n"
+      "</div>\n"
+    "</div>\n"
+    "<div class=\"form-group\">\n"
+      "<div class=\"col-sm-offset-3 col-sm-9\">\n"
+        "<button type=\"button\" class=\"btn btn-default\" id=\"fw-upload-btn\">Upload &amp; flash now</button>\n"
+      "</div>\n"
+    "</div>\n"
+    "<hr>");
 
   c.printf(
     "<div class=\"form-group\">\n"
@@ -386,6 +413,10 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
             "<h4 class=\"modal-title\">Flashing…</h4>"
           "</div>"
           "<div class=\"modal-body\">"
+            "<div id=\"upload-progress\" class=\"progress\" style=\"display:none\">"
+              "<div id=\"upload-progress-bar\" class=\"progress-bar\" role=\"progressbar\" "
+                "aria-valuenow=\"0\" aria-valuemin=\"0\" aria-valuemax=\"100\" style=\"width:0%\">0%</div>"
+            "</div>"
             "<pre id=\"output\"></pre>"
           "</div>"
           "<div class=\"modal-footer\">"
@@ -430,6 +461,39 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
           "$(\"#ota-server-version\").removeClass(\"text-muted\").addClass(\"text-warning\").text(\"update check failed\");"
           "$(\"#ota-changelog\").text(\"Update check failed (no network, or the update server is unreachable).\");"
         "});"
+      // Upload progress bar control: a pct sets the bar width; mode 'indeterminate'
+      // shows an animated striped full bar (used while the module finalises the
+      // flash, when no byte count is meaningful); call fwbar(null) to hide it.
+      "function fwbar(o){"
+        "var box = $(\"#upload-progress\"), bar = $(\"#upload-progress-bar\");"
+        "if (!o) { box.hide(); return; }"
+        "box.show();"
+        "bar.removeClass(\"progress-bar-striped active progress-bar-success progress-bar-danger\");"
+        "if (o.klass) bar.addClass(o.klass);"
+        "if (o.mode == \"indeterminate\") {"
+          "bar.addClass(\"progress-bar-striped active\").css(\"width\",\"100%\").attr(\"aria-valuenow\",100);"
+        "} else {"
+          "var p = Math.max(0, Math.min(100, o.pct || 0));"
+          "bar.css(\"width\", p+\"%\").attr(\"aria-valuenow\", p);"
+        "}"
+        "bar.text(o.text || \"\");"
+      "}"
+      // --- shared flash-dialog helpers (used by every flash method) --------
+      // Reset the dialog's reboot button to its idle (secondary) style.
+      "function flashReset(){"
+        "$(\".action-reboot\").removeClass(\"btn-primary\").addClass(\"btn-default\");"
+      "}"
+      // Finalise the dialog: colour the bar; on success highlight Reboot.
+      "function flashFinish(ok){"
+        "setloading(\"#flash-dialog\", false);"
+        "if (ok) {"
+          "fwbar({ pct: 100, text: \"Done\", klass: \"progress-bar-success\" });"
+          "$(\"#output\").append(\"\\nReboot to activate the new firmware.\");"
+          "$(\".action-reboot\").removeClass(\"btn-default\").addClass(\"btn-primary\");"
+        "} else {"
+          "fwbar({ pct: 100, text: \"Failed\", klass: \"progress-bar-danger\" });"
+        "}"
+      "}"
       "$(\".action-update-now\").on(\"click\", function(ev){"
         "var server = $(\"input[name=server]\").val() || \"https://api.openvehicles.com/firmware/ota\";"
         "var tag = $(\"input[name=tag]\").val() || \"main\";"
@@ -477,8 +541,224 @@ void OvmsWebServer::HandleCfgFirmware(PageEntry_t& p, PageContext_t& c)
         "$(\"#flash-dialog\").removeClass(\"fade\").modal(\"hide\");"
         "loaduri(\"#main\", \"get\", \"/cfg/firmware\");"
       "});"
+      // Browse: the native file input is hidden; the styled button and the
+      // read-only name field both open it, and its name is shown on selection.
+      "$(\"#fw-choose-btn, #input-flash_upload_name\").on(\"click\", function(){"
+        "$(\"#input-flash_upload\").click();"
+      "});"
+      "$(\"#input-flash_upload\").on(\"change\", function(){"
+        "$(\"#input-flash_upload_name\").val(this.files && this.files.length ? this.files[0].name : \"\");"
+      "});"
+      // Upload & flash: stream the selected file to /api/firmware/upload (the
+      // session cookie authorizes the request); show progress in the flash dialog.
+      "$(\"#fw-upload-btn\").on(\"click\", function(ev){"
+        "ev.stopPropagation();"
+        "var input = document.getElementById(\"input-flash_upload\");"
+        "if (!input.files || !input.files.length) {"
+          "confirmdialog(\"Upload firmware\", \"Please select a firmware file first.\", [\"Close\"]);"
+          "return false;"
+        "}"
+        "var file = input.files[0];"
+        "var fd = new FormData();"
+        "fd.append(\"file\", file, file.name);"
+        "flashReset();"
+        "$(\"#output\").text(\"Uploading firmware (do not interrupt)…\\n\");"
+        "fwbar({ pct: 0, text: \"0%\" });"
+        "setloading(\"#flash-dialog\", true);"
+        "$(\"#flash-dialog\").modal(\"show\");"
+        "var xhr = new XMLHttpRequest();"
+        // Pass the size so the module erases only what's needed (faster start) and
+        // can reject an oversized image up front:
+        "xhr.open(\"POST\", \"/api/firmware/upload?size=\" + file.size, true);"
+        "xhr.upload.onprogress = function(e){"
+          // No length => can't show a percentage; show an animated 'working' bar:
+          "if (!e.lengthComputable) { fwbar({ mode: \"indeterminate\", text: \"Uploading…\" }); return; }"
+          "var pct = Math.round((e.loaded / e.total) * 100);"
+          "if (pct >= 100) fwbar({ mode: \"indeterminate\", text: \"Finalising… (writing to flash)\" });"
+          "else fwbar({ pct: pct, text: pct + \"%\" });"
+        "};"
+        // Body fully sent; the module is still writing the last of it to flash:
+        "xhr.upload.onload = function(){"
+          "fwbar({ mode: \"indeterminate\", text: \"Finalising… (writing to flash)\" });"
+        "};"
+        "xhr.onload = function(){"
+          "if (xhr.status == 200) {"
+            "$(\"#output\").text(xhr.responseText);"
+            "flashFinish(true);"
+          "} else {"
+            "$(\"#output\").text(\"Error \" + xhr.status + \": \" + xhr.responseText);"
+            "flashFinish(false);"
+          "}"
+        "};"
+        "xhr.onerror = function(){"
+          "$(\"#output\").text(\"Error: upload failed (connection lost).\");"
+          "flashFinish(false);"
+        "};"
+        "xhr.send(fd);"
+        "return false;"
+      "});"
     "</script>");
 
   c.done();
+}
+
+
+/**
+ * AuthorizeMultipart: re-check cookie/apikey auth for a multipart request.
+ *
+ * Multipart uploads are delivered as MG_EV_HTTP_MULTIPART_* events and never
+ * pass through FindPage()/PageEntry::Serve(), so the standard auth check does
+ * not run for them. We mirror PageEntry::Serve here: open if no module password
+ * is set, else require a valid session cookie or a matching ?apikey= parameter.
+ */
+bool OvmsWebServer::AuthorizeMultipart(http_message *hm)
+{
+  // No module password configured => web access is open:
+  if (MyConfig.GetParamValue("password", "module").empty())
+    return true;
+  // Valid session cookie?
+  if (GetSession(hm) != NULL)
+    return true;
+  // Or an apikey (= admin password) passed as a query parameter:
+  char buf[64];
+  if (mg_get_http_var(&hm->query_string, "apikey", buf, sizeof(buf)) > 0 &&
+      CheckLogin("admin", buf))
+    return true;
+  return false;
+}
+
+
+/**
+ * HttpFirmwareUpload: streamed multipart firmware upload -> OTA partition
+ */
+
+HttpFirmwareUpload::HttpFirmwareUpload(mg_connection* nc, size_t expected_size)
+  : MgHandler(nc)
+{
+  m_expected = expected_size;
+}
+
+HttpFirmwareUpload::~HttpFirmwareUpload()
+{
+  // Safety net: if the connection died mid-stream, discard the flash session:
+  if (m_flashing)
+    MyOTA.StreamFlashAbort();
+}
+
+void HttpFirmwareUpload::Respond(int code, const std::string& text)
+{
+  if (m_responded || !m_nc)
+    return;
+  m_responded = true;
+  mg_send_head(m_nc, code, (int64_t) text.size(), "Content-Type: text/plain; charset=utf-8");
+  mg_send(m_nc, text.data(), (int) text.size());
+  m_nc->flags |= MG_F_SEND_AND_CLOSE;
+}
+
+int HttpFirmwareUpload::HandleEvent(int ev, void* p)
+{
+  switch (ev)
+  {
+    case MG_EV_HTTP_PART_BEGIN:
+    {
+      struct mg_http_multipart_part* mp = (struct mg_http_multipart_part*) p;
+      // Only act on the first part carrying a filename (the image); ignore any
+      // other form fields, and any further parts once we're busy/done:
+      if (m_flashing || m_ok || m_responded)
+        break;
+      if (mp->file_name == NULL || mp->file_name[0] == 0)
+        break;
+      std::string err;
+      if (MyOTA.StreamFlashBegin(m_expected, err) != ESP_OK) {
+        ESP_LOGW(TAG, "Firmware upload: cannot start flash: %s", err.c_str());
+        Respond(409, "Error: " + err + "\n");
+      }
+      else {
+        m_flashing = true;
+        m_size = 0;
+        ESP_LOGI(TAG, "Firmware upload: receiving '%s'", mp->file_name);
+      }
+      break;
+    }
+
+    case MG_EV_HTTP_PART_DATA:
+    {
+      struct mg_http_multipart_part* mp = (struct mg_http_multipart_part*) p;
+      if (!m_flashing)
+        break;
+      std::string err;
+      if (MyOTA.StreamFlashWrite(mp->data.p, mp->data.len, err) != ESP_OK) {
+        // StreamFlashWrite() has already aborted & unlocked the session:
+        m_flashing = false;
+        ESP_LOGE(TAG, "Firmware upload: flash write failed: %s", err.c_str());
+        Respond(500, "Error: " + err + "\n");
+      }
+      else {
+        m_size += mp->data.len;
+      }
+      break;
+    }
+
+    case MG_EV_HTTP_PART_END:
+    {
+      struct mg_http_multipart_part* mp = (struct mg_http_multipart_part*) p;
+      if (!m_flashing)
+        break;
+      if (mp->status < 0) {
+        // Part was not properly terminated (connection lost): discard.
+        MyOTA.StreamFlashAbort();
+        m_flashing = false;
+        ESP_LOGW(TAG, "Firmware upload: aborted (incomplete part)");
+        Respond(400, "Error: upload aborted\n");
+      }
+      else {
+        std::string err;
+        const char* target = MyOTA.m_stream_target ? MyOTA.m_stream_target->label : "?";
+        if (MyOTA.StreamFlashFinish(err) != ESP_OK) {
+          m_flashing = false;
+          ESP_LOGE(TAG, "Firmware upload: finalise failed: %s", err.c_str());
+          Respond(500, "Error: " + err + "\n");
+        }
+        else {
+          m_flashing = false;
+          m_ok = true;
+          m_target = target;
+          ESP_LOGI(TAG, "Firmware upload: flashed %u bytes, next boot from '%s'",
+                   (unsigned) m_size, m_target.c_str());
+        }
+      }
+      break;
+    }
+
+    case MG_EV_HTTP_MULTIPART_REQUEST_END:
+    {
+      if (!m_responded) {
+        if (m_ok) {
+          char buf[160];
+          snprintf(buf, sizeof(buf),
+            "OTA flash was successful\n  Flashed %u bytes\n  Next boot will be from '%s'\n",
+            (unsigned) m_size, m_target.c_str());
+          Respond(200, buf);
+        }
+        else {
+          Respond(400, "Error: no firmware file received\n");
+        }
+      }
+      break;
+    }
+
+    case MG_EV_CLOSE:
+    {
+      if (m_flashing) {
+        MyOTA.StreamFlashAbort();
+        m_flashing = false;
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+  return ev;
 }
 #endif


### PR DESCRIPTION
Addresses #86 (Web UI: add firmware upload). Design was discussed on the issue and had no objections from @dexterbg; this is the minimal "add upload" slice, with the UI-unification work split into a separate follow-up PR as requested.

## What it does

Adds an "Upload & flash" control to the existing **Flash from file** tab of the firmware setup page. A firmware image selected in the browser is streamed straight into the inactive OTA partition and flashed - no SD card, and the image is never buffered in RAM. The existing flash methods (Update now, Flash from web, Flash from file/SD) are unchanged.

## Notes on the review feedback

- **UI unification is a separate PR.** The earlier draft also unified all four flash methods onto one shared progress dialog; that has been pulled out into a stacked follow-up PR (`feature/firmware-flash-dialogs`) so this one stays focused on adding upload. This PR touches no other flash method - the `.action-update-now` and `.section-flash` handlers are byte-identical to master.

## Validation

Built and flashed to a hw3.1 module (ESP32 rev 3). Verified on-device:

- **Full browser flow:** selecting a `~3 MB` image with the "Upload & flash" control and clicking "Upload & flash now" uploads it with a live progress bar (switching to a "finalising" indicator while the module writes the last of the image to flash); the module reports the flash succeeded and boots the uploaded image. This was used to flash a real build end-to-end from the browser.
- The image is streamed straight to the inactive OTA partition, never buffered in RAM; the `POST /api/firmware/upload` endpoint was also exercised directly with the same result.
- **Auth:** the same request without a session cookie is rejected with `401 Unauthorized` (`AuthorizeMultipart`), so multipart uploads can't bypass the page auth.
- No crashes; `ota_flash_vfs` (SD/file recovery path) exercised unchanged.