### PR TITLE
vfs stat: stack-allocate the MD5 context

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_vfs.cpp
+++ b/vehicle/OVMS.V3/main/ovms_vfs.cpp
@@ -434,17 +434,17 @@ void vfs_stat(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc, con
     return;
     }
 
-  OVMS_MD5_CTX* md5 = new OVMS_MD5_CTX;
-  OVMS_MD5_Init(md5);
+  OVMS_MD5_CTX md5;
+  OVMS_MD5_Init(&md5);
   int filesize = 0;
   uint8_t *buf = new uint8_t[512];
   while(size_t n = fread(buf, sizeof(char), 512, f))
     {
     filesize += n;
-    OVMS_MD5_Update(md5, buf, n);
+    OVMS_MD5_Update(&md5, buf, n);
     }
   uint8_t* rmd5 = new uint8_t[16];
-  OVMS_MD5_Final(rmd5, md5);
+  OVMS_MD5_Final(rmd5, &md5);
 
   char dchecksum[33];
   sprintf(dchecksum,"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",


### PR DESCRIPTION
`vfs_stat()` allocates its MD5 context with `OVMS_MD5_CTX* md5 = new OVMS_MD5_CTX` and frees `rmd5` and `buf` on the way out, but never deletes `md5` leaking 88 bytes (`uint32_t state[4]` + `uint32_t count[2]` + `uint8_t buffer[64]`) on every `vfs stat` invocation.

Both `return`s in the function are before the allocation, so there is exactly one exit path after it and the leak is unconditional on every successful call.

### The change

Rather than add a matching `delete`, this stack-allocates the context, which is what every other user of the API in the tree already does, `components/crypto/crypt_hmac.cpp:45` and four sites in `components/ovms_ota/src/ovms_partitions.cpp` (306, 364, 453, 1026). `vfs_stat()` was the only place heap-allocating one.

That removes the leak by construction rather than relying on a matching free (so a future early return cannot reintroduce it), and drops a heap allocation from the command. The context is 88 bytes against a 6kB command stack (`CONFIG_OVMS_SYS_COMMAND_STACK_SIZE`).

No behavioural change: `new OVMS_MD5_CTX` is default-initialisation, so the context was equally uninitialised beforehand; `OVMS_MD5_Init()` sets `state` and `count`, and `buffer` is written before it is read. `OVMS_MD5_Final()` does not free the context so there is no double-free concern either way.

### Testing

Measured on hw3.1 (ESP32 + PSRAM) with a clean upstream build (vehicle NONE), as an A-B-A. 80 x `vfs stat /store/tlstest.js` (a 175-byte file, so the digest loop itself is negligible), taking a `module memory` snapshot before and reading `module leaks` after. Heap change attributed to the task the command runs on:

```
  arm A  baseline (upstream/master)   OVMS NetMan  SPIRAM  +7040
  arm B  with this patch              OVMS NetMan  SPIRAM     -4
  arm A  baseline again (repeat)      OVMS NetMan  SPIRAM  +7040
```

7040 = 80 x 88 bytes = exactly `sizeof(OVMS_MD5_CTX)` per invocation, reproduced on both baseline arms and gone with the patch. Other tasks show unrelated background churn of a similar magnitude in both arms, which is why the per-task attribution matters.

Note the context lands in SPIRAM rather than internal DRAM on this hardware, so the practical impact is modest - 4MB of PSRAM absorbs a lot of 88-byte leaks. It is still an unbounded per-invocation leak on a long-running module, and `vfs stat` is used by the web backup page as well as interactively.

Both arms were built from the same commit plus an identical throwaway CI/harness commit, so the only difference between them is this patch.