### PR TITLE
Leaf/fix fix can2 traffic flood by implementing MCP2515 filters

### DIFF
--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -279,22 +279,10 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
   WriteReg(REG_CANCTRL, CANCTRL_MODE_CONFIG | CANCTRL_ABAT | CANCTRL_OSM);
   m_canctrl_mode = CANCTRL_MODE_CONFIG;
 
-  // Filter logic is such that if enabled mask and filters 0, 1 are
-  // applied to RX buffer 0, and mask 1 and filters 2-5 are applied to RX buffer 0.
-  // If a packet matches Filters 0, 1 then it is placed in RX buffer 0,
-  // otherwise if it matches Filters 2-5 then it is placed in RX buffer 1.
-  //
-  // If RX Buffer 0 is full and if roll over is enabled then the packet
-  // will be placed in RX Buffer 1 regardless of if it matched the Filters 2-5.
-  //
-  // At start we enable roll over and set all filters to accept all.  If a filter
-  // is set later then we update the registers to check the new filters.
 
   // Disable filter checking and enable buffer 1 rollover
-  WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01100100);
-  WriteRegAndVerify(REG_RXB1CTRL, 0b01100000, 0b01100000);
-
- 
+  EnableRXFilter(false);
+  
   SetTransceiverMode(mode);
 
   // Bus speed
@@ -464,6 +452,43 @@ esp_err_t mcp2515::Stop()
   return ESP_OK;
   }
 
+// Filter logic is such that if enabled mask and filters 0, 1 are
+// applied to RX buffer 0, and mask 1 and filters 2-5 are applied to RX buffer 0.
+// If a packet matches Filters 0, 1 then it is placed in RX buffer 0,
+// otherwise if it matches Filters 2-5 then it is placed in RX buffer 1.
+//
+// If RX Buffer 0 is full and if roll over is enabled then the packet
+// will be placed in RX Buffer 1 regardless of if it matched the Filters 2-5.
+//
+// Roll over from RXB0 to RXB1 is always enabled.
+esp_err_t mcp2515::EnableRXFilter(bool enable)
+  {
+  bool success = false;
+
+  if (enable)
+    {
+    success = (WriteRegAndVerify(REG_RXB0CTRL, 0b00000100, 0b01100100) == ESP_OK &&
+               WriteRegAndVerify(REG_RXB1CTRL, 0b00000000, 0b01100000) == ESP_OK);
+    }
+
+  else
+    {
+    success = (WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01100100) == ESP_OK &&
+               WriteRegAndVerify(REG_RXB1CTRL, 0b01100000, 0b01100000) == ESP_OK);
+    }
+
+  if (!success)
+    {
+    ESP_LOGE(TAG, "%s: Could not %s RX filter", this->GetName(), enable ? "enable" : "disable");
+    return ESP_FAIL;
+    }
+  else
+    {
+    return ESP_OK;
+    }
+  }
+
+
 
 /**
  * SetAcceptanceFilter: configure MCP2515 specific hardware RX filter
@@ -501,18 +526,11 @@ esp_err_t mcp2515::SetAcceptanceFilter(const mcp2515_filter_config_t& cfg)
                     cfg.filter[0].u32 == 0 && cfg.filter[1].u32 == 0 &&
                     cfg.filter[2].u32 == 0 && cfg.filter[3].u32 == 0 &&
                     cfg.filter[4].u32 == 0 && cfg.filter[5].u32 == 0);
-                    
-  if (filters_cleared) {
-    // Disable filter checking as all filters are cleared (revert to default behaviour)
-    WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01100100);
-    WriteRegAndVerify(REG_RXB1CTRL, 0b01100000, 0b01100000);
-  } else
-  {
-    // Enable filter checking as filters have been defined.
-    WriteRegAndVerify(REG_RXB0CTRL, 0b00000100, 0b01100100);
-    WriteRegAndVerify(REG_RXB1CTRL, 0b00000000, 0b01100000);
-  }
-
+            
+  // There is nothing in the MCP2515 datasheet that says that this needs
+  // to be done in config mode but it seems to be a good idea to do so.                    
+  EnableRXFilter(!filters_cleared);
+  
   // Write filters 0-2:
   m_spibus->spi_cmd(m_spi, buf, 0, 14, CMD_WRITE, REG_RXF0SIDH,
     cfg.filter[0].u8[3], cfg.filter[0].u8[2], cfg.filter[0].u8[1],cfg.filter[0].u8[0],

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
@@ -90,6 +90,7 @@ class mcp2515 : public canbus
 
   protected:
     esp_err_t WriteFrame(const CAN_frame_t* p_frame);
+    esp_err_t EnableRXFilter(bool enable);
 
   public:
     void SetPowerMode(PowerMode powermode) override;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/docs/index.rst
@@ -84,6 +84,20 @@ Charge Interruption Alerts  Yes
 
 .. [5] For ZE1 models, a separate 8-wire CAN tap cable and DB9 connector are required. The standard OBD-II to DB9 cable supplied with OVMS cannot be used, as it only has 6 wires. Additionally, the OBD-II port itself cannot be used because the vehicle’s CAN gateway module powers down when the ignition is off, isolating the port from the rest of the vehicle. Instead, you need to build an adapter cable to tap into the CAN buses going to the CAN gateway module located behind the instrument cluster. See the :ref:`2018+ models (ZE1)` for more details.
 
+----------------
+CAN Bus Mapping
+----------------
+
+The Leaf module uses two of the three available OVMS v3 CAN buses.
+
+=========================== ============== ======================================== =================================================================
+OVMS bus                    Leaf bus       Controller                               Function
+=========================== ============== ======================================== =================================================================
+CAN1 (DB9 pins 2 / 7)       EV-CAN         ESP32 internal TWAI/CAN controller       BMS/LBC, motor/inverter, A/C module, pre-2016 TCU/remote commands, wakeup frames
+CAN2 (DB9 pins 4 / 5)       CAR-CAN        MCP2515 #1                               Charger/PDM, VIN, charge counters, lock/unlock, 2016+ TCU/remote commands
+CAN3 (DB9 pins 6 / 8)       IT-CAN         MCP2515 #2                               Instrument cluster / internal bus — not used by the Leaf module
+=========================== ============== ======================================== =================================================================
+
 ----------------------
 Remote Climate Control
 ----------------------
@@ -93,9 +107,9 @@ Remote Climate Control
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 OVMS remote climate support will 'just work' on e-Nv200 Visia/Acenta which don't have a Nissan satnav headunit.
-For Tekna models which are fitted with a Nissan satnav headunit, the Nissan TCU must be unplugged. The TCU is located just below the head unit, remove the trim around the cental head unit to access. 
+For Tekna models which are fitted with a Nissan satnav headunit, follow the instructions below for a 2013-2016 LEAF to unplug the TCU
 
-IMPORTANT: for remote climate to work on the e-NV200, the model year in OVMS should be set to 2015 for model year 2014-2017 and then 2016 for model year 2018+ . CAN writing also needs to be enabled. If remote climate doens't work try a differant model year setting. 
+IMPORTANT: for remote climate to work on the e-NV200, the model year in OVMS should be set to 2015 regardless of the the actual model year of the vehicle. CAN writing also needs to be enabled.
 
 The model year can be set in the web interface or via the command:
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -725,6 +725,7 @@ void OvmsVehicleNissanLeaf::PollReply_Battery(const uint8_t *reply_data, uint16_
 
   float newCarAh = MyConfig.GetParamValueFloat("xnl", "newCarAh", GEN_1_NEW_CAR_AH);
   float soh = ah / newCarAh * 100;
+  ESP_LOGD(TAG, "PollReply_Battery SOH: %.2f", soh);
   m_soh_new_car->SetValue(soh);
   if (cfg_soh_newcar)
     {
@@ -845,7 +846,7 @@ void OvmsVehicleNissanLeaf::PollReply_BMS_SOH(const uint8_t *reply_data, uint16_
 
     uint16_t uint_soh = (reply_data[2] << 8) | reply_data[3];
     float soh = uint_soh / 100.0f;
-    ESP_LOGD(TAG, "BMS SOH: %.2f", soh);
+    ESP_LOGD(TAG, "PollReply_BMS_SOH SOH: %.2f", soh);
     m_soh_instrument->SetValue(soh);
     if (!cfg_soh_newcar)
       {
@@ -1549,15 +1550,20 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           break;
         }
 
+
       // ZE0 SOH
-      if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
-        uint8_t soh = (d[4] >> 1 & 0xF7);
-        m_soh_instrument->SetValue(soh);
-        if (!MyConfig.GetParamValueBool("xnl", "soh.newcar", false))
-        {
-          StandardMetrics.ms_v_bat_soh->SetValue(soh);
+      if (!cfg_ze1) {
+        if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
+          uint8_t soh = (d[4] >> 1 & 0xF7);
+          m_soh_instrument->SetValue(soh);
+          ESP_LOGD(TAG, "IncomingFrameCan1 SOH: %d", soh);
+          if (!MyConfig.GetParamValueBool("xnl", "soh.newcar", false))
+          {
+            StandardMetrics.ms_v_bat_soh->SetValue(soh);
+          }
         }
       }
+
 
 
       uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
@@ -1841,6 +1847,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
           if (soh != 0)
             {
             m_soh_instrument->SetValue(soh);
+            ESP_LOGD(TAG, "IncomingFrameCan2 SOH: %d", soh);
             // we use this unless the user has opted otherwise
             if (!cfg_soh_newcar)
               {

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -45,6 +45,7 @@ static const char *TAG = "v-nissanleaf";
 #endif
 #include "ovms_command.h"
 #include "ovms_config.h"
+#include "mcp2515.h"
 
 #define MAX_POLL_DATA_LEN         329
 #define BMS_TXID                  0x79B
@@ -71,10 +72,10 @@ enum poll_states
 
 static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
   {
-    // BUS 2
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID, {  0, 3600, 0, 0 }, 2, ISOTP_STD },           // VIN [19] Never changes
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID, {  0, 0, 0, 3600 }, 2, ISOTP_STD },   // QC [2] Only changes when charging. Do not update when car is active to reduce traffic.
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID, {  0, 0, 0, 3600 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging. Do not update when car is active to reduce traffic.
+    // BUS 2                                                                         Off,   On, Run, Charge 
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,            {  0, 3600,   0,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,    {  0,    0,   0,   3600 }, 2, ISOTP_STD }, // QC [2] Only changes when charging. Do not update when car is active to reduce traffic.
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,  {  0,    0,   0,   3600 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging. Do not update when car is active to reduce traffic.
     // BUS 1
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
@@ -290,6 +291,52 @@ OvmsVehicleNissanLeaf::~OvmsVehicleNissanLeaf()
 #endif
   }
 
+/// @brief Set the MCP2515 hardware receive filter for CAN2
+/// This is used to filter out unwanted CAN messages on the CAR bus (CAN2) to reduce CPU load and improve performance.
+/// The filter is set to accept only the CAN IDs that are used by the Nissan Leaf ZE1.
+/// Accepted packets are:
+/// - 0x355 and 0x385 (shared mask with bits 7,6,4 don't-care)
+/// - 0x5a9 and 0x5b9 (shared mask with bits 7,6,4 don't-care)
+/// - 0x421, 0x5c5, 0x60d, 0x79a
+/// @param bus The CAN bus to configure (expected to be an MCP2515).
+/// @param enable true to apply the Leaf ZE1 filter, false to clear it (accept all).
+void OvmsVehicleNissanLeaf::SetCan2Mcp2515Filter(canbus* bus, bool enable)
+  {
+  mcp2515* sbus = (mcp2515*)bus;
+  if (sbus == NULL)
+    {
+    ESP_LOGW(TAG, "can2 is not available; hardware receive filter not set");
+    return;
+    }
+
+  mcp2515_filter_config_t cfg = {};
+  if (enable)
+    {
+    // Mask 0 / filters 0-1: shared mask with bits 7,6,4 don't-care.
+    cfg.mask[0].b.sid = 0x72F;
+    cfg.filter[0].b.sid = 0x355;  // covers 0x355 and 0x385
+    cfg.filter[1].b.sid = 0x5a9;  // covers 0x5a9 and 0x5b9
+
+    // Mask 1 / filters 2-5: exact 11-bit ID match.
+    cfg.mask[1].b.sid = 0x7FF;
+    cfg.filter[2].b.sid = 0x421;
+    cfg.filter[3].b.sid = 0x5c5;
+    cfg.filter[4].b.sid = 0x60d;
+    cfg.filter[5].b.sid = 0x79a;
+    }
+
+  esp_err_t res = sbus->SetAcceptanceFilter(cfg);
+  if (res == ESP_OK)
+    {
+    ESP_LOGI(TAG, "can2 MCP2515 hardware receive filter %s", enable ? "set" : "cleared");
+    }
+  else
+    {
+    ESP_LOGE(TAG, "can2 MCP2515 hardware receive filter %s failed", enable ? "set" : "cleared");
+    }
+  }
+
+
 void OvmsVehicleNissanLeaf::CommandInit()
   {
   cmd_xnl = MyCommandApp.RegisterCommand("xnl","Nissan Leaf framework");
@@ -308,6 +355,7 @@ void OvmsVehicleNissanLeaf::CommandInit()
     "Example: 79B 7BB 2101", 3, 3);
   cmd_can2->RegisterCommand("broadcast", "Send OBD2 request as broadcast", shell_obd_request, "<request>", 1, 1);
   }
+
 
 void OvmsVehicleNissanLeaf::ConfigChanged(OvmsConfigParam* param)
   {
@@ -339,6 +387,9 @@ void OvmsVehicleNissanLeaf::ConfigChanged(OvmsConfigParam* param)
   if (!cfg_enable_write) PollSetState(POLLSTATE_OFF);
 
   cfg_ze1 = MyConfig.GetParamValueBool("xnl", "ze1", false);
+
+  // Apply or clear the CAN2 MCP2515 hardware filter when configuration is updated.
+  SetCan2Mcp2515Filter(m_can2, cfg_ze1);
   }
 
 
@@ -1764,6 +1815,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
 
   switch (p_frame->MsgID)
     {
+/* These have been removed to simplify the CAN filter.      
     case 0x180:
       if (d[5] != 0xff)
         {
@@ -1776,26 +1828,33 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_env_footbrake->SetValue(d[6] / 1.39);
         }
       break;
-   case 0x355:
+*/
+    case 0x355:
      // The odometer value on the bus is always in units appropriate
      // for the car's intended market and is unaffected by the dash
      // display preference (in d[4] bit 5).
-     if ((d[6]>>5) & 1)
-       {
-         m_odometer_units = Miles;
-       }
-     else
-       {
-         m_odometer_units = Kilometers;
-       }
-     break;
-    case 0x385:
+      if ((d[6]>>5) & 1)
+        {
+        m_odometer_units = Miles;
+        }
+      else
+        {
+        m_odometer_units = Kilometers;
+        }
+      ESP_LOGV(TAG, "IncomingFrameCan2 odometer units: %s", m_odometer_units == Miles ? "Miles" : "Kilometers");
+      break;
+    case 0x385: // Returns 0,0,0,0 on ZE1
       if (d[2]) StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FL, d[2] / 4.0, PSI);
       if (d[3]) StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FR, d[3] / 4.0, PSI);
       if (d[4]) StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RR, d[4] / 4.0, PSI);
       if (d[5]) StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RL, d[5] / 4.0, PSI);
+      ESP_LOGV(TAG, "IncomingFrameCan2 TPMS: FL=%f FR=%f RR=%f RL=%f",
+               StandardMetrics.ms_v_tpms_pressure->GetElemValue(MS_V_TPMS_IDX_FL, PSI),
+               StandardMetrics.ms_v_tpms_pressure->GetElemValue(MS_V_TPMS_IDX_FR, PSI),
+               StandardMetrics.ms_v_tpms_pressure->GetElemValue(MS_V_TPMS_IDX_RR, PSI),
+               StandardMetrics.ms_v_tpms_pressure->GetElemValue(MS_V_TPMS_IDX_RL, PSI));
       break;
-    case 0x421:
+    case 0x421:  
       switch ( (d[0] >> 3) & 7 )
         {
         case 0: // Parking
@@ -1818,14 +1877,16 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
           if (cfg_enable_write) PollSetState(POLLSTATE_RUNNING);
           break;
         }
+      ESP_LOGV(TAG, "IncomingFrameCan2 Gear: %d", StandardMetrics.ms_v_env_gear->AsInt());
       break;
-    case 0x5a9:
+    case 0x5a9:  
       {
       uint16_t nl_range = d[1] << 4 | d[2] >> 4;
       if (nl_range != 0xfff)
         {
-        m_range_instrument->SetValue(nl_range / 5, Kilometers);
+        m_range_instrument->SetValue(nl_range / 5, Kilometers); // incorrect on a ZE1 (409 returned when dispay shows 129 km)
         }
+      ESP_LOGV(TAG, "IncomingFrameCan2 Range: %f km", m_range_instrument->AsFloat());
       break;
       }
     case 0x5b9:
@@ -1837,6 +1898,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
       uint16_t minutes = ((d[1] & 0x07) | d[2]);
       m_charge_minutes_3kW_remaining->SetValue(minutes);
       }
+      ESP_LOGV(TAG, "IncomingFrameCan2 Charge bars: %d, 3kW minutes: %d", m_remaining_chargebars->AsInt(), m_charge_minutes_3kW_remaining->AsInt());
       break;
     case 0x5b3:
       {
@@ -1864,6 +1926,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         {
         StandardMetrics.ms_v_pos_odometer->SetValue(d[1] << 16 | d[2] << 8 | d[3], m_odometer_units);
         }
+      ESP_LOGV(TAG, "IncomingFrameCan2 Odometer: %f %s", StandardMetrics.ms_v_pos_odometer->AsFloat(m_odometer_units), m_odometer_units == Miles ? "mi" : "km");
       break;
     case 0x60d:
       StandardMetrics.ms_v_door_trunk->SetValue(d[0] & 0x80);
@@ -1909,7 +1972,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
             }
           break;
         }
-
+      ESP_LOGV(TAG, "IncomingFrameCan2 Start button: %d, Locked: %d, Headlights: %d", (d[1]>>1) & 3, StandardMetrics.ms_v_env_locked->AsBool(), StandardMetrics.ms_v_env_headlights->AsBool());
       break;
     }
   }

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1815,20 +1815,18 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
 
   switch (p_frame->MsgID)
     {
-/* These have been removed to simplify the CAN filter.      
-    case 0x180:
+    case 0x180: // Filtered out by CAN RX filter on ZE1
       if (d[5] != 0xff)
         {
         StandardMetrics.ms_v_env_throttle->SetValue(d[5] / 2.00);
         }
       break;
-    case 0x292:
+    case 0x292: // Filtered out by CAN RX filter on ZE1
       if (d[6] != 0xff)
         {
         StandardMetrics.ms_v_env_footbrake->SetValue(d[6] / 1.39);
         }
       break;
-*/
     case 0x355:
      // The odometer value on the bus is always in units appropriate
      // for the car's intended market and is unaffected by the dash
@@ -1843,7 +1841,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         }
       ESP_LOGV(TAG, "IncomingFrameCan2 odometer units: %s", m_odometer_units == Miles ? "Miles" : "Kilometers");
       break;
-    case 0x385: // Returns 0,0,0,0 on ZE1
+    case 0x385: 
       if (d[2]) StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FL, d[2] / 4.0, PSI);
       if (d[3]) StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_FR, d[3] / 4.0, PSI);
       if (d[4]) StandardMetrics.ms_v_tpms_pressure->SetElemValue(MS_V_TPMS_IDX_RR, d[4] / 4.0, PSI);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -157,6 +157,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     void GetDashboardConfig(DashboardConfig& cfg);
 
   private:
+    void SetCan2Mcp2515Filter(canbus* bus, bool enable);
     void CommandInit(); // initialise shell commands specific to Leaf
     void vehicle_nissanleaf_car_on(bool isOn);
     void vehicle_nissanleaf_charger_status(ChargerStatus status);


### PR DESCRIPTION
On the Leaf ZE1 can2 is extremely busy, most packets are meaningless and are not acted on, however the shear volume degrades the system performance and results in overruns.  This patch implements MCP2515 filters so that only the required packets are passed.

Depends upon #1486 and adds to the changes made in #1487.