### PR TITLE
feat(vwegolf): add regen-brake strength metric xvg.v.recup

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,8 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- VW e-Golf: add regenerative-braking strength metric xvg.v.recup (0..4: D0=0, D1=1,
+    D2=2, D3=3, B=4; -1 = N/A), decoded from the gear-selector frame 0x187.
 - vehicle_cadillac_ct5:
     Set the acceptance filter to allow 0x063 (v.on) and 0x5E4 (v.b.soc).
     The high frame rate of this vehicle (> 1600/sec) causes watchdog

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vwegolf.dbc
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vwegolf.dbc
@@ -119,6 +119,9 @@ BO_ 1447 OCU_Keepalive: 8 OVMS
 
 BO_ 391 GearSelector: 8 GearModule
  SG_ GearPosition : 16|4@1+ (1,0) [0|15] "" OVMS
+ SG_ RecupLevel : 12|2@1+ (1,0) [0|3] "" OVMS
+ SG_ RecupSailing : 14|1@1+ (1,0) [0|1] "" OVMS
+ SG_ SystemActive : 15|1@1+ (1,0) [0|1] "" OVMS
 
 // VIN is spread across three sequential frames (frame index 0, 1, 2 in d[0]).
 // Not representable as a simple signal; assembled in firmware from all three.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -38,6 +38,10 @@ OvmsVehicleVWeGolf::OvmsVehicleVWeGolf() {
     // init configs:
     MyConfig.RegisterParam("xvg", "VW e-Golf", true, true);
 
+    // Regenerative-braking strength (numeric, cheap to transmit). Decoded from the
+    // gear-selector frame 0x187 in IncomingFrameCan2. -1 until first seen in D/B.
+    m_recup_level = MyMetrics.InitInt("xvg.v.recup", SM_STALE_MIN, -1);
+
     // KCAN (CAN3) carries comfort, body, and clima frames via the J533 gateway.
     // FCAN (CAN2) is the powertrain bus (BMS, motor controller, VIN).
     // CAN1 (OBD) is diagnostic-only and inaccessible while the car is asleep.
@@ -100,6 +104,27 @@ void OvmsVehicleVWeGolf::IncomingFrameCan2(CAN_frame_t* p_frame) {
                 StandardMetrics.ms_v_env_gear->SetValue(1);
                 StandardMetrics.ms_v_env_drivemode->SetValue(1);
             }
+
+            // Regenerative-braking (recuperation) strength. The e-Golf has five
+            // regen levels: D0 (coast, no regen), D1, D2, D3, and B (max). D0..D3
+            // are selected with the paddles while in gear D; B is its own gear.
+            // Exposed as a 0..4 strength (least->most) on xvg.v.recup.
+            //
+            // State is in this frame's d[1] high nibble; the top bit is always set
+            // in operation, so mask it off (rc = low 3 bits). In gear D:
+            //   0 = D0 coast (just shifted into D, no stage selected)
+            //   1 = D1, 2 = D2, 3 = D3  (paddle regen stages)
+            //   5 = D0 with recuperation switched off by the driver (also coast)
+            // In gear B rc reads 0, but the gear itself means max regen.
+            const uint8_t rc = (p_frame->data.u8[1] >> 4) & 0x7;
+            int recup = -1;                                 // N/A unless in D or B
+            if (gear_nibble == 6) {
+                recup = 4;                                  // B — max regen
+            } else if (gear_nibble == 5) {
+                recup = (rc >= 1 && rc <= 3) ? rc : 0;      // D1/D2/D3, else D0 (coast)
+            }
+            m_recup_level->SetValue(recup);
+            ESP_LOGV(TAG, "0x187 gear=%u rc=%u recup=%d", gear_nibble, rc, recup);
             break;
         }
         case 0x6B4: {
@@ -746,6 +771,10 @@ void OvmsVehicleVWeGolf::Ticker1(uint32_t ticker) {
         m_drivetrain_ready = false;
         StandardMetrics.ms_v_env_awake->SetValue(false);
         StandardMetrics.ms_v_env_on->SetValue(false);
+        // Regen level (xvg.v.recup) is a driving concept — clear it to N/A once the
+        // car is off/asleep so it doesn't linger on the last D/B value (the gear
+        // frame 0x187 stops broadcasting when the car sleeps).
+        m_recup_level->SetValue(-1);
     }
 
     // Clear OCU node presence on either condition:

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
@@ -169,6 +169,10 @@ class OvmsVehicleVWeGolf : public OvmsVehicle {
     // identified by data[0]. We collect all three before committing to the metric.
     uint8_t m_vin_parts_received = 0;
     char m_vin_buf[18] = {};
+    // Regenerative-braking strength, decoded from 0x187 (see IncomingFrameCan2).
+    // The e-Golf's five regen levels as a 0..4 scale (least->most): D0 (coast) = 0,
+    // D1 = 1, D2 = 2, D3 = 3, B = 4. -1 = N/A (not in gear D or B).
+    OvmsMetricInt* m_recup_level = nullptr;
 
 #ifdef VWEGOLF_NATIVE_TEST
  public:

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.cpp
@@ -3,6 +3,7 @@
 MetricStore         g_metrics;
 uint32_t            g_tick_count = 0;
 StandardMetricsType StandardMetrics;
+OvmsMetrics         MyMetrics;
 OvmsConfig          MyConfig;
 OvmsCommandApp      MyCommandApp;
 OvmsVehicleFactory  MyVehicleFactory;

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
@@ -232,6 +232,19 @@ extern StandardMetricsType StandardMetrics;
 #define StdMetrics StandardMetrics
 
 // ---------------------------------------------------------------------------
+// Metric registry (subset) — InitInt creates a standalone custom metric.
+// ---------------------------------------------------------------------------
+static constexpr int SM_STALE_MIN = 60;
+struct OvmsMetrics {
+    OvmsMetricInt* InitInt(const char* name, int /*autostale*/ = 0, int value = 0) {
+        auto* m = new OvmsMetricInt(name);
+        m->SetValue(value);
+        return m;
+    }
+};
+extern OvmsMetrics MyMetrics;
+
+// ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 struct OvmsConfig {


### PR DESCRIPTION
Decode the recuperation level from the gear-selector frame 0x187 into the integer metric xvg.v.recup as a 0..4 strength over the e-Golf's five regen levels: D0 (coast)=0, D1=1, D2=2, D3=3, B=4. The level is in d[1]'s high nibble (valid bit + gear); reset to -1 (N/A) when not in D/B and when the car goes off/asleep so it doesn't hold a stale value. Documents the signals in vwegolf.dbc and adds the InitInt/SM_STALE_MIN mock support for the native tests.