### PR TITLE
feat(vwegolf): set v.e.drivemode from Charisma profile (0x386)

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -1,6 +1,9 @@
 Open Vehicle Monitor System v3 - Change log
 
 ????-??-?? ???  ???????  OTA release
+- VW e-Golf: set v.e.drivemode from the Charisma / Fahrprofilauswahl active profile
+    (KCAN 0x386): Normal/Eco/Eco+ -> 1/2/3 (matching the e-Up module), replacing the
+    incorrect B-gear-derived value.
 - vehicle_cadillac_ct5:
     Set the acceptance filter to allow 0x063 (v.on) and 0x5E4 (v.b.soc).
     The high frame rate of this vehicle (> 1600/sec) causes watchdog

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vwegolf.dbc
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/vwegolf.dbc
@@ -137,6 +137,11 @@ BO_ 913 OBD_01: 8 Powertrain
  SG_ OBD_Driving_Cycle : 61|1@1+ (1,0) [0|1] "" OVMS
  SG_ OBD_Abs_Pedal_Pos : 40|8@1+ (0.392,0) [0|100] "%" OVMS
 
+// 0x386. Charisma / Fahrprofilauswahl active drive profile (Normal/Eco/Eco+).
+// d[5]: 2=Normal, 5=Eco, 8=Eco+ (CharismaProfiles enum); 0=inactive (car not drivable).
+BO_ 902 DriveProfile: 8 Gateway
+ SG_ ActiveProfile : 40|8@1+ (1,0) [0|255] "" OVMS
+
 // ---------------------------------------------------------------------------
 // BAP extended frames on KCAN (29-bit IDs, node 0x25 = clima ECU)
 // These are multi-frame BAP messages, not conventional CAN signals.
@@ -238,6 +243,7 @@ VAL_ 1516 ClimaStatus 4 "Idle" 7 "Active" ;
 VAL_ 1525 ClimaIdle 0 "Active" 1 "Idle" ;
 VAL_ 1646 ClimaRunning 0 "Off" 1 "On" ;
 VAL_ 391 GearPosition 2 "Park" 3 "Reverse" 4 "Neutral" 5 "Drive" 6 "B_mode" ;
+VAL_ 902 ActiveProfile 0 "Inactive" 2 "Normal" 5 "Eco" 8 "Eco_plus" ;
 VAL_ 1428 ChargeType 0 "None" 1 "AC_Type2" 2 "DC_CCS" ;
 VAL_ 1428 ChargeTimerMode 0 "Inactive" 1 "Active" 2 "Unknown_2" 3 "Unknown_3" ;
 VAL_ 1428 ChargeInProgress 0 "Idle" 1 "Charging" ;

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -79,26 +79,24 @@ void OvmsVehicleVWeGolf::IncomingFrameCan2(CAN_frame_t* p_frame) {
         case 0x187: {
             const uint8_t gear_nibble = p_frame->data.u8[2] & 0x0F;
             ESP_LOGV(TAG, "0x187 gear nibble=%d", gear_nibble);
+            // Drive mode (Normal/Eco/Eco+) is NOT derived here — B is a gear/regen
+            // selection, not a Charisma drive profile. ms_v_env_drivemode is set from
+            // the Charisma active profile in frame 0x386 (IncomingFrameCan3).
             if (gear_nibble == 2) {
                 // Park
                 StandardMetrics.ms_v_env_gear->SetValue(0);
-                StandardMetrics.ms_v_env_drivemode->SetValue(0);
             } else if (gear_nibble == 3) {
                 // Reverse
                 StandardMetrics.ms_v_env_gear->SetValue(-1);
-                StandardMetrics.ms_v_env_drivemode->SetValue(0);
             } else if (gear_nibble == 4) {
                 // Neutral
                 StandardMetrics.ms_v_env_gear->SetValue(0);
-                StandardMetrics.ms_v_env_drivemode->SetValue(0);
             } else if (gear_nibble == 5) {
                 // Drive
                 StandardMetrics.ms_v_env_gear->SetValue(1);
-                StandardMetrics.ms_v_env_drivemode->SetValue(0);
             } else if (gear_nibble == 6) {
                 // B mode
                 StandardMetrics.ms_v_env_gear->SetValue(1);
-                StandardMetrics.ms_v_env_drivemode->SetValue(1);
             }
             break;
         }
@@ -265,6 +263,30 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
                 StandardMetrics.ms_v_pos_longitude->SetValue(lon);
             }
             ESP_LOGV(TAG, "0x0486 lat=%.6f lon=%.6f valid=%d", lat, lon, valid);
+            break;
+        }
+        case 0x386:  // Drive mode (Charisma / Fahrprofilauswahl active profile).
+        {
+            // d[5] = active drive profile: 0x02 = Normal, 0x05 = Eco, 0x08 = Eco+
+            // (matches the MIB CharismaProfiles enum auto_normal=2/efficiency=5/range=8).
+            // Mapped to ms_v_env_drivemode as 1 = Normal, 2 = Eco, 3 = Eco+, matching the
+            // sibling VW e-Up module's v.e.drivemode encoding (1=STD, 2=ECO, 3=ECO+).
+            switch (d[5]) {
+                case 0x02:
+                    StandardMetrics.ms_v_env_drivemode->SetValue(1);
+                    break;
+                case 0x05:
+                    StandardMetrics.ms_v_env_drivemode->SetValue(2);
+                    break;
+                case 0x08:
+                    StandardMetrics.ms_v_env_drivemode->SetValue(3);
+                    break;
+                default:
+                    // Unknown profile value (0x00 = inactive when not drivable) — leave
+                    // the last known drive mode.
+                    break;
+            }
+            ESP_LOGV(TAG, "0x0386 drivemode raw=0x%02x", d[5]);
             break;
         }
         case 0x583:  // ZV_02: central locking and door open states.


### PR DESCRIPTION
Decode the drive mode (Normal/Eco/Eco+) from KCAN frame 0x386 d[5], the Charisma /
Fahrprofilauswahl active profile: 0x02=Normal, 0x05=Eco, 0x08=Eco+ (matches the MIB
CharismaProfiles enum auto_normal=2/efficiency=5/range=8), mapped to ms_v_env_drivemode
as 1=Normal, 2=Eco, 3=Eco+, matching the sibling VW e-Up module's encoding (1=STD,
2=ECO, 3=ECO+). 0x00 (inactive, car not drivable) is ignored so the metric keeps its
last value.

Drop the previous ms_v_env_drivemode writes in the 0x187 gear handler, which derived
'drive mode' from the B-gear nibble -- B is a gear/regen selection, not a Charisma drive
profile, so that was incorrect and would fight the 0x386 decode. Documents 0x386 in
vwegolf.dbc.