### PR TITLE
SmartEQ: Set CAN transceiver to listen-only mode and add option CAR-Off

### DIFF
--- a/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
+++ b/vehicle/OVMS.V3/components/esp32can/src/esp32can.cpp
@@ -613,7 +613,10 @@ esp_err_t esp32can::Stop()
 void esp32can::SetTransceiverMode(CAN_mode_t mode)
   {
   int rs_state = (mode == CAN_MODE_ACTIVE) ? 0 : 1;
-  
+
+  if ( rs_state == 0 ) ESP_LOGV(TAG,"CAN Transceiver set to active mode");
+  else ESP_LOGV(TAG,"CAN Transceiver set to listen only mode");
+
 #ifdef CONFIG_OVMS_COMP_MAX7317
   // Enable TX driver of matching SN65 transceiver
   MyPeripherals->m_max7317->Output(MAX7317_CAN1_EN, rs_state);

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -1033,11 +1033,13 @@ void mcp2515::SetTransceiverMode(CAN_mode_t mode)
     {
       // BFPCTRL RXnBF PIN CONTROL AND STATUS - enable TX driver of SN65 - rd/wr mode
       WriteRegAndVerify(REG_BFPCTRL, 0b00001100);
+      ESP_LOGV(TAG,"CAN Transceiver set to active mode");
     } 
   else
     {
       // BFPCTRL RXnBF PIN CONTROL AND STATUS - disable TX driver of SN65 - listen only mode
       WriteRegAndVerify(REG_BFPCTRL, 0b00111100);
+      ESP_LOGV(TAG,"CAN Transceiver set to listen only mode");
     }
   }
 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can.cpp
@@ -46,7 +46,7 @@ static const char *TAG = "v-smarteq";
 void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
   uint8_t *data = p_frame->data.u8;
   uint64_t c = swap_uint64(p_frame->data.u64);
-  
+  m_can_msg_received = true;
   switch (p_frame->MsgID) {
     case 0x17E: //gear shift
       {
@@ -223,6 +223,15 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       can_charge_inprogress = (CAN_BYTE(5) & 0x20) != 0;
       break;
       }
+    case 0x668:
+      // Car on/off state used if CAN write disabled, otherwise utilize 0x350 polling
+      if (!IsCANwrite() )
+        {
+        REQ_DLC(1);
+        can_env_on = (CAN_BYTE(0) & 0x40) > 0;
+        }
+      break;
+
     case 0x673:
       {
       // TPMS pressure values only used, when CAN write is disabled, otherwise utilize PollReply_TPMS_InputCapt
@@ -249,6 +258,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
       break;
       }
     default:
+      m_can_msg_received = false;
       //ESP_LOGI(TAG, "PID:%x DATA: %02x %02x %02x %02x %02x %02x %02x %02x", p_frame->MsgID, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
       break;
   }
@@ -257,6 +267,7 @@ void OvmsVehicleSmartEQ::IncomingFrameCan1(CAN_frame_t* p_frame) {
 // Sync CAN datapoints to OVMS metrics, called by Ticker1, because CAN refresh rate is too high
 void OvmsVehicleSmartEQ::smartCAN2Metrics()
 {
+  m_can_msg_received = false; 
   if (m_cmd_locked && !can_locked)
     {
     // prevent desync of command lock and actual lock status    
@@ -267,6 +278,7 @@ void OvmsVehicleSmartEQ::smartCAN2Metrics()
     StdMetrics.ms_v_env_locked->SetValue(can_locked);
     }
   StdMetrics.ms_v_env_on->SetValue(can_env_on);
+  CheckCANAccess();  // car on/off state might have changed - check, if CAN write access has to be changed 
   StdMetrics.ms_v_env_awake->SetValue(IsAwakeEQ());
   StdMetrics.ms_v_env_hvac->SetValue(can_hvac);
   StdMetrics.ms_v_env_handbrake->SetValue(can_handbrake);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -375,7 +375,7 @@ void OvmsVehicleSmartEQ::smartAwake()
 {
   smartCoolDownPolling();
   // enable active polling when car wakes up (canwrite only)
-  if(m_enable_write)
+  if(m_enable_write || m_enable_write_caroff)
     smartOBDpolling(true);
   else if (m_enable_write_caron && m_can_active)
     smartOBDpolling(false); // only enable when car is on and CAN write access #2 is enabled

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -93,7 +93,7 @@ void OvmsVehicleSmartEQ::Ticker1(uint32_t ticker)
     smartCAN2Metrics();
     }
 
-  if(IsAwakeEQ())
+  if(IsAwakeEQ() || m_can_msg_received)
     smartCAN2Metrics();
 
   if(IsChargingEQ()) 

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -82,14 +82,15 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   auto lock = MyConfig.Lock();
 
   std::string error, full_km, rebootnw, contactor_1h_limit;
-  bool canwrite, canwrite_caron, canwrite_sleep, led, resettrip, resettotal, bcvalue;
+  bool canwrite, canwrite_caron, canwrite_caroff, canwrite_sleep, led, resettrip, resettotal, bcvalue;
   bool charge12v, extstats, unlocked, tripnotify, opendoors;
   bool obdii79b, obdii79b_cell, obdii743, obdii745, obdii745_tpms, obdii7e4, obdii7e4_dcdc;
 
   if (c.method == "POST") {
     // process form submission:
-    canwrite    = (c.getvar("canwrite") == "yes");
-    canwrite_caron = (c.getvar("canwrite_caron") == "yes");
+    canwrite    = (c.getvar("canwrite_mode") == "ON");
+    canwrite_caron = (c.getvar("canwrite_mode") == "CARON");
+    canwrite_caroff = (c.getvar("canwrite_mode") == "CAROFF");
     canwrite_sleep = (c.getvar("canwrite_sleep") == "yes");
     led         = (c.getvar("led") == "yes");
     rebootnw    = (c.getvar("rebootnw"));
@@ -139,6 +140,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
          }
       map.SetValueBool("canwrite", canwrite);
       map.SetValueBool("canwrite.caron", canwrite_caron);
+      map.SetValueBool("canwrite.caroff", canwrite_caroff);
       map.SetValueBool("canwrite.sleep", canwrite_sleep);
       map.SetValueBool("led", led);
       map["rebootnw"] = rebootnw;
@@ -177,6 +179,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   } else {
     canwrite       = sq->m_enable_write;
     canwrite_caron = sq->m_enable_write_caron;
+    canwrite_caroff = sq->m_enable_write_caroff;
     canwrite_sleep = sq->m_enable_write_sleep;
     led            = sq->m_enable_LED_state;
     resettrip      = sq->m_resettrip;
@@ -209,17 +212,23 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.form_start(p.uri);
   
   c.fieldset_start("Remote Control");
-  c.input_checkbox("Enable CAN write access #1", "canwrite", canwrite,
-    "<p>CAN write access all time! (OBDII polling, start Preconditioning etc.)</p>");
-  c.input_checkbox("Enable CAN write access #2", "canwrite_caron", canwrite_caron,
-    "<p>CAN write access all time!</p>"
-    "<p>Clears polling list when vehicle is in awake/sleep mode</p>"
-    "<p>This will stop CAN polling when the vehicle is in awake/sleep mode</p>"
-    "<p>Alternative to CAN write access #1; select one or neither!</p>");
-  c.input_checkbox("Disable CAN polling during sleep", "canwrite_sleep", canwrite_sleep,
+
+  std::string canwrite_mode = "OFF";
+  if( canwrite ) canwrite_mode = "ON";
+  else if ( canwrite_caron ) canwrite_mode = "CARON";
+  else if ( canwrite_caroff ) canwrite_mode = "CAROFF";
+  c.input_radiobtn_start("CAN Bus Write Access", "canwrite_mode");
+    c.input_radiobtn_option("canwrite_mode", "Off", "OFF", canwrite_mode == "OFF");
+    c.input_radiobtn_option("canwrite_mode", "On", "ON", canwrite_mode == "ON");
+    c.input_radiobtn_option("canwrite_mode", "Car Off", "CAROFF", canwrite_mode == "CAROFF");
+    c.input_radiobtn_option("canwrite_mode", "Car On", "CARON", canwrite_mode == "CARON");
+  c.input_radiobtn_end(
+    "<p>Enable write access to CAN bus.<br> Off - no access (Listen only)<br>On - allow full access<br> Car Off  - only when car is off (parked)<br> Car On - Only when car is on</p>");
+
+    c.input_checkbox("Disable CAN polling during sleep", "canwrite_sleep", canwrite_sleep,
     "<p>Clears polling list when vehicle is in sleep mode</p>");
   c.fieldset_end();
-  
+
   // trip reset or OBD activation
   c.fieldset_start("Trip calculated or OBD kWh/100km");
   c.input_checkbox("Reset Trip when Charging", "resettrip", resettrip,

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -184,8 +184,9 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_mfr_id                 = MyMetrics.InitInt("xsq.bms.id.mfr", SM_STALE_NONE, 0,   Other);
   mt_bms_basic_parts            = MyMetrics.InitString("xsq.bms.id.basic.parts", SM_STALE_NONE, "",  Other);
 
-  // Start CAN bus in CAN_MODE_ACTIVE mode
-  RegisterCanBus(1, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);
+  // Initial state of CAN bus is Listen-only mode - will be set according to CAN write mode in ConfigChanged()
+  RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);   // Inititial state of CAN transceiver: LISTEN-ONLY 
+  m_can_last_acc_state = false;
   PollSetState(POLLSTATE_OFF);
 
   // register config container for smart EQ module, with callback to ConfigChanged() on changes
@@ -269,7 +270,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // Note: GetValueBool/Int/Float treat empty string as "not set" and return the default.
   OvmsConfigParam* map = MyConfig.CachedParam("xsq");
   
-  bool stateWrite         = m_enable_write;
   bool obdii_743          = true;
   bool obdii_745          = true;
   bool obdii_745_tpms     = true;
@@ -282,6 +282,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     {
     m_enable_write         = map->GetValueBool("canwrite", false);
     m_enable_write_caron   = map->GetValueBool("canwrite.caron", false);
+    m_enable_write_caroff  = map->GetValueBool("canwrite.caroff", false);
     m_enable_write_sleep   = map->GetValueBool("canwrite.sleep", false);
     m_enable_LED_state     = map->GetValueBool("led", false);
     m_bcvalue              = map->GetValueBool("bcvalue", false);
@@ -328,12 +329,8 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     }
 #endif
 
-  // set CAN bus transceiver to active or listen-only depending on user selection
-  if ( stateWrite != m_enable_write )
-    {
-    smartCoolDownPolling();
-    smartOBDpolling(m_enable_write);
-    }
+  CheckCANAccess(); 
+
   // disable caron write mode if normal write mode is enabled to avoid conflicts
   if(m_enable_write_caron && m_enable_write) 
     {
@@ -372,6 +369,20 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     }
   StdMetrics.ms_v_charge_limit_soc->SetValue((float) m_suffsoc, Percentage );
   StdMetrics.ms_v_charge_limit_range->SetValue((float) m_suffrange, Kilometers );
+}
+
+void OvmsVehicleSmartEQ::CheckCANAccess() {
+  if ( m_can_last_acc_state != IsCANwrite() )
+    {
+    smartCoolDownPolling();
+    if ( IsCANwrite() ) ESP_LOGI(TAG,"CAN write state enabled ");
+    else ESP_LOGI(TAG,"CAN write state disabled ");
+    // set CAN bus transceiver to active or listen-only state, depending on user selection
+    CAN_mode_t mode = IsCANwrite() ? CAN_MODE_ACTIVE : CAN_MODE_LISTEN;
+    RegisterCanBus(1, mode, CAN_SPEED_500KBPS);   // set CAN transceiver via GPIO to ACTIVE or LISTEN-only mode 
+    smartOBDpolling(IsCANwrite());
+    m_can_last_acc_state = IsCANwrite();
+    }
 }
 
 uint64_t OvmsVehicleSmartEQ::swap_uint64(uint64_t val) {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -203,6 +203,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
 
     // --- Config / Features ---
     void ConfigChanged(OvmsConfigParam* param) override;
+    void CheckCANAccess();
     bool SetFeature(int key, const char* value);
     const std::string GetFeature(int key);
     uint64_t swap_uint64(uint64_t val);
@@ -232,7 +233,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool IsOnEQ() { return can_env_on; }
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
-    bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
+    bool IsCANwrite() { return m_enable_write || ( m_enable_write_caroff && !IsOnEQ() ) || ( m_enable_write_caron && IsOnEQ() ); }
     bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) >= 13.1f || 
                                   (m_can_active && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f ) || 
                                   (m_can_active && can_charging12v); }
@@ -434,6 +435,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // --- Config-driven member variables ---
     bool m_enable_write = false;            // canwrite enable write access
     bool m_enable_write_caron = false;      // canwrite enable write access, only when car is on
+    bool m_enable_write_caroff = false;      // canwrite enable only while the car is parked
     bool m_enable_write_sleep = false;      // canwrite disable write access, only when car is asleep
     bool m_can_active = false;              // true if CAN bus is in active mode, false if in listen-only mode
     bool m_enable_LED_state = false;        // Online LED State
@@ -488,6 +490,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     int m_led_state = 4;                    // Online LED State: 0=off, 1=red, 2=green, 3=blue, 4=default (configurable)
     int m_12v_ticker = 0;                   // ticker for 12V charge state check
     int m_modem_ticker = 0;                 // ticker for modem restart
+    bool m_can_last_acc_state = false;      // remember the last access state of the CAN bus 
 
     // --- OBDII polling flags ---
     bool m_obdii_745_tpms;                  // basic TPMS without temperature and low battery status
@@ -570,6 +573,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     int m_candata_timer = -1;
     int32_t m_above_cycles = 50000;       // alert threshold for cycles counted
     int m_contactor_1h_limit = 8;         // limit for contactor cycles changes per hour (for alerting)
+    bool m_can_msg_received  = false;    // true after a received message
 
     // --- TPMS internal arrays ---
     bool m_tpms_lowbatt[4] = {};          // 0=ok, 1=low


### PR DESCRIPTION
In case the CAN write acces is disabled by user selection, the CAN transceiver is set into listen-only mode via the corresponding GPIO. The listen-only mode ensures, that a mistake in the firmware or a crash of the module is not interfering with the car.
This had already been present for the SmartEQ, but somhow got lost again. 

In addition the different CAN write access selections (`SmartEQ->Features`) has been replaced by a radio button to have a mutual exclusive selection.

Added again the `CAR OFF` selection, which prohibits any interference of the module with the car, while driving. The SmartEQ is sending a lot of information over the bus anyway and this is available in listen-only mode as well. At least for my application, there is no need for polling while driving. The `CAR OFF` CAN write access allows polling, while the car is parked and/or charging.
