### PR TITLE
MCP2515 Fix:Tidy up RX Filter enablement, improve error handling

### DIFF
--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.cpp
@@ -279,22 +279,10 @@ esp_err_t mcp2515::Start(CAN_mode_t mode, CAN_speed_t speed)
   WriteReg(REG_CANCTRL, CANCTRL_MODE_CONFIG | CANCTRL_ABAT | CANCTRL_OSM);
   m_canctrl_mode = CANCTRL_MODE_CONFIG;
 
-  // Filter logic is such that if enabled mask and filters 0, 1 are
-  // applied to RX buffer 0, and mask 1 and filters 2-5 are applied to RX buffer 0.
-  // If a packet matches Filters 0, 1 then it is placed in RX buffer 0,
-  // otherwise if it matches Filters 2-5 then it is placed in RX buffer 1.
-  //
-  // If RX Buffer 0 is full and if roll over is enabled then the packet
-  // will be placed in RX Buffer 1 regardless of if it matched the Filters 2-5.
-  //
-  // At start we enable roll over and set all filters to accept all.  If a filter
-  // is set later then we update the registers to check the new filters.
 
   // Disable filter checking and enable buffer 1 rollover
-  WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01100100);
-  WriteRegAndVerify(REG_RXB1CTRL, 0b01100000, 0b01100000);
-
- 
+  EnableRXFilter(false);
+  
   SetTransceiverMode(mode);
 
   // Bus speed
@@ -464,6 +452,43 @@ esp_err_t mcp2515::Stop()
   return ESP_OK;
   }
 
+// Filter logic is such that if enabled mask and filters 0, 1 are
+// applied to RX buffer 0, and mask 1 and filters 2-5 are applied to RX buffer 0.
+// If a packet matches Filters 0, 1 then it is placed in RX buffer 0,
+// otherwise if it matches Filters 2-5 then it is placed in RX buffer 1.
+//
+// If RX Buffer 0 is full and if roll over is enabled then the packet
+// will be placed in RX Buffer 1 regardless of if it matched the Filters 2-5.
+//
+// Roll over from RXB0 to RXB1 is always enabled.
+esp_err_t mcp2515::EnableRXFilter(bool enable)
+  {
+  bool success = false;
+
+  if (enable)
+    {
+    success = (WriteRegAndVerify(REG_RXB0CTRL, 0b00000100, 0b01100100) == ESP_OK &&
+               WriteRegAndVerify(REG_RXB1CTRL, 0b00000000, 0b01100000) == ESP_OK);
+    }
+
+  else
+    {
+    success = (WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01100100) == ESP_OK &&
+               WriteRegAndVerify(REG_RXB1CTRL, 0b01100000, 0b01100000) == ESP_OK);
+    }
+
+  if (!success)
+    {
+    ESP_LOGE(TAG, "%s: Could not %s RX filter", this->GetName(), enable ? "enable" : "disable");
+    return ESP_FAIL;
+    }
+  else
+    {
+    return ESP_OK;
+    }
+  }
+
+
 
 /**
  * SetAcceptanceFilter: configure MCP2515 specific hardware RX filter
@@ -501,18 +526,11 @@ esp_err_t mcp2515::SetAcceptanceFilter(const mcp2515_filter_config_t& cfg)
                     cfg.filter[0].u32 == 0 && cfg.filter[1].u32 == 0 &&
                     cfg.filter[2].u32 == 0 && cfg.filter[3].u32 == 0 &&
                     cfg.filter[4].u32 == 0 && cfg.filter[5].u32 == 0);
-                    
-  if (filters_cleared) {
-    // Disable filter checking as all filters are cleared (revert to default behaviour)
-    WriteRegAndVerify(REG_RXB0CTRL, 0b01100100, 0b01100100);
-    WriteRegAndVerify(REG_RXB1CTRL, 0b01100000, 0b01100000);
-  } else
-  {
-    // Enable filter checking as filters have been defined.
-    WriteRegAndVerify(REG_RXB0CTRL, 0b00000100, 0b01100100);
-    WriteRegAndVerify(REG_RXB1CTRL, 0b00000000, 0b01100000);
-  }
-
+            
+  // There is nothing in the MCP2515 datasheet that says that this needs
+  // to be done in config mode but it seems to be a good idea to do so.                    
+  EnableRXFilter(!filters_cleared);
+  
   // Write filters 0-2:
   m_spibus->spi_cmd(m_spi, buf, 0, 14, CMD_WRITE, REG_RXF0SIDH,
     cfg.filter[0].u8[3], cfg.filter[0].u8[2], cfg.filter[0].u8[1],cfg.filter[0].u8[0],

--- a/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
+++ b/vehicle/OVMS.V3/components/mcp2515/src/mcp2515.h
@@ -90,6 +90,7 @@ class mcp2515 : public canbus
 
   protected:
     esp_err_t WriteFrame(const CAN_frame_t* p_frame);
+    esp_err_t EnableRXFilter(bool enable);
 
   public:
     void SetPowerMode(PowerMode powermode) override;


### PR DESCRIPTION
- Tidy up of RX register setter implementation to improve code reuse.
- Ensure that failure to write to the RX registers is handled safely.