### PR TITLE
OTA: fix double fclose() of the source image in ota_flash_vfs

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
+++ b/vehicle/OVMS.V3/components/ovms_ota/src/ovms_ota.cpp
@@ -251,8 +251,6 @@ void ota_flash_vfs(int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc
     return;
     }
 
-  fclose(f);
-
   MyOTA.SetFlashStatus("OTA Flash VFS: Setting boot partition...");
   writer->puts(MyOTA.GetFlashStatus());
   err = esp_ota_set_boot_partition(target);


### PR DESCRIPTION
`ota_flash_vfs()` closes the source image twice on the success path: once right after the read loop, and again after `esp_ota_end()`. Passing an already-closed `FILE*` to `fclose()` is undefined behaviour.

In practice newlib's `fclose()` returns early when the stream's `_flags` are zero, so the second call is usually a no-op - which is presumably why this has never been noticed. The hazard is that newlib allocates `FILE` structures from a shared pool: once the first `fclose()` releases the slot, the next `fopen()` in any task can be handed the same structure. If that happens in the window between the two calls - `esp_ota_end()` sits in the middle, so the window is not tiny - the second `fclose()` operates on an unrelated stream, closing another task's descriptor and releasing its buffer. On a module that logs to SD while flashing, that window is reachable.

The fix drops the second call. The earlier one (immediately after the read loop) is the one to keep, because the two error returns that sit between the two calls already return without closing, so they rely on the file having been closed at that point.

`AutoFlashSD()`, which has the same structure, closes exactly once and is unaffected. Those are the only two `fopen()` sites in the file.

### Testing

Compile-checked against current master, and exercised on a v3.3 module: `ota flash vfs` of a 2.8 MB image still completes and sets the boot partition as before, with the free 8-bit heap byte-identical before and after the flash (no leaked stream).

The change is a pure deletion, so there is no new code to exercise; I also confirmed by inspection that every path out of the `fopen()` still closes the stream exactly once:

- `fopen()` returns NULL - nothing to close
- `esp_ota_begin()` fails - closes, returns
- `esp_ota_write()` fails - closes, returns
- read loop completes - closes; the later `esp_ota_end()` and `esp_ota_set_boot_partition()` error returns then correctly return without closing again