### PR TITLE
Wifi: fix STA reconnect deadlock

### DIFF
--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp
@@ -52,6 +52,13 @@ static const char *TAG = "esp32wifi";
 #include <dhcpserver/dhcpserver.h>
 #endif
 
+// STA connect state machine timing [seconds]:
+#define WIFI_RECONNECT_INTERVAL   10    // retry interval after a failed/fruitless attempt
+#define WIFI_RECONNECT_DELAY       2    // retry delay after losing an established link
+#define WIFI_SCAN_TIMEOUT         30    // max time to wait for a scan result
+#define WIFI_CONNECT_TIMEOUT      20    // max time to wait for an association to complete
+#define WIFI_STUCK_LIMIT           3    // consecutive timeouts before restarting the driver
+
 const char* const esp32wifi_mode_names[] = {
   "Modem is off",
   "Client mode",
@@ -415,6 +422,9 @@ esp32wifi::esp32wifi(const char* name)
   m_powermode = Off;
   m_poweredup = false;
   m_sta_reconnect = 0;
+  m_sta_scan_pending = 0;
+  m_sta_connect_pending = 0;
+  m_sta_stuck_count = 0;
   m_sta_connected = false;
   m_sta_rssi = -1270;
   m_good_signal = false;
@@ -603,6 +613,9 @@ void esp32wifi::PowerDown()
 void esp32wifi::StartClientMode(std::string ssid, std::string password, uint8_t* bssid)
   {
   m_sta_reconnect = 0;
+  m_sta_scan_pending = 0;
+  m_sta_connect_pending = 0;
+  m_sta_stuck_count = 0;
 
   // mode reconfiguration?
   if (m_mode == ESP32WIFI_MODE_AP || m_mode == ESP32WIFI_MODE_APCLIENT || m_sta_connected)
@@ -654,6 +667,9 @@ void esp32wifi::StartClientMode(std::string ssid, std::string password, uint8_t*
 void esp32wifi::StartAccessPointMode(std::string ssid, std::string password)
   {
   m_sta_reconnect = 0;
+  m_sta_scan_pending = 0;
+  m_sta_connect_pending = 0;
+  m_sta_stuck_count = 0;
 
   // mode reconfiguration?
   if (m_mode == ESP32WIFI_MODE_CLIENT || m_mode == ESP32WIFI_MODE_APCLIENT)
@@ -704,6 +720,9 @@ void esp32wifi::StartAccessPointMode(std::string ssid, std::string password)
 void esp32wifi::StartAccessPointClientMode(std::string apssid, std::string appassword, std::string stassid, std::string stapassword, uint8_t* stabssid)
   {
   m_sta_reconnect = 0;
+  m_sta_scan_pending = 0;
+  m_sta_connect_pending = 0;
+  m_sta_stuck_count = 0;
 
   // mode reconfiguration?
   if (m_mode == ESP32WIFI_MODE_CLIENT || m_mode == ESP32WIFI_MODE_AP || m_sta_connected)
@@ -788,6 +807,13 @@ void esp32wifi::Reconnect(OvmsWriter* writer)
     ESP_LOGE(TAG, "Reconnect: starting Wifi client reconnect");
   if (!m_sta_connected)
     {
+    // Abort an association attempt in progress, else the driver would refuse the
+    // scan and could get stuck in the connecting state:
+    if (m_sta_connect_pending)
+      {
+      m_sta_connect_pending = 0;
+      esp_wifi_disconnect();
+      }
     m_sta_reconnect = monotonictime + 1;
     }
   else
@@ -820,6 +846,9 @@ void esp32wifi::StopStation()
     }
 
   m_sta_reconnect = 0;
+  m_sta_scan_pending = 0;
+  m_sta_connect_pending = 0;
+  m_sta_stuck_count = 0;
   m_sta_connected = false;
 
   memset(&m_wifi_ap_cfg,0,sizeof(m_wifi_ap_cfg));
@@ -911,8 +940,12 @@ void esp32wifi::Scan(OvmsWriter* writer, bool json)
 
   m_mode = ESP32WIFI_MODE_SCAN;
   esp_wifi_scan_stop();
-  if (m_sta_reconnect)
-    m_sta_reconnect = monotonictime + 10;
+  // This aborts a connect scan in progress; its result won't reach the connect
+  // state machine (scan.done is ignored in SCAN mode), so drop the pending state
+  // and re-arm the retry timer, else the client would never retry:
+  if (m_sta_scan_pending || m_sta_reconnect)
+    m_sta_reconnect = monotonictime + WIFI_RECONNECT_INTERVAL;
+  m_sta_scan_pending = 0;
 
   if (!json)
     writer->puts("Scanning for WIFI Access Points...");
@@ -1138,6 +1171,9 @@ void esp32wifi::EventWifiStaConnected(std::string event, void* data)
 
   m_sta_connected = true;
   m_previous_reason = 0;
+  m_sta_connect_pending = 0;
+  m_sta_reconnect = 0;
+  m_sta_stuck_count = 0;
   UpdateNetMetrics();
 
   ESP_LOGI(TAG, "STA connected with SSID: %.*s, BSSID: " MACSTR ", Channel: %u, Auth: %s",
@@ -1164,8 +1200,19 @@ void esp32wifi::EventWifiStaDisconnected(std::string event, void* data)
     m_previous_reason = disconn.reason;
     }
 
+  bool was_connected = m_sta_connected;
   m_sta_connected = false;
+  m_sta_connect_pending = 0;
   memset(&m_ip_info_sta,0,sizeof(m_ip_info_sta));
+
+  // Schedule the next attempt: the driver does not retry by itself. Retry quickly
+  // after losing an established link (fast transition to the next best AP), on the
+  // regular interval after a failed association.
+  if (m_mode == ESP32WIFI_MODE_CLIENT || m_mode == ESP32WIFI_MODE_APCLIENT)
+    {
+    m_sta_reconnect = monotonictime +
+      (was_connected ? WIFI_RECONNECT_DELAY : WIFI_RECONNECT_INTERVAL);
+    }
 
   UpdateNetMetrics();
   }
@@ -1314,6 +1361,9 @@ void esp32wifi::EventTimer1(std::string event, void* data)
       }
     }
 
+  // recover from a stalled scan or association:
+  StaWatchdog();
+
   // reconnect?
   if ((m_mode == ESP32WIFI_MODE_CLIENT || m_mode == ESP32WIFI_MODE_APCLIENT)
       && !m_sta_connected && m_sta_reconnect && monotonictime >= m_sta_reconnect)
@@ -1330,6 +1380,25 @@ void esp32wifi::StartConnect()
   // do a scan and connect explicitly to the AP with the strongest signal.
 
   OvmsRecMutexLock exclusive(&m_mutex);
+
+  // Never start a scan while the driver is associating: esp_wifi_scan_stop() /
+  // esp_wifi_scan_start() are rejected in that state ("STA is connecting, scan are
+  // not allowed!") and can leave the driver wedged in the connecting state, from
+  // which it emits no disconnect event and so never recovers on its own.
+  // StaWatchdog() picks up an association that doesn't complete in time.
+  if (m_sta_connect_pending)
+    {
+    ESP_LOGD(TAG, "StartConnect: association in progress, not scanning");
+    return;
+    }
+
+  // A scan of ours is still running; wait for its result (or the watchdog).
+  if (m_sta_scan_pending)
+    {
+    ESP_LOGD(TAG, "StartConnect: scan in progress, not restarting it");
+    return;
+    }
+
   esp_wifi_scan_stop();
 
   wifi_scan_config_t scanConf;
@@ -1342,12 +1411,67 @@ void esp32wifi::StartConnect()
   scanConf.scan_time.active = GetScanTime();
   esp_err_t res = esp_wifi_scan_start(&scanConf, false);
   if (res != ESP_OK)
+    {
+    // A wedged driver refuses every scan, so this counts towards the stuck check
+    // handled by StaWatchdog():
     ESP_LOGE(TAG, "StartConnect: error 0x%x starting scan", res);
+    m_sta_stuck_count++;
+    m_sta_reconnect = monotonictime + WIFI_RECONNECT_INTERVAL;
+    }
   else
+    {
     ESP_LOGV(TAG, "StartConnect: scan started");
+    // The scan result drives the next step, so disarm the retry timer and let the
+    // watchdog handle a scan that never delivers a result:
+    m_sta_scan_pending = monotonictime + WIFI_SCAN_TIMEOUT;
+    m_sta_reconnect = 0;
+    }
+  }
 
-  // next regular scan in 10 seconds:
-  m_sta_reconnect = monotonictime + 10;
+/**
+ * StaWatchdog: recover from a stalled scan or association.
+ *
+ * The esp-idf Wifi driver can get stuck in the "connecting" state without ever
+ * emitting a disconnect event (e.g. when an association to a weak AP is disturbed).
+ * Every subsequent scan is then refused and the station stays down until it is
+ * restarted. This detects that and escalates: abort the attempt, and if that does
+ * not help within WIFI_STUCK_LIMIT attempts, restart the Wifi driver.
+ */
+void esp32wifi::StaWatchdog()
+  {
+  if (m_mode != ESP32WIFI_MODE_CLIENT && m_mode != ESP32WIFI_MODE_APCLIENT)
+    return;
+
+  if (m_sta_connect_pending && monotonictime >= m_sta_connect_pending)
+    {
+    m_sta_connect_pending = 0;
+    m_sta_stuck_count++;
+    ESP_LOGW(TAG, "StaWatchdog: association to '%s' timed out, aborting",
+      m_wifi_sta_cfg.sta.ssid);
+    // Clear the driver's connecting state so scans are allowed again:
+    esp_wifi_disconnect();
+    m_sta_reconnect = monotonictime + WIFI_RECONNECT_DELAY;
+    }
+
+  if (m_sta_scan_pending && monotonictime >= m_sta_scan_pending)
+    {
+    m_sta_scan_pending = 0;
+    m_sta_stuck_count++;
+    ESP_LOGW(TAG, "StaWatchdog: scan timed out, aborting");
+    esp_wifi_scan_stop();
+    m_sta_reconnect = monotonictime + WIFI_RECONNECT_DELAY;
+    }
+
+  // Repeated timeouts / refused scans mean the driver is stuck in a state it does
+  // not report and cannot leave by itself; a driver restart is the only way out
+  // (this is what the "wifi restart" command does manually):
+  if (m_sta_stuck_count >= WIFI_STUCK_LIMIT)
+    {
+    m_sta_stuck_count = 0;
+    ESP_LOGE(TAG, "StaWatchdog: Wifi driver stuck after %d attempts, restarting it",
+      WIFI_STUCK_LIMIT);
+    Restart();
+    }
   }
 
 void esp32wifi::EventWifiScanDone(std::string event, void* data)
@@ -1358,6 +1482,14 @@ void esp32wifi::EventWifiScanDone(std::string event, void* data)
   std::string ssid, password;
 
   if (m_mode == ESP32WIFI_MODE_SCAN) return; // Let scan routine handle it
+
+  // Our scan has ended; a delivered scan result proves the driver is alive, so
+  // clear the stuck count. Default to retrying on the regular interval, unless we
+  // start an association below:
+  m_sta_scan_pending = 0;
+  m_sta_stuck_count = 0;
+  if (!m_sta_connected && (m_mode == ESP32WIFI_MODE_CLIENT || m_mode == ESP32WIFI_MODE_APCLIENT))
+    m_sta_reconnect = monotonictime + WIFI_RECONNECT_INTERVAL;
 
   res = esp_wifi_scan_get_ap_num(&apCount);
   if (res != ESP_OK)
@@ -1381,6 +1513,7 @@ void esp32wifi::EventWifiScanDone(std::string event, void* data)
   if (res != ESP_OK)
     {
     ESP_LOGE(TAG, "EventWifiScanDone: can't get AP records, error=0x%x", res);
+    free(list);
     return;
     }
 
@@ -1454,6 +1587,10 @@ void esp32wifi::EventWifiScanDone(std::string event, void* data)
             }
           else
             {
+            // Association started: block further scans until it completes or the
+            // watchdog aborts it.
+            m_sta_connect_pending = monotonictime + WIFI_CONNECT_TIMEOUT;
+            m_sta_reconnect = 0;
             std::string ipconfig = MyConfig.GetParamValue("wifi.ssid", ssid + ".ovms.staticip");
             if (!ipconfig.empty())
               SetSTAWifiIP();

--- a/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
+++ b/vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h
@@ -78,6 +78,7 @@ class esp32wifi : public pcp, public InternalRamAllocated
     void StartAccessPointClientMode(std::string apssid, std::string appassword, std::string stassid, std::string stapassword, uint8_t* stabssid=NULL);
     void StopStation();
     void StartConnect();
+    void StaWatchdog();
     void Reconnect(OvmsWriter* writer);
     wifi_active_scan_time_t GetScanTime();
     void Scan(OvmsWriter* writer, bool json=false);
@@ -134,7 +135,10 @@ class esp32wifi : public pcp, public InternalRamAllocated
     wifi_config_t m_wifi_ap_cfg;
     wifi_config_t m_wifi_sta_cfg;
     bool m_sta_connected;
-    uint32_t m_sta_reconnect;
+    uint32_t m_sta_reconnect;                    //!< monotonictime to start the next connect attempt (0 = none)
+    uint32_t m_sta_scan_pending;                 //!< monotonictime scan result deadline (0 = no scan in flight)
+    uint32_t m_sta_connect_pending;              //!< monotonictime association deadline (0 = not associating)
+    uint8_t m_sta_stuck_count;                   //!< consecutive scan/association timeouts
     wifi_ap_record_t m_sta_ap_info;
     int m_sta_rssi;                              // smoothed RSSI [dBm/10]
     float m_good_dbm;


### PR DESCRIPTION
# esp32wifi: STA reconnect can permanently deadlock the Wifi driver ("STA is connecting, scan are not allowed!")

(Potentially) resolves https://github.com/openvehicles/Open-Vehicle-Monitoring-System-3/issues/1498

## Summary

The STA reconnect logic in `esp32wifi` can race its own scan/connect cycle: the
periodic retry timer fires while an association is still in progress, calls
`esp_wifi_scan_stop()` / `esp_wifi_scan_start()` into the connecting driver, and
the driver ends up wedged in the *connecting* state. From that state it never
emits a disconnect event, refuses every subsequent scan, and the module stays
offline indefinitely — even after returning into Wifi range. Only `wifi restart`
(or a reboot) recovers it.

The attached patch fixes the race and adds a watchdog that automatically
recovers the driver if it wedges anyway.

## Symptom

After the module leaves Wifi range while a (re)connect attempt is in flight,
the log repeats this every 10 seconds, indefinitely:

```
W wifi:sta_scan: STA is connecting, scan are not allowed!
E esp32wifi: StartConnect: error 0xffffffff starting scan
```

No Wifi connection is ever re-established, including after returning to the AP.

**Workaround:** `wifi restart`

## Reproduction (observed while driving out of AP range)

1. Module is connected to a home AP, vehicle drives away.
2. Signal degrades; netmanager disconnects the STA
   (`WIFI client has bad signal quality`) and, with `wifi.bad.reconnect`
   enabled, immediately triggers a reconnect.
3. The reconnect scan still finds the (now weak) AP and starts an association.
4. The retry timer fires into the in-flight association → driver wedges.
5. Module never reconnects to any Wifi until `wifi restart`.

## Log excerpt

```
HH:34:58.860 I (21939390) netmanager: WIFI client has bad signal quality (-89.2 dBm); disconnect
HH:34:58.880 E (21939410) esp32wifi: Reconnect: starting Wifi client reconnect
HH:34:58.960 I (21939490) esp32wifi: STA disconnected with reason 8 = ASSOC_LEAVE
HH:35:15.670 I (21956200) esp32wifi: ScanDone: connect to ssid='<SSID>' bssid='<BSSID>' chan=10 rssi=-86
HH:35:15.680 W (21956210) wifi:sta_scan: STA is connecting, scan are not allowed!
HH:35:15.690 E (21956220) esp32wifi: StartConnect: error 0xffffffff starting scan
.... module is now in the broken state ....
HH:35:24.850 W (21965380) wifi:sta_scan: STA is connecting, scan are not allowed!
HH:35:24.850 E (21965380) esp32wifi: StartConnect: error 0xffffffff starting scan
HH:35:34.850 W (21975380) wifi:sta_scan: STA is connecting, scan are not allowed!
HH:35:34.850 E (21975380) esp32wifi: StartConnect: error 0xffffffff starting scan
.... repeats every 10.000 s until 'wifi restart' ....
```

Note the tight sequence at the wedge onset: `esp_wifi_connect()` is issued at
`21956200`, and 10–20 ms later `StartConnect` stops/starts a scan into the
association. The exact 10-second period of the follow-up errors matches the
retry timer.

## Root cause

`StartConnect()` armed its retry deadline at **scan start** rather than when
the attempt concluded:

```cpp
esp_err_t res = esp_wifi_scan_start(&scanConf, false);   // async
...
m_sta_reconnect = monotonictime + 10;                    // starts ticking NOW
```

`EventTimer1()` re-invokes `StartConnect()` once that deadline passes, with no
check for whether a scan or association is already in flight. Two factors make
the race window land reliably inside the association:

1. A full all-channel scan (`show_hidden`, 120 ms/channel, plus coexistence
   with the cellular modem) can take most of — or more than — the 10-second
   retry interval, so the deadline expires around the time `ScanDone` fires.
2. `EventWifiScanDone()` and `EventTimer1()` both run on the OVMS event task;
   the `ticker.1` event can be queued directly behind `scan.done`, so
   `StartConnect()` can run milliseconds after `esp_wifi_connect()`.

A weak AP (here −86 dBm, reconnecting while driving away) stretches the
association long enough that the interfering `esp_wifi_scan_stop()` /
`esp_wifi_scan_start()` leaves the esp-idf Wifi blob stuck in its *connecting*
state. In that state it:

- never emits `WIFI_EVENT_STA_DISCONNECTED` (so `m_sta_connected` stays false
  and no code path ever issues `esp_wifi_disconnect()` to clear the state), and
- rejects every scan (`STA is connecting, scan are not allowed!`), which is the
  first step of every subsequent connect attempt.

Result: a permanent retry loop that can never succeed.

An additional latent bug with the same mechanism: `m_sta_reconnect` was never
cleared on a successful connect, so during normal operation it holds a
long-expired timestamp. On any disconnect, the very next ticker fires
`StartConnect()` against whatever state the driver is in.

The racy retry logic dates back to 5d1f12406 (2020-07-10).

## Fix

Two layers, both in `components/esp32wifi`:

### 1. Don't race the driver (removes the trigger)

Track the in-flight operation with two deadlines, `m_sta_scan_pending` and
`m_sta_connect_pending`:

- `StartConnect()` returns early while a scan or association is in flight;
  it no longer stops/starts scans into a connecting driver.
- While an operation is pending, the retry timer is disarmed — the `scan.done`
  and connected/disconnected events drive the state machine instead.
- `EventWifiScanDone()` arms `m_sta_connect_pending` when it issues
  `esp_wifi_connect()`.
- `EventWifiStaConnected()` clears the retry state;
  `EventWifiStaDisconnected()` now schedules the next attempt itself
  (2 s after losing an established link — preserving netmanager's fast-roam
  intent — 10 s after a failed association).
- `Scan()` (user scan command) aborts a pending connect scan, so it re-arms
  the retry timer to keep the client state machine alive.
- `Reconnect()` aborts a pending association via `esp_wifi_disconnect()`
  instead of being silently ignored by the driver.

### 2. Recover if the driver wedges anyway (cause-agnostic safety net)

New `StaWatchdog()`, called from the 1-second ticker:

- aborts an association that hasn't completed within 20 s via
  `esp_wifi_disconnect()` (the documented way to cancel a connect attempt,
  which also clears the driver's *connecting* state),
- aborts a scan that hasn't delivered a result within 30 s,
- after 3 consecutive timeouts or refused scans, escalates to a Wifi driver
  restart — automating the manual `wifi restart` workaround. A delivered scan
  result resets the strike counter.

This layer recovers the module even if some other path wedges the driver.

### Drive-by fix

`EventWifiScanDone()` leaked the AP record list on the
`esp_wifi_scan_get_ap_records()` error path.

## Notes / caveats

- The watchdog escalation calls `esp32wifi::Restart()`, which reverts to the
  boot/default Wifi config (same as the `wifi restart` command). If the mode
  was switched at runtime, that runtime mode is lost on this (rare, last-resort)
  recovery.
- Timing constants are `#define`s at the top of `esp32wifi.cpp`
  (`WIFI_RECONNECT_INTERVAL`, `WIFI_RECONNECT_DELAY`, `WIFI_SCAN_TIMEOUT`,
  `WIFI_CONNECT_TIMEOUT`, `WIFI_STUCK_LIMIT`) and could be made config
  parameters if desired.

## Testing status

- Component compiles clean (no warnings) with the esp-idf 3.x make build.
- Layer 1 verified by inspection against the captured log; layer 2 is a safety
  net that by design only fires in driver states that are hard to reproduce on
  demand. Not yet road-tested — feedback from others hitting this welcome.

## Files changed

```
vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.cpp | 145 ++++++++++++++++-
vehicle/OVMS.V3/components/esp32wifi/src/esp32wifi.h   |   6 +-
2 files changed, 146 insertions(+), 5 deletions(-)
```

CC @dexterbg 
