### PR TITLE
webserver: stop the file API holding three copies of the body in RAM

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.cpp
@@ -871,58 +871,6 @@ int HttpDataSender::HandleEvent(int ev, void* p)
 
 
 /**
- * HttpStringSender: chunked transfer of a memory region (needs to be const during xfer)
- */
-HttpStringSender::HttpStringSender(mg_connection* nc, std::string* msg, bool keepalive /*=true*/)
-  : MgHandler(nc)
-{
-  m_msg = msg;
-  m_sent = 0;
-  m_keepalive = keepalive;
-  ESP_EARLY_LOGV(TAG, "HttpStringSender[%p]: init msg=%p, %d bytes", nc, m_msg, m_msg->size());
-}
-
-HttpStringSender::~HttpStringSender()
-{
-  if (m_sent < m_msg->size()) {
-    ESP_EARLY_LOGV(TAG, "HttpStringSender[%p]: abort msg=%p, %d bytes sent", m_nc, m_msg, m_sent);
-  }
-  delete m_msg;
-}
-
-int HttpStringSender::HandleEvent(int ev, void* p)
-{
-  switch (ev)
-  {
-    case MG_EV_SEND:          // last transmission has finished
-    {
-      if (m_sent < m_msg->size()) {
-        // send next chunk:
-        size_t len = MIN(m_msg->size() - m_sent, XFER_CHUNK_SIZE);
-        mg_send_http_chunk(m_nc, (const char*) m_msg->data() + m_sent, len);
-        m_sent += len;
-        ESP_EARLY_LOGV(TAG, "HttpStringSender[%p] msg=%p sent %d/%d", m_nc, m_msg, m_sent, m_msg->size());
-      }
-      else {
-        // done:
-        if (!m_keepalive)
-          m_nc->flags |= MG_F_SEND_AND_CLOSE;
-        mg_send_http_chunk(m_nc, "", 0);
-        ESP_EARLY_LOGV(TAG, "HttpStringSender[%p]: done msg=%p, %d bytes sent", m_nc, m_msg, m_sent);
-        delete this;
-      }
-    }
-    break;
-
-    default:
-      break;
-  }
-
-  return ev;
-}
-
-
-/**
  * CheckLogin: check username & password
  *
  * We use "admin" as a fixed username for now to be able to extend users later on

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.h
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/ovms_webserver.h
@@ -334,23 +334,75 @@ class HttpDataSender : public MgHandler
 
 
 /**
- * HttpStringSender transmits a std::string in HTTP chunks of XFER_CHUNK_SIZE size.
+ * HttpStringSenderT transmits a string in HTTP chunks of XFER_CHUNK_SIZE size.
  * Note: the string is deleted after transmission.
+ *
+ * Two instantiations are provided: HttpStringSender for a std::string, and
+ * HttpExtRamStringSender for an extram::string. Prefer the latter for file-sized
+ * bodies: the sender takes ownership of the buffer the body was loaded into and
+ * emits it in place, so serving a large body needs no second full-size allocation.
  */
-class HttpStringSender : public MgHandler
+template <class StringType>
+class HttpStringSenderT : public MgHandler
 {
   public:
-    HttpStringSender(mg_connection* nc, std::string* msg, bool keepalive=true);
-    ~HttpStringSender();
+    HttpStringSenderT(mg_connection* nc, StringType* msg, bool keepalive=true)
+      : MgHandler(nc)
+    {
+      m_msg = msg;
+      m_sent = 0;
+      m_keepalive = keepalive;
+      ESP_EARLY_LOGV("webserver", "HttpStringSender[%p]: init msg=%p, %d bytes", nc, m_msg, m_msg->size());
+    }
+    ~HttpStringSenderT()
+    {
+      if (m_sent < m_msg->size()) {
+        ESP_EARLY_LOGV("webserver", "HttpStringSender[%p]: abort msg=%p, %d bytes sent", m_nc, m_msg, m_sent);
+      }
+      delete m_msg;
+    }
 
   public:
-    int HandleEvent(int ev, void* p);
+    int HandleEvent(int ev, void* p)
+    {
+      switch (ev)
+      {
+        case MG_EV_SEND:          // last transmission has finished
+        {
+          if (m_sent < m_msg->size()) {
+            // send next chunk:
+            size_t remain = m_msg->size() - m_sent;
+            size_t len = (remain < (size_t) XFER_CHUNK_SIZE) ? remain : (size_t) XFER_CHUNK_SIZE;
+            mg_send_http_chunk(m_nc, (const char*) m_msg->data() + m_sent, len);
+            m_sent += len;
+            ESP_EARLY_LOGV("webserver", "HttpStringSender[%p] msg=%p sent %d/%d", m_nc, m_msg, m_sent, m_msg->size());
+          }
+          else {
+            // done:
+            if (!m_keepalive)
+              m_nc->flags |= MG_F_SEND_AND_CLOSE;
+            mg_send_http_chunk(m_nc, "", 0);
+            ESP_EARLY_LOGV("webserver", "HttpStringSender[%p]: done msg=%p, %d bytes sent", m_nc, m_msg, m_sent);
+            delete this;
+          }
+        }
+        break;
+
+        default:
+          break;
+      }
+
+      return ev;
+    }
 
   public:
-    std::string*              m_msg = NULL;           // pointer to data
+    StringType*               m_msg = NULL;           // pointer to data
     size_t                    m_sent = 0;             // size sent up to now
     bool                      m_keepalive = false;    // false = close connection when done
 };
+
+typedef HttpStringSenderT<std::string>      HttpStringSender;
+typedef HttpStringSenderT<extram::string>   HttpExtRamStringSender;
 
 
 /**

--- a/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
+++ b/vehicle/OVMS.V3/components/ovms_webserver/src/web_cfg.cpp
@@ -1188,7 +1188,21 @@ void OvmsWebServer::HandleFile(PageEntry_t& p, PageContext_t& c)
   } else {
     c.head(200);
     if (c.method == "GET") {
-      c.print(content);
+      // Stream the file instead of appending the whole body to the connection buffer.
+      // The API will open any readable path on /store or /sd, so the body is bounded
+      // only by the file. Printing it whole holds three full-size copies at once: the
+      // load_file() target, the by-value argument of print(const extram::string), and
+      // the copy mg_send_http_chunk() appends to the connection mbuf - which cannot
+      // drain while the handler is still running. Streaming keeps only the first.
+      // Ownership of the body passes to the sender, which frees it and itself once the
+      // transfer completes and emits the terminating chunk - so this path deliberately
+      // does not fall through to c.done().
+      // An empty body (a directory path, which loads nothing) is handled correctly:
+      // the sender sends the terminating chunk on its first event and retires.
+      extram::string* body = new extram::string();
+      body->swap(content);
+      new HttpExtRamStringSender(c.nc, body);
+      return;
     }
   }
 


### PR DESCRIPTION
`HandleFile` serves any readable path under `/store` or `/sd`, so the body it returns on a GET is bounded only by the file it is pointed at. That body was passed to `PageContext::print()`, and the peak cost of doing so is three full-size copies of the file:

| | source | size |
|---|---|---|
| the loaded body | `load_file()` into an `extram::string` | N |
| the print argument | `PageContext::print(const extram::string text)` takes it **by value** | N |
| the connection buffer | `mg_send_http_chunk()` appends it; the mbuf grows by `MBUF_SIZE_MULTIPLIER` 1.5 | 1.5N |

Nothing frees the earlier copies before the later ones are built, because the send buffer cannot drain while the handler is still running. So the peak is roughly 3.5x the file, and the mbuf leg needs its 1.5N contiguous. All three live in SPIRAM, since `mg_locals.h` maps the mongoose allocators onto `ExternalRam*`; they fall back to internal RAM only when SPIRAM cannot supply a contiguous block.

This streams the body straight out of the buffer it was loaded into, so neither of the other two copies happens. Peak drops from roughly 3.5x the file to roughly 1x.

## Evidence

The measured evidence comes from the same code shape rather than from this handler. My e-TNGA vehicle module writes a report at the end of each charge session and offers a page to browse and download them; a long DC session CSV runs to a few megabytes. That page printed whole bodies and died reproducibly after about two dozen files and roughly 660 KB in one session, with the failing allocation usually somewhere unrelated. After handing the body to the chunked sender it completed 72 files and about 20 MB cleanly.

Fixing that is what produced `HttpExtRamStringSender`, and `HandleFile` is the upstream code with the same shape, which is why this PR exists as its own change rather than buried in a vehicle PR.

`/api/file` itself has been exercised at 2.7 MB after the change, with byte-identical output. I do not have a pre-change failure on this specific handler.

Measured on an OVMS v3 module reading SD-card files over the local network. Those runs were on my own tree, which carries this change plus unrelated work: the code path is identical, but the module hours are not attributable to this branch alone.

## The change

`HandleFile`'s GET path hands ownership of the loaded body to a chunked sender and returns. The sender frees the body and itself after the last chunk and emits the terminating zero-length chunk, which is why this path deliberately does not fall through to `c.done()`. An empty body, meaning a directory path, is handled: the sender terminates on its first event.

`HttpStringSender` is generalised to `HttpStringSenderT<StringType>`:

```
typedef HttpStringSenderT<std::string>      HttpStringSender;
typedef HttpStringSenderT<extram::string>   HttpExtRamStringSender;
```

The old name survives as a typedef, so this is source compatible, and nothing else in the tree referenced the class, so `HandleFile` is the only behavioural change. The implementation moves into the header because it is now a template, which is a mechanical move with the `ESP_EARLY_LOGV` traces preserved verbatim (the log tag is the literal `"webserver"`). The one functional edit inside the sender is computing the chunk length with a comparison rather than the `MIN` macro, which is not visible in the header.

## Testing

Builds clean in CI with no vehicle modules enabled, so the result is attributable to this change alone. That covers compilation; the figures above are the behavioural evidence.

## Worth knowing

The streaming path is roughly 1.6x slower than serving the same file statically. Irrelevant when editing a script, but a client pulling a multi-megabyte file through `/api/file` needs a timeout above about 150 seconds, and a default-timeout client may now give up where it previously succeeded.

I could not find an existing issue for this. It surfaced while chasing an unrelated memory problem rather than from a user report.

## Scope: GET only

The save path is untouched and cannot be fixed the same way. `PageContext::getvar(name, extram::string&)` allocates a buffer the size of the entire url-encoded body while `hm->body` is still in `recv_mbuf`, and mongoose has already buffered the complete request before `MG_EV_HTTP_REQUEST` fires. Streaming the save side means the multipart or streaming request path, which is a different API shape for `/api/file` rather than an extension of this change. Happy to write it as its own PR if that is wanted.

## Three decisions I would happily revisit

**Only HandleFile is converted.** The other `c.print()` sites on an `extram::string` are `PluginHandler`, which holds a reference to registry-owned content and so cannot pass ownership without a copy, and `PluginCallback`, which emits a fragment into a composed page where a stream-and-return sender would truncate everything after it. Plugin content is also bounded in practice, unlike an arbitrary path under `/sd`. Happy to add a non-owning variant if you want those covered.

**Template versus a second class.** Duplicating forty lines to change one type seemed the worse trade, but this does touch code that already works. Easy to switch to a standalone extram sender alongside the concrete class if you prefer.

**Streaming is unconditional.** Small files pay the slowdown for a problem they do not have. A size threshold avoids that at the cost of two paths to keep correct, and I erred toward one.