### PR TITLE
Server V2: advertise capability C26 so the app can offer climate control

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
+++ b/vehicle/OVMS.V3/components/ovms_server_v2/src/ovms_server_v2.cpp
@@ -1735,7 +1735,20 @@ void OvmsServerV2::TransmitMsgEnvironment(bool always)
 
 void OvmsServerV2::TransmitMsgCapabilities(bool always)
   {
+  bool requested = m_now_capabilities;
   m_now_capabilities = false;
+
+  // Quick exit if not explicitly requested (mirrors the other TransmitMsg*)
+  if ((!always) && (!requested)) return;
+
+  OvmsVehicle* vehicle = MyVehicleFactory.ActiveVehicle();
+  if (vehicle == NULL) return;
+  if (!vehicle->SupportsClimateControl()) return;
+
+  // Protocol v2 message 0x56 "V": comma separated capability list,
+  // C<cmd> = vehicle supports command <cmd>.
+  // 26 = Remote Climate Control -> app shows its climate button.
+  Transmit("MP-0 VC26");
   }
 
 void OvmsServerV2::TransmitMsgGroup(bool always)

--- a/vehicle/OVMS.V3/components/vehicle/vehicle.h
+++ b/vehicle/OVMS.V3/components/vehicle/vehicle.h
@@ -527,6 +527,9 @@ class OvmsVehicle : public InternalRamAllocated
     virtual vehicle_command_t CommandCooldown(bool cooldownon);
     virtual vehicle_command_t CommandWakeup();
     virtual vehicle_command_t CommandClimateControl(bool enable);
+    // Whether CommandClimateControl() is actually implemented by this
+    // vehicle. Used to advertise V2 capability C26 to the app.
+    virtual bool SupportsClimateControl() { return false; }
     virtual vehicle_command_t CommandLock(const char* pin);
     virtual vehicle_command_t CommandUnlock(const char* pin);
     virtual vehicle_command_t CommandActivateValet(const char* pin);

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.h
@@ -67,6 +67,7 @@ class OvmsVehicleVWeGolf : public OvmsVehicle {
     vehicle_command_t CommandUnlock(const char* pin) override;
     vehicle_command_t CommandWakeup() override;
     vehicle_command_t CommandClimateControl(bool enable) override;
+    bool SupportsClimateControl() override { return true; }
     // Charge control — shares the BatteryControl (LSG 0x25) command path with climate.
     vehicle_command_t CommandSetChargeCurrent(uint16_t limit) override;  // persistent maxCurrent edit
     vehicle_command_t CommandStartCharge() override;  // immediate charge start (on-car validated)

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
@@ -357,6 +357,8 @@ struct OvmsVehicle {
     virtual vehicle_command_t CommandUnlock(const char*) { return NotImplemented; }
     virtual vehicle_command_t CommandWakeup()                 { return NotImplemented; }
     virtual vehicle_command_t CommandClimateControl(bool)     { return NotImplemented; }
+    // Mirrors the base class: vehicles opt in to advertising V2 capability C26.
+    virtual bool SupportsClimateControl()                     { return false; }
     virtual vehicle_command_t CommandSetChargeCurrent(uint16_t){ return NotImplemented; }
     virtual vehicle_command_t CommandStartCharge()            { return NotImplemented; }
     virtual vehicle_command_t CommandStopCharge()             { return NotImplemented; }


### PR DESCRIPTION
# Server V2: advertise capability C26 so the app can offer climate control

## The problem

`OvmsServerV2::TransmitMsgCapabilities()` is an empty stub, so no V3 module ever
sends the `V` message. The official Android app calls `hasCommand(26)` before it
enables the climate control button, and since that is never true it falls back to
a hard-coded list of car types:

```java
// The V3 framework does not support capabilities yet, but
// the Leaf, Smart, VW e-Up and Zoe Ph2 are the only cars providing command 26 up to now, so:
if (carData.hasCommand(26)
    || carData.car_type == "NL"
    || carData.car_type == "SE"
    ...
```

Anything outside that list gets a greyed-out button no matter what the firmware
can do. That is a real, reported problem: see
https://github.com/openvehicles/Open-Vehicle-Monitoring-System-3/issues/690#issuecomment-5337489845
— a 2020 e-Golf on current edge, where the firmware has climate control and the
app will not ask for it.

## What this does

* `OvmsVehicle::SupportsClimateControl()`, virtual, defaults to `false`, so no
  existing vehicle changes behaviour.
* `TransmitMsgCapabilities()` sends `MP-0 VC26` when the active vehicle
  overrides it to `true`, following the same requested/always pattern as the
  other `TransmitMsg*` methods.
* `vehicle_vwegolf` opts in.

Any other vehicle that implements `CommandClimateControl()` opts in with one
line and its users get the button without waiting for an app release. I have
deliberately not flipped the flag on vehicles I cannot test — the ones the app
hard-codes today (Leaf, Smart, e-Up, ZOE Ph2, Volt/Ampera) are the obvious
candidates, and their maintainers know better than I do whether the command is
complete on their car.

## Testing

* 2016 VW e-Golf, module on cellular: the climate button appears in the official
  app, and both start and stop reach the car.
* The e-Golf component's native tests still build and pass (88/88) — the mock
  mirrors the new virtual.
