### PR TITLE
vwegolf: set the pre-conditioning target temperature (BC_SET_TEMP)

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/bat-ctrl-bap.md
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/docs/bat-ctrl-bap.md
@@ -132,8 +132,22 @@ kill climate** — so OVMS blocks charge-stop while `ms_v_env_hvac` is set (the 
 stop climate first). Climate-stop is unaffected and always allowed.
 
 **Skip-write optimization.** For climate/charge, if profile 0 already holds the target op the arm
-writes nothing (the ~5-frame RA0 write is a no-op) and only the trigger is sent. SET_CURRENT always
-writes (applying the current is the command, and it confirms on the write echo).
+writes nothing (the ~5-frame RA0 write is a no-op) and only the trigger is sent. SET_CURRENT and
+SET_TEMP always write (applying the value is the command, and they confirm on the write echo).
+
+**Set target temperature** — edits the `temperature` field of profile 0 (byte 12,
+`raw = °C×10 − 100`), snapped to the car's half-degree steps between 15.5 and 30.0 °C.
+Like SET_CURRENT it is a pure settings edit: only that byte moves, the operation byte is left exactly
+as read, so it can neither start nor stop anything, and there is **no trigger**. Confirmed on the
+FSG's SET echo `49 59 bx`, which also updates `v.e.cabinsetpoint`.
+
+Unlike the charge current, a **running** conditioning session picks the new setpoint up by itself —
+no re-fire needed. Measured on a 2016 e-Golf at 28 °C ambient, polling `v.e.cabintemp` every
+20 s: with a 30 °C target and a 35 °C cabin it drifted at −0.19 °C/min; about 40 s
+after writing 16.0 °C the rate went to −2.2 °C/min. The reverse holds as well — cooling
+at −1.3 °C/min, write 30.0 °C, and it turns around to +0.29 °C/min within the same
+~40 s. So the BCU re-reads the profile while it runs, and only the charge current needs the start
+re-fired.
 
 **Errors are terminal.** A BAP `ERROR` (opcode 7) on the OperationMode func — e.g. the BCU refusing
 to charge while unplugged — aborts the command immediately: no re-fire, and a later `49 58` echo

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -27,6 +27,7 @@
 */
 
 // #include <stdio.h>
+#include <cmath>  // lroundf, for the cctemp command
 #include "vehicle_vwegolf.h"
 
 #undef TAG
@@ -65,6 +66,36 @@ OvmsVehicleVWeGolf::OvmsVehicleVWeGolf() {
     });
     cmd_vweg->RegisterCommand("fold_mirrors", "Fold mirrors in",
                               [this](...) { CommandMirrorFoldIn(); });
+    cmd_vweg->RegisterCommand(
+        "cctemp", "Set the pre-conditioning target temperature",
+        [this](int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc,
+               const char* const* argv) {
+            if (argc < 1) { writer->puts("Usage: xvg cctemp <15.5..30.0>"); return; }
+            // Snap to the half-degree steps the car uses.
+            int deci = 5 * (int)lroundf((float)atof(argv[0]) * 2.0F);
+            if (deci < 155 || deci > 300) {
+                writer->printf("Out of range: %s C. The car accepts 15.5 to 30.0 C.\n", argv[0]);
+                return;
+            }
+            if (!m_batctrl.SetClimateTempRaw(bap::egolf::tempToRawDeci(deci))) {
+                writer->puts("Could not start the write -- is the car reachable?");
+                return;
+            }
+            writer->printf("Setting target temperature to %.1f C.\n", deci / 10.0F);
+        },
+        "<degrees C, 15.5..30.0 in 0.5 steps>", 1, 1);
+    cmd_vweg->RegisterCommand(
+        "ccstatus", "Climate settings as one machine-readable line",
+        [this](int verbosity, OvmsWriter* writer, OvmsCommand* cmd, int argc,
+               const char* const* argv) {
+            // From the standard metrics, not from the profile: the module fetches
+            // the profile per command and does not keep it, the metrics persist.
+            // A target temperature below 10 C is not encodable, so 0 means
+            // "never read" rather than a real value.
+            float t = StandardMetrics.ms_v_env_cabinsetpoint->AsFloat();
+            writer->printf("cctemp=%.1f current=%d valid=%d\n", t,
+                           StandardMetrics.ms_v_charge_climit->AsInt(), t > 0 ? 1 : 0);
+        });
 }
 
 OvmsVehicleVWeGolf::~OvmsVehicleVWeGolf() {

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf_bat_ctrl.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf_bat_ctrl.cpp
@@ -53,6 +53,12 @@ bool VWeGolfBatteryControl::Charge(bool enable) {
     return Begin(BC_CHARGE, enable, 0);
 }
 
+bool VWeGolfBatteryControl::SetClimateTempRaw(uint8_t raw) {
+    // Pure settings edit: no trigger, no op change. The car keeps running whatever
+    // it was doing; only the stored target temperature changes.
+    return Begin(BC_SET_TEMP, /*enable=*/true, raw);
+}
+
 bool VWeGolfBatteryControl::SetChargeCurrent(uint16_t amps) {
     // Snap to an allowed BCU step {5,10,13,32} — the car turns any out-of-set value into 10 A (it
     // echoes the requested value but charges at 10 A), so snapping to the nearest valid step is what
@@ -64,6 +70,9 @@ bool VWeGolfBatteryControl::SetChargeCurrent(uint16_t amps) {
 bool VWeGolfBatteryControl::Begin(BcOp op, bool enable, uint16_t param) {
     if (op == BC_SET_CURRENT)
         ESP_LOGI(TAG, "BatteryControl SetChargeCurrent -> %u A", (unsigned)param);
+    else if (op == BC_SET_TEMP)
+        ESP_LOGI(TAG, "BatteryControl SetClimateTemp -> %.1f C",
+                 bap::egolf::rawToTemp((uint8_t)param));
     else
         ESP_LOGI(TAG, "BatteryControl %s %s", op == BC_CHARGE ? "Charge" : "Climate",
                  enable ? "ON" : "OFF");
@@ -132,7 +141,7 @@ void VWeGolfBatteryControl::Ticker1(bool bus_alive) {
                         // the write echo in CP_ARM_WAIT when it must auto-apply (re-fire the start for
                         // a running charge), else CP_CONFIRM; climate/charge trigger immediately on a
                         // skipped arm, else wait for the echo in CP_ARM_WAIT.
-                        if (m_op == BC_SET_CURRENT)   m_phase = m_apply ? CP_ARM_WAIT : CP_CONFIRM;
+                        if (IsSettingsEdit())         m_phase = m_apply ? CP_ARM_WAIT : CP_CONFIRM;
                         else if (m_arm_skipped)     { SendTrigger(m_enable); m_phase = CP_CONFIRM; }
                         else                          m_phase = CP_ARM_WAIT;
                     }
@@ -152,7 +161,7 @@ void VWeGolfBatteryControl::Ticker1(bool bus_alive) {
                 // write echo -> re-write. Everything else (climate/charge, or SET_CURRENT auto-apply
                 // past its re-trigger) is waiting on the 49 58 -> re-fire the trigger. Never re-arm a
                 // climate/charge start (that resets the BCU's spin-up).
-                if (m_op == BC_SET_CURRENT && !m_apply) SendArm();
+                if (IsSettingsEdit() && !m_apply) SendArm();
                 else SendTrigger(m_enable);
                 break;
             default:  // CP_WAKE: keep NM-waking until the BCU is heard; CP_DONE: nothing
@@ -174,10 +183,11 @@ void VWeGolfBatteryControl::Ticker1(bool bus_alive) {
         // distinguished cause so a remote user knows what happened.
         const char* what = m_op == BC_CHARGE       ? "Charge"
                          : m_op == BC_SET_CURRENT  ? "SetChargeCurrent"
+                         : m_op == BC_SET_TEMP     ? "SetClimateTemp"
                                                    : "Climate";
         if (m_confirmed) {
             ESP_LOGI(TAG, "%s %s confirmed — releasing NM, cluster self-sustains", what,
-                     m_op == BC_SET_CURRENT ? "" : (m_enable ? "ON" : "OFF"));
+                     IsSettingsEdit() ? "" : (m_enable ? "ON" : "OFF"));
         } else {
             char reason[96];
             // Every command (ON, OFF, SET_CURRENT) reads profile 0 first to arm the matching op, so a
@@ -323,6 +333,19 @@ void VWeGolfBatteryControl::IncomingBapStatus(const CAN_frame_t* p_frame) {
         if (lead & 0x80) {
             // SET_CURRENT: the write landed -> reflect the applied limit (the read-back left it
             // untouched, so there's no jump-back).
+            if (m_op == BC_SET_TEMP) {
+                // Erst jetzt steht fest, dass die neue Temperatur im Fahrzeug ist.
+                StandardMetrics.ms_v_env_cabinsetpoint->SetValue(
+                    bap::egolf::rawToTemp((uint8_t)m_param), Celcius);
+                if (m_phase == CP_CONFIRM) {  // der Schreibvorgang IST der ganze Befehl
+                    m_confirmed = true;
+                    m_phase = CP_DONE;
+                    if (m_wake_hold > 2) m_wake_hold = 2;
+                    ESP_LOGI(TAG, "SetClimateTemp %.1f C written -- BCU echoed 49 59 %02x",
+                             bap::egolf::rawToTemp((uint8_t)m_param), lead);
+                    return;
+                }
+            }
             if (m_op == BC_SET_CURRENT) {
                 StandardMetrics.ms_v_charge_climit->SetValue((float)m_param, Amps);
                 if (m_apply && m_phase == CP_ARM_WAIT) {
@@ -379,11 +402,13 @@ void VWeGolfBatteryControl::IncomingBapStatus(const CAN_frame_t* p_frame) {
                     // old value (a natural rollback) — see the SET_CURRENT confirm + failure handling.
                     if (m_op != BC_SET_CURRENT)
                         StandardMetrics.ms_v_charge_climit->SetValue((float)m_profile0.maxCurrent, Amps);
-                    if (m_profile0.temperatureRaw != 0xFF)  // 0xFF = unset/padding
+                    // Bei BC_SET_TEMP nicht den gerade zu ersetzenden Wert anzeigen --
+                    // die Metrik wuerde sichtbar auf alt springen und dann auf neu.
+                    if (m_op != BC_SET_TEMP && m_profile0.temperatureRaw != 0xFF)  // 0xFF = unset/padding
                         StandardMetrics.ms_v_env_cabinsetpoint->SetValue(
                             bap::egolf::rawToTemp(m_profile0.temperatureRaw), Celcius);
                     if (!SendArm()) break;  // arm TX failed; the CP_PROFILE backstop re-arms
-                    if (m_op == BC_SET_CURRENT) {
+                    if (IsSettingsEdit()) {
                         // Idle: confirm on the write echo (0xbX), no trigger. Auto-apply (charging):
                         // wait for the echo, then re-fire the start (handled in CP_ARM_WAIT).
                         m_phase = m_apply ? CP_ARM_WAIT : CP_CONFIRM;
@@ -516,6 +541,11 @@ bool VWeGolfBatteryControl::SendArm() {
             p.operation = (uint8_t)((p.operation | bap::egolf::PO_CHARGING)
                                     & ~(bap::egolf::PO_CLIMATE | bap::egolf::PO_ALLOW_BATTERY));
             break;
+        case BC_SET_TEMP:
+            // Only the temperature; the op byte stays as the car has it, so this
+            // cannot start or stop anything.
+            p.temperatureRaw = m_param;
+            break;
         case BC_SET_CURRENT:
             p.maxCurrent = m_param;
             // Auto-apply (a charge is running): also set the op to charge so the re-fired start
@@ -535,7 +565,7 @@ bool VWeGolfBatteryControl::SendArm() {
     // already holds, so the ~5-frame RA0 write is a no-op — skip it and let the trigger run the
     // already-correct op. (SET_CURRENT always writes — applying the current IS the command, and it
     // confirms on the write echo. A write still happens if the hard cap changed maxCurrent, i.e. p differs.)
-    if (m_op != BC_SET_CURRENT &&
+    if (!IsSettingsEdit() &&
         p.operation == m_profile0.operation && p.maxCurrent == m_profile0.maxCurrent) {
         m_arm_skipped = true;  // no write -> no "49 59 bx" echo coming -> caller triggers immediately
         ESP_LOGI(TAG, "%s arm: profile 0 already op 0x%02x — no write needed",
@@ -554,6 +584,9 @@ bool VWeGolfBatteryControl::SendArm() {
     if (m_op == BC_SET_CURRENT)
         ESP_LOGI(TAG, "SetChargeCurrent arm: profile 0 maxCurrent 0x%02x -> 0x%02x (%u frames)",
                  m_profile0.maxCurrent, p.maxCurrent, r.framesSent);
+    else if (m_op == BC_SET_TEMP)
+        ESP_LOGI(TAG, "SetClimateTemp arm: profile 0 temperature 0x%02x -> 0x%02x (%u frames)",
+                 m_profile0.temperatureRaw, p.temperatureRaw, r.framesSent);
     else
         ESP_LOGI(TAG, "%s arm: profile 0 op 0x%02x -> 0x%02x written (%u frames)",
                  m_op == BC_CHARGE ? "Charge" : "Climate", m_profile0.operation, p.operation,

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf_bat_ctrl.h
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf_bat_ctrl.h
@@ -91,6 +91,10 @@ class VWeGolfBatteryControl {
                                            // car's own UI only edits timers. Gated no-arm->no-trigger like
                                            // climate. STOP is op-specific: OFF arms the pure-charge op
                                            // first, so it's blocked while climate is on.)
+    // Set the pre-conditioning target temperature (persistent settings edit via
+    // the same RA0 read-modify-write). Takes the raw profile encoding
+    // (degC * 10 - 100) so it fits the uint8_t command parameter.
+    bool SetClimateTempRaw(uint8_t raw);
     bool SetChargeCurrent(uint16_t amps);  // set the charge-current limit (persistent settings edit via
                                            // profile-0 RMW, NO trigger). Amps are snapped to the car's
                                            // allowed steps {5,10,13,32} and hard-capped at 0x20 (see .cpp).
@@ -119,10 +123,14 @@ class VWeGolfBatteryControl {
         BC_CLIMATE = 0,   // arm PO_CLIMATE  -> trigger start/stop; confirm 49 58 -> ms_v_env_hvac
         BC_CHARGE,        // arm PO_CHARGING -> trigger start/stop; confirm 49 58 (charge state via 0x594)
         BC_SET_CURRENT,   // RMW maxCurrent only, NO trigger (settings edit); confirm on the write echo
+        BC_SET_TEMP,      // RMW temperature only, NO trigger (settings edit); confirm on the write echo
     };
 
     // Shared entry: reset command state, select the op, kick the wake. enable = on/off for
     // climate/charge (ignored/true for set-current); param = clamped amps for BC_SET_CURRENT.
+    // Write-only settings edits: change one stored field, confirm on the write
+    // echo, never fire the immediate trigger.
+    bool IsSettingsEdit() const { return m_op == BC_SET_CURRENT || m_op == BC_SET_TEMP; }
     bool Begin(BcOp op, bool enable, uint16_t param);
 
     // Command progress. The BCU's replies advance it; Ticker1 only holds the wake + backstops.

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/mock/mock_ovms.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstdarg>
 #include <cstdio>
 #include <cstring>
 #include <functional>
@@ -157,6 +158,7 @@ struct OvmsMetric {
     void Clear()                    { g_metrics.numbers.erase(name); }
     T    AsValue() const  { return static_cast<T>(g_metrics.numbers[name]); }
     float AsFloat() const { return static_cast<float>(g_metrics.numbers[name]); }
+    int  AsInt() const    { return static_cast<int>(g_metrics.numbers[name]); }
 };
 
 template<>
@@ -299,7 +301,19 @@ extern OvmsConfig MyConfig;
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
-struct OvmsWriter {};
+struct OvmsWriter {
+    // The real writer prints to the console the command was issued from. The
+    // tests only need the calls to compile and to be harmless, so they go to
+    // stdout.
+    int puts(const char* s) { return std::puts(s); }
+    int printf(const char* fmt, ...) {
+        va_list ap;
+        va_start(ap, fmt);
+        int n = std::vprintf(fmt, ap);
+        va_end(ap);
+        return n;
+    }
+};
 struct OvmsCommand {
     OvmsCommand* RegisterCommand(const char*, const char*, ...) { return this; }
 };


### PR DESCRIPTION
Follow-up to #1496, as suggested by @SCjona: the one BatteryControl setting his
module could not change yet.

`BC_SET_TEMP` is shaped like his `BC_SET_CURRENT` — read profile 0, change one
field, write it back, confirm on the write echo, no trigger. Only the
temperature byte moves; the operation byte is left exactly as the car has it, so
it can neither start nor stop anything. The raw profile encoding
(`degC * 10 - 100`) goes in as the command param so it fits the existing
`uint8_t`: 15.5 °C is 55, 30.0 °C is 200.

Three places needed the new op alongside `BC_SET_CURRENT`, so they share an
`IsSettingsEdit()` predicate now: the post-arm phase choice, the lost-echo retry,
and the skip-write optimisation. That last one is the one that bites — it
compares only the operation byte, so a temperature-only edit looks like a no-op,
nothing is written at all, and the trigger fires anyway. Confirmation also lives
inside the `BC_SET_CURRENT` branch of the write-echo handler; without its own the
command never completes and re-arms every two seconds until the window closes.
Both are worth a suspicious look from whoever knows that state machine.

Two commands come with it, since the target temperature is not carried by the v2
protocol and cannot be read app-side from metrics:

```
xvg cctemp <15.5..30.0>   set it, snapped to the half-degree steps
xvg ccstatus              cctemp=22.0 current=32 valid=1
```

`valid` tests the temperature against 0, per @SCjona's suggestion: below 10 °C is
not encodable, so 0 can only mean "not read yet".

## Does the BCU apply it mid-run?

@SCjona expected it to behave like the charge current, which a running charge
ignores until the next start. It does not — the setpoint is picked up while
conditioning runs, so there is no re-fire. Measured on a 2016 e-Golf, plugged in,
28 °C ambient, `v.e.cabintemp` polled every 20 s:

| window | target | cabin | rate |
|---|---|---|---|
| 1:23 – 5:00 | 30.0 °C | 35.2 → 34.5 °C | −0.19 °C/min |
| 5:43 – 7:23 | 16.0 °C | 34.0 → 30.3 °C | **−2.2 °C/min** |

Three and a half minutes at a 30 °C target with a 35 °C cabin and it barely
moved. About 40 s after the write the curve bends and the cooling rate goes up
tenfold. The reverse, in a second run:

| window | target | cabin | rate |
|---|---|---|---|
| 0:22 – 3:43 | 16.0 °C | 31.0 → 26.7 °C | −1.3 °C/min |
| 4:03 – 10:00 | 30.0 °C | 26.7 → **28.4 °C** | +0.29 °C/min |

Cooling to heating, no restart, same ~40 s latency. Both runs are in the log with
the `49 59 bx` write echoes; `v.e.hvac` stayed set throughout and the only
`49 58 00 -> HVAC OFF` in either came from the stop command. This contrast is
documented in `bat-ctrl-bap.md` next to the charge-current note.

## Notes

* Two small additions keep the native tests building: the mock's `OvmsWriter`
  gained `puts`/`printf` and `OvmsMetric` an `AsInt()`, both used by `ccstatus`,
  and `vehicle_vwegolf.cpp` now includes `<cmath>` for `lroundf` instead of
  picking it up transitively as it does on the target. 136/136 pass.
* One earlier version of this commit also carried a change to
  `TransmitMsgCapabilities()`. That is a separate concern and is now #1506.
