### PR TITLE
Housekeeping: do not read the ADC before the peripherals exist

### DIFF
--- a/vehicle/OVMS.V3/main/ovms_housekeeping.cpp
+++ b/vehicle/OVMS.V3/main/ovms_housekeeping.cpp
@@ -85,6 +85,13 @@ void HousekeepingUpdate12V()
     return;
   if (MyPeripherals == NULL)
     return;
+  // MyPeripherals is published by Peripherals::Peripherals() as its first
+  // statement, so a non-NULL pointer does not mean the peripherals exist yet.
+  // Creating them takes ~150 ms, and this runs on a 1 s timer that can fall
+  // inside that window -- reading through m_esp32adc then panics
+  // (LoadProhibited in esp32adc::read).
+  if (MyPeripherals->m_esp32adc == NULL)
+    return;
 
   // smooth out ADC errors & noise:
   aux_avg_v.add(MyPeripherals->m_esp32adc->read());

--- a/vehicle/OVMS.V3/main/ovms_peripherals.h
+++ b/vehicle/OVMS.V3/main/ovms_peripherals.h
@@ -174,7 +174,10 @@ class Peripherals : public InternalRamAllocated
 #endif // #ifdef CONFIG_OVMS_COMP_BLUETOOTH
 
 #ifdef CONFIG_OVMS_COMP_ADC
-    esp32adc* m_esp32adc;
+    // Initialised here, not just in the constructor: the constructor publishes
+    // MyPeripherals before it creates its members, so anything running during
+    // that window sees this pointer.
+    esp32adc* m_esp32adc = nullptr;
 #endif // #ifdef CONFIG_OVMS_COMP_ADC
 
 #ifdef CONFIG_OVMS_COMP_MCP2515


### PR DESCRIPTION
# Housekeeping reads the ADC before the peripherals exist

## The bug

`Peripherals::Peripherals()` publishes the global pointer as its **first**
statement:

```cpp
Peripherals::Peripherals()
  {
  ESP_LOGI(TAG, "Initialising OVMS Peripherals...");
  MyPeripherals = this;      // ovms_peripherals.cpp:53
```

Everything after that — including `m_esp32adc` — is created over the next ~150 ms.
`HousekeepingUpdate12V()` runs on a 1 s timer and guards only against the global
being NULL:

```cpp
  if (MyPeripherals == NULL)
    return;
  aux_avg_v.add(MyPeripherals->m_esp32adc->read());   // ovms_housekeeping.cpp:90
```

So inside that window the pointer is valid and the member is not. `m_esp32adc`
has no initialiser, so it holds whatever was in the heap block.

## What it looks like

Two outcomes, depending on what that garbage happens to be.

If it addresses unmapped memory, the module boot-loops:

```
Guru Meditation Error: Core 0 panicked (LoadProhibited)
Backtrace: 0x4010d57f 0x401402ec 0x40140435 0x40091abf

0x4010d57f: esp32adc::read() at esp32adc.cpp:50
0x401402ec: HousekeepingUpdate12V() at ovms_housekeeping.cpp:90
0x40140435: HousekeepingTicker1() at ovms_housekeeping.cpp:116
0x40091abf: prvProcessExpiredTimer at freertos/timers.c:1006
```

If it addresses something readable, it survives boot but the channel is nonsense,
so once a second:

```
E (2623) RTC_MODULE: rtc_module.c:1541 (adc1_get_raw): ADC Channel Err
```

and `v.b.12v.voltage` is meaningless. In that state I also saw the DukTape task
miss its watchdog and abort — same boot, different victim.

## Reproducing it

The race is always there; only the timing decides. It reproduced reliably for me
by building with the toolchain this repo's own `.travis.yml` names,
`1.22.0-97-gc752ad5-5.2.0`, instead of `esp-2021r2-patch5-8.4.0`. Identical
commit, identical sdkconfig, one boots and one does not — which is what sent me
looking for a race rather than a code change. Hardware is an OVMS v3.1
(ESP32-D0WD rev 3, 64 Mbit PSRAM), esp-idf v3.3.4-854-g9063c8662.

## The fix

Two lines. The member gets a `nullptr` initialiser — testing it without one
would prove nothing, since it is indeterminate until assigned — and the caller
checks it.

The same reasoning applies to the other `Peripherals` members; this fixes the one
that is reached from a timer. Moving `MyPeripherals = this` to the end of the
constructor would be the broader fix, but sub-objects constructed in there may
rely on it, so that seemed like the riskier change to propose.

Tested on the car: with the fix, the same build that boot-looped comes up
normally, `v.b.12v.voltage` reads correctly, and there are no ADC errors.
