### PR TITLE
SmartEQ: CAN Access selection and transceiver active/listen-only state  

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_can_poll.cpp
@@ -391,6 +391,7 @@ void OvmsVehicleSmartEQ::PollReply_BMS_HVContactorCycles(const char* data, uint1
         smartOBDpolling(false);
         MyConfig.SetParamValueBool("xsq", "canwrite", false);
         MyConfig.SetParamValueBool("xsq", "canwrite.caron", false);
+        MyConfig.SetParamValueBool("xsq", "canwrite.caroff", false);
         }
       }
     // Alert if consumed cycles are above expected for a healthy contactor (e.g. above 50000 cycles consumed)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_commands.cpp
@@ -473,7 +473,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandPreset(int verbosity, 
     if (PRESET_VERSION == PRESET_VERSION_12VREF) 
     {
       m["12v.ref"] = "12.5";
-      m["12v.alert"] = "0.9";
+      m["12v.alert"] = "0.75";
       changed = true;
     }
     if (it_ref == m.end())
@@ -483,7 +483,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandPreset(int verbosity, 
       }
     if (it_alert == m.end())
       {
-      m["12v.alert"] = "0.9";
+      m["12v.alert"] = "0.75";
       changed = true;
       }
     if (need_stream)
@@ -646,7 +646,7 @@ OvmsVehicle::vehicle_command_t OvmsVehicleSmartEQ::CommandSetDefault(int verbosi
   auto map_vehicle = MyConfig.GetParamMap("vehicle");
   map_vehicle["stream"] = "10";
   map_vehicle["12v.ref"] = "12.5";
-  map_vehicle["12v.alert"] = "0.9";
+  map_vehicle["12v.alert"] = "0.75";
   MyConfig.SetParamMap("vehicle", map_vehicle);
 
   // ota section

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -356,16 +356,9 @@ void OvmsVehicleSmartEQ::smartOn()
   // reset idle ticker when vehicle turned on to prevent trigger every 60 sec.
   m_idle_ticker = 15 * 60;
   // canwrite enable write access, only when car is on
-  if(IsCANwrite() && IsOnEQ())
-    {
-    smartCoolDownPolling(5);
-    smartOBDpolling(true);
-    }
-  else
-    {
-    smartCoolDownPolling(5);
-    smartOBDpolling(false);
-    }
+
+  smartCoolDownPolling(5);
+  smartOBDpolling();
   ESP_LOGD(TAG, "smartOn()");
 }
 
@@ -374,24 +367,21 @@ void OvmsVehicleSmartEQ::smartOff()
   // Reset gear
   StdMetrics.ms_v_env_gear->SetValue(0);
   smartCoolDownPolling();
+  smartOBDpolling();
 }
 
 void OvmsVehicleSmartEQ::smartAwake()
 {
   smartCoolDownPolling();
   // enable active polling when car wakes up (canwrite only)
-  if(IsCANwrite())
-    smartOBDpolling(true);
-  else 
-    smartOBDpolling(false); // only enable when car is on and CAN write access #2 is enabled
+  smartOBDpolling();
 }
 
 void OvmsVehicleSmartEQ::smartSleep()
 {  
   smartCoolDownPolling(20);
   // disable active polling when car goes to sleep
-  if( m_enable_write_sleep )
-    smartOBDpolling(false);
+  smartOBDpolling();
   ESP_LOGD(TAG, "smartSleep()");
 }
 
@@ -418,7 +408,7 @@ void OvmsVehicleSmartEQ::smartChargeStart()
     m_ADCfactor_recalc_timer = 2;   // wait at least 2 min. before recalculation
     m_ADCfactor_recalc = true;      // recalculate ADC factor when HV charging
     }
-  smartOBDpolling(true);  
+  smartOBDpolling();  
   ESP_LOGD(TAG, "smartChargeStart()");
 }
 
@@ -479,9 +469,9 @@ void OvmsVehicleSmartEQ::smartCoolDownPolling(int delay_sec)
 
 void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
 {
-  if ( m_can_active != activate ) smartCoolDownPolling(); // cool down polling before switching the state 
-  m_can_active = IsCANwrite() && activate;
-  if(!m_can_active)
+  bool setCANactive = IsCANwrite() && activate;
+  if ( m_can_active != setCANactive ) smartCoolDownPolling(); // cool down polling before switching the state 
+  if(!setCANactive)
     {
     PollSetPidList(m_can1, NULL);
     m_poll_on_charge = false;
@@ -490,6 +480,7 @@ void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
   else {
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list will be updated");
   }    
+  m_can_active = setCANactive;
   smartCANbusAccess(m_can_active);
   HandleOBDpolling();
 }
@@ -498,11 +489,10 @@ void OvmsVehicleSmartEQ::smartCANbusAccess(bool activate)
 {
   if ( m_can_last_acc_state != activate )
     {
-    smartCoolDownPolling();
     if ( activate ) 
-      ESP_LOGI(TAG,"CAN write state: ACTIVE ");
+      ESP_LOGI(TAG,"CAN access state: ACTIVE ");
     else 
-      ESP_LOGI(TAG,"CAN write state: LISTEN-ONLY ");
+      ESP_LOGI(TAG,"CAN access state: LISTEN-ONLY ");
     // set CAN bus transceiver to active or listen-only state
     CAN_mode_t mode = activate ? CAN_MODE_ACTIVE : CAN_MODE_LISTEN;
     RegisterCanBus(1, mode, CAN_SPEED_500KBPS);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_features.cpp
@@ -356,10 +356,15 @@ void OvmsVehicleSmartEQ::smartOn()
   // reset idle ticker when vehicle turned on to prevent trigger every 60 sec.
   m_idle_ticker = 15 * 60;
   // canwrite enable write access, only when car is on
-  if(IsCANwrite()) 
+  if(IsCANwrite() && IsOnEQ())
     {
     smartCoolDownPolling(5);
     smartOBDpolling(true);
+    }
+  else
+    {
+    smartCoolDownPolling(5);
+    smartOBDpolling(false);
     }
   ESP_LOGD(TAG, "smartOn()");
 }
@@ -375,9 +380,9 @@ void OvmsVehicleSmartEQ::smartAwake()
 {
   smartCoolDownPolling();
   // enable active polling when car wakes up (canwrite only)
-  if(m_enable_write)
+  if(IsCANwrite())
     smartOBDpolling(true);
-  else if (m_enable_write_caron && m_can_active)
+  else 
     smartOBDpolling(false); // only enable when car is on and CAN write access #2 is enabled
 }
 
@@ -385,7 +390,7 @@ void OvmsVehicleSmartEQ::smartSleep()
 {  
   smartCoolDownPolling(20);
   // disable active polling when car goes to sleep
-  if((m_enable_write_caron && m_can_active) || (m_enable_write_sleep && m_can_active))
+  if( m_enable_write_sleep )
     smartOBDpolling(false);
   ESP_LOGD(TAG, "smartSleep()");
 }
@@ -474,21 +479,35 @@ void OvmsVehicleSmartEQ::smartCoolDownPolling(int delay_sec)
 
 void OvmsVehicleSmartEQ::smartOBDpolling(bool activate)
 {
-  if(!IsCANwrite())
+  if ( m_can_active != activate ) smartCoolDownPolling(); // cool down polling before switching the state 
+  m_can_active = IsCANwrite() && activate;
+  if(!m_can_active)
     {
     PollSetPidList(m_can1, NULL);
-    m_can_active = false;
     m_poll_on_charge = false;
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared (write access disabled)");
-    return;
     }
-    
-  m_can_active = activate;
-  if (activate)
+  else {
     ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list will be updated");
-  else
-    ESP_LOGD(TAG, "smartOBDpolling(): CAN bus polling list cleared");
+  }    
+  smartCANbusAccess(m_can_active);
   HandleOBDpolling();
+}
+
+void OvmsVehicleSmartEQ::smartCANbusAccess(bool activate) 
+{
+  if ( m_can_last_acc_state != activate )
+    {
+    smartCoolDownPolling();
+    if ( activate ) 
+      ESP_LOGI(TAG,"CAN write state: ACTIVE ");
+    else 
+      ESP_LOGI(TAG,"CAN write state: LISTEN-ONLY ");
+    // set CAN bus transceiver to active or listen-only state
+    CAN_mode_t mode = activate ? CAN_MODE_ACTIVE : CAN_MODE_LISTEN;
+    RegisterCanBus(1, mode, CAN_SPEED_500KBPS);
+    m_can_last_acc_state = activate;
+    }
 }
 
 /**

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_handle.cpp
@@ -102,7 +102,6 @@ void OvmsVehicleSmartEQ::HandleOBDpolling() {
   PollSetPidList(m_can1, NULL);  // Stop active polls during list rebuild (sufficient – no smartCoolDownPolling needed here)
   PollSetThrottling(3);
   PollSetResponseSeparationTime(20);
-
   // modify Poller..
   m_poll_vector.clear();
   if (!m_can_active)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -136,12 +136,9 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
 
   if(m_enable_LED_state) 
     OnlineState();
-  if((!m_can_active && m_enable_write && IsAwakeEQ()) ||
-     (!m_can_active && m_enable_write_caron && IsOnEQ()))
-    {
-    smartCoolDownPolling();
-    smartOBDpolling(true);
-    }
+
+  smartOBDpolling(IsCANwrite());  // check, if the CAN access state has to be switched
+
   // if charging is in progress, then modify polling to get the DCDC/Charging data (reboot prevention)
   if (IsChargingEQ() && !m_poll_on_charge)
     {

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_ticker.cpp
@@ -137,7 +137,7 @@ void OvmsVehicleSmartEQ::Ticker10(uint32_t ticker)
   if(m_enable_LED_state) 
     OnlineState();
 
-  smartOBDpolling(IsCANwrite());  // check, if the CAN access state has to be switched
+  smartOBDpolling();  // check, if the CAN access state has to be switched
 
   // if charging is in progress, then modify polling to get the DCDC/Charging data (reboot prevention)
   if (IsChargingEQ() && !m_poll_on_charge)

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/eq_web.cpp
@@ -82,14 +82,15 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   auto lock = MyConfig.Lock();
 
   std::string error, full_km, rebootnw, contactor_1h_limit;
-  bool canwrite, canwrite_caron, canwrite_sleep, led, resettrip, resettotal, bcvalue;
+  bool canwrite, canwrite_caron, canwrite_caroff, canwrite_sleep, led, resettrip, resettotal, bcvalue;
   bool charge12v, extstats, unlocked, tripnotify, opendoors;
   bool obdii79b, obdii79b_cell, obdii743, obdii745, obdii745_tpms, obdii7e4, obdii7e4_dcdc;
 
   if (c.method == "POST") {
     // process form submission:
-    canwrite    = (c.getvar("canwrite") == "yes");
-    canwrite_caron = (c.getvar("canwrite_caron") == "yes");
+    canwrite    = (c.getvar("canwrite_mode") == "ON");
+    canwrite_caron = (c.getvar("canwrite_mode") == "CARON");
+    canwrite_caroff = (c.getvar("canwrite_mode") == "CAROFF");
     canwrite_sleep = (c.getvar("canwrite_sleep") == "yes");
     led         = (c.getvar("led") == "yes");
     rebootnw    = (c.getvar("rebootnw"));
@@ -139,6 +140,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
          }
       map.SetValueBool("canwrite", canwrite);
       map.SetValueBool("canwrite.caron", canwrite_caron);
+      map.SetValueBool("canwrite.caroff", canwrite_caroff);
       map.SetValueBool("canwrite.sleep", canwrite_sleep);
       map.SetValueBool("led", led);
       map["rebootnw"] = rebootnw;
@@ -177,6 +179,7 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   } else {
     canwrite       = sq->m_enable_write;
     canwrite_caron = sq->m_enable_write_caron;
+    canwrite_caroff = sq->m_enable_write_caroff;
     canwrite_sleep = sq->m_enable_write_sleep;
     led            = sq->m_enable_LED_state;
     resettrip      = sq->m_resettrip;
@@ -209,17 +212,30 @@ void OvmsVehicleSmartEQ::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
   c.form_start(p.uri);
   
   c.fieldset_start("Remote Control");
-  c.input_checkbox("Enable CAN write access #1", "canwrite", canwrite,
-    "<p>CAN write access all time! (OBDII polling, start Preconditioning etc.)</p>");
-  c.input_checkbox("Enable CAN write access #2", "canwrite_caron", canwrite_caron,
-    "<p>CAN write access all time!</p>"
-    "<p>Clears polling list when vehicle is in awake/sleep mode</p>"
-    "<p>This will stop CAN polling when the vehicle is in awake/sleep mode</p>"
-    "<p>Alternative to CAN write access #1; select one or neither!</p>");
-  c.input_checkbox("Disable CAN polling during sleep", "canwrite_sleep", canwrite_sleep,
+
+  std::string canwrite_mode = "OFF";
+  if( canwrite ) canwrite_mode = "ON";
+  else if ( canwrite_caron ) canwrite_mode = "CARON";
+  else if ( canwrite_caroff ) canwrite_mode = "CAROFF";
+  c.input_radiobtn_start("CAN Bus Write Access", "canwrite_mode");
+    c.input_radiobtn_option("canwrite_mode", "Off", "OFF", canwrite_mode == "OFF");
+    c.input_radiobtn_option("canwrite_mode", "On", "ON", canwrite_mode == "ON");
+    c.input_radiobtn_option("canwrite_mode", "Car Off", "CAROFF", canwrite_mode == "CAROFF");
+    c.input_radiobtn_option("canwrite_mode", "Car On", "CARON", canwrite_mode == "CARON");
+  c.input_radiobtn_end(
+    "<dl>"
+    "<dt>Off</dt><dd><p>CAN write is never allowed. The module is only listening to the meesages on the CAN bus</p></dd>"
+    "<dt>On</dt><dd><p>CAN write is allowed at all times (OBDII polling, start Preconditioning etc.)</p></dd>"
+    "<dt>Car Off</dt><dd><p>CAN write access only when car is <strong>OFF</strong>. Clears polling list when vehicle is switched on."
+    " This will stop CAN polling when the vehicle is on and moving</p></dd>"
+    "<dt>Car On</dt><dd><p>CAN write access only, when the car is <strong>ON</strong>."
+    " Polling is disabled, when the vehicle is in awake/sleep mode</p></dd>"
+    "</dl>");
+
+    c.input_checkbox("Disable CAN polling during sleep", "canwrite_sleep", canwrite_sleep,
     "<p>Clears polling list when vehicle is in sleep mode</p>");
   c.fieldset_end();
-  
+
   // trip reset or OBD activation
   c.fieldset_start("Trip calculated or OBD kWh/100km");
   c.input_checkbox("Reset Trip when Charging", "resettrip", resettrip,

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -269,7 +269,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // Note: GetValueBool/Int/Float treat empty string as "not set" and return the default.
   OvmsConfigParam* map = MyConfig.CachedParam("xsq");
   
-  bool stateWrite         = IsCANwrite();
   bool obdii_743          = true;
   bool obdii_745          = true;
   bool obdii_745_tpms     = true;
@@ -329,12 +328,6 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     }
 #endif
 
-  // set CAN bus transceiver to active or listen-only depending on user selection
-  if ( stateWrite != IsCANwrite() )
-    {
-    smartCoolDownPolling();
-    smartOBDpolling(IsCANwrite());
-    }
   // disable caron/off write modes if at least two write modes are enabled
   if ((m_enable_write && (m_enable_write_caron || m_enable_write_caroff)) ||
       (m_enable_write_caron && m_enable_write_caroff))
@@ -344,13 +337,9 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     MyConfig.SetParamValueBool("xsq", "canwrite.caron", false);
     MyConfig.SetParamValueBool("xsq", "canwrite.caroff", false);
     }
-  // start in listen-only mode if sleep-write is enabled while car is asleep,
-  // or if car-off write mode is enabled while car is on
-  if ( !IsCANwrite() )
-    {
-    smartCoolDownPolling();
-    smartOBDpolling(false);
-    }
+
+  // Set the state of the CAN access and polling, according to the user selection
+  smartOBDpolling();
 
   bool do_modify_poll = (
     (obdii_79b != m_obdii_79b) ||

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.cpp
@@ -184,8 +184,8 @@ OvmsVehicleSmartEQ::OvmsVehicleSmartEQ() {
   mt_bms_mfr_id                 = MyMetrics.InitInt("xsq.bms.id.mfr", SM_STALE_NONE, 0,   Other);
   mt_bms_basic_parts            = MyMetrics.InitString("xsq.bms.id.basic.parts", SM_STALE_NONE, "",  Other);
 
-  // Start CAN bus in CAN_MODE_ACTIVE mode
-  RegisterCanBus(1, CAN_MODE_ACTIVE, CAN_SPEED_500KBPS);
+  // Start CAN bus in CAN_MODE_LISTEN mode
+  RegisterCanBus(1, CAN_MODE_LISTEN, CAN_SPEED_500KBPS);
   PollSetState(POLLSTATE_OFF);
 
   // register config container for smart EQ module, with callback to ConfigChanged() on changes
@@ -269,7 +269,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
   // Note: GetValueBool/Int/Float treat empty string as "not set" and return the default.
   OvmsConfigParam* map = MyConfig.CachedParam("xsq");
   
-  bool stateWrite         = m_enable_write;
+  bool stateWrite         = IsCANwrite();
   bool obdii_743          = true;
   bool obdii_745          = true;
   bool obdii_745_tpms     = true;
@@ -282,6 +282,7 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
     {
     m_enable_write         = map->GetValueBool("canwrite", false);
     m_enable_write_caron   = map->GetValueBool("canwrite.caron", false);
+    m_enable_write_caroff  = map->GetValueBool("canwrite.caroff", false);
     m_enable_write_sleep   = map->GetValueBool("canwrite.sleep", false);
     m_enable_LED_state     = map->GetValueBool("led", false);
     m_bcvalue              = map->GetValueBool("bcvalue", false);
@@ -329,19 +330,23 @@ void OvmsVehicleSmartEQ::ConfigChanged(OvmsConfigParam* param) {
 #endif
 
   // set CAN bus transceiver to active or listen-only depending on user selection
-  if ( stateWrite != m_enable_write )
+  if ( stateWrite != IsCANwrite() )
     {
     smartCoolDownPolling();
-    smartOBDpolling(m_enable_write);
+    smartOBDpolling(IsCANwrite());
     }
-  // disable caron write mode if normal write mode is enabled to avoid conflicts
-  if(m_enable_write_caron && m_enable_write) 
+  // disable caron/off write modes if at least two write modes are enabled
+  if ((m_enable_write && (m_enable_write_caron || m_enable_write_caroff)) ||
+      (m_enable_write_caron && m_enable_write_caroff))
     {
     m_enable_write_caron = false;
+    m_enable_write_caroff = false;
     MyConfig.SetParamValueBool("xsq", "canwrite.caron", false);
+    MyConfig.SetParamValueBool("xsq", "canwrite.caroff", false);
     }
-  // start in listen-only mode if sleep write is enabled and bus is not awake
-  if (m_enable_write_sleep && !IsAwakeEQ())
+  // start in listen-only mode if sleep-write is enabled while car is asleep,
+  // or if car-off write mode is enabled while car is on
+  if ( !IsCANwrite() )
     {
     smartCoolDownPolling();
     smartOBDpolling(false);

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -35,8 +35,8 @@
 
 // --- Constants ---
 #define VERSION "2.2.0"
-#define PRESET_VERSION 20260720        // Configuration preset version
-#define PRESET_VERSION_12VREF 20260706 // Configuration preset version for 12V reference migration, defined separately to allow setting 12V reference migration
+#define PRESET_VERSION 20260823        // Configuration preset version
+#define PRESET_VERSION_12VREF 20260823 // Configuration preset version for 12V reference migration, defined separately to allow setting 12V reference migration
 #define DEFAULT_BATTERY_CAPACITY 16700 // <- net 16700 Wh, gross 17600 Wh
 #define MAX_POLL_DATA_LEN 126
 #define CELLCOUNT 96
@@ -154,6 +154,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void smartChargePrepare();
     void smartChargeFinish();
     void smartOBDpolling(bool activate);
+    void smartCANbusAccess(bool activate);
     void smartCoolDownPolling(int delay_sec = 10);
     void smartCAN2Metrics();
 
@@ -232,7 +233,11 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool IsOnEQ() { return can_env_on; }
     bool IsChargingEQ() { return can_charge_inprogress; }
     bool IsOnHVACEQ() { return can_hvac; }
-    bool IsCANwrite() { return m_enable_write || m_enable_write_caron; }
+    bool IsCANwrite() { return ( (!m_enable_write_sleep || IsAwakeEQ()) && 
+                                 ( m_enable_write || 
+                                  (m_enable_write_caron && IsOnEQ()) || 
+                                  (m_enable_write_caroff && !IsOnEQ()) ) 
+                                ); }
     bool Is12VchargeEQ() { return StdMetrics.ms_v_bat_12v_voltage->AsFloat(0.0f) >= 13.1f || 
                                   (m_can_active && StdMetrics.ms_v_charge_12v_voltage->AsFloat(0.0f) >= 13.1f ) || 
                                   (m_can_active && can_charging12v); }
@@ -434,6 +439,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     // --- Config-driven member variables ---
     bool m_enable_write = false;            // canwrite enable write access
     bool m_enable_write_caron = false;      // canwrite enable write access, only when car is on
+    bool m_enable_write_caroff = false;     // canwrite enable write access, only when car is off
     bool m_enable_write_sleep = false;      // canwrite disable write access, only when car is asleep
     bool m_can_active = false;              // true if CAN bus is in active mode, false if in listen-only mode
     bool m_enable_LED_state = false;        // Online LED State
@@ -482,6 +488,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     bool m_notifySOClimit = false;          // notify SOClimit reached one time
     bool m_poll_on_charge = false;          // flag to trigger poll state change actions
     bool m_cmd_locked = false;
+    bool m_can_last_acc_state = false;      // last active/listen state from CAN bus
     int m_adc_samples = 5;                  // number of samples for ADC factor calculation
     int m_ddt4all_ticker = 0;               // DDT4ALL active ticker
     int m_ddt4all_exec = 0;                 // DDT4ALL ticker for next execution

--- a/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
+++ b/vehicle/OVMS.V3/components/vehicle_smarteq/src/vehicle_smarteq.h
@@ -153,7 +153,7 @@ class OvmsVehicleSmartEQ : public OvmsVehicle
     void smartChargeStop();
     void smartChargePrepare();
     void smartChargeFinish();
-    void smartOBDpolling(bool activate);
+    void smartOBDpolling(bool activate = true);
     void smartCANbusAccess(bool activate);
     void smartCoolDownPolling(int delay_sec = 10);
     void smartCAN2Metrics();


### PR DESCRIPTION
Updated version of @zorgms PR #1505, with streamlined and simplified logic. Updated UI to use a radiobutton for the CAN access selection on the feature page of the Smart EQ.

This modifications set the CAN transceiver chip to listen-only mode, if the CAN write access is disabled by selection of the user on the Feature page of the Smart EQ.  

Additional change by @zorgms to adjust the default threshold to trigger the 12V battery trickle charge 
 