### PR TITLE
GSMPPP: Check for a valid IPv4 address in the callback function.

### DIFF
--- a/vehicle/OVMS.V3/components/ovms_cellular/src/gsmpppos.cpp
+++ b/vehicle/OVMS.V3/components/ovms_cellular/src/gsmpppos.cpp
@@ -69,6 +69,11 @@ static void GsmPPPOS_StatusCallback(ppp_pcb *pcb, int err_code, void *ctx)
     {
     case PPPERR_NONE:
       {
+      if ( ip_addr_isany(&pppif->ip_addr) || ip_addr_isany(&pppif->gw))
+        {  
+        ESP_LOGI(TAG, "StatusCallBack: Invalid IPV4 address or Gateway address received - ignored");
+        return;
+        }
       ESP_LOGI(TAG, "status_cb: Connected");
 #if PPP_IPV4_SUPPORT
       ESP_LOGI(TAG, "   our_ipaddr  = %s", ipaddr_ntoa(&pppif->ip_addr));


### PR DESCRIPTION
For the mobile PPP connection, multiple calls to the gsmppp callback have been observed. First call only with an IPv6 address and immediately afterwards with IPv4 address and gateway. 
This PR ignores the callback, if there is no valid IPv4 IP address and gateway set. 
THis avoids  to trigger multiple `network.interface.up`  and `system.modem.gotip` events.