### PR TITLE
vwegolf: report charge current/power while charging

### DIFF
--- a/vehicle/OVMS.V3/changes.txt
+++ b/vehicle/OVMS.V3/changes.txt
@@ -16,6 +16,10 @@ Open Vehicle Monitor System v3 - Change log
     D2=2, D3=3, B=4; -1 = N/A), decoded from the gear-selector frame 0x187.
 - VW e-Golf: correct v.b.current / v.b.power sign to the OVMS output=positive convention
     (discharge positive, charge negative).
+- VW e-Golf: report charge current and power (v.c.current / v.c.power) while charging. The
+    comfort bus carries no AC charger-side telemetry, so these mirror the DC pack-side 0x191
+    measurement (sign-flipped to the charge convention) and are zeroed when charging stops.
+    The app's charge screen previously showed 0 A.
 - vehicle_cadillac_ct5:
     Set the acceptance filter to allow 0x063 (v.on) and 0x5E4 (v.b.soc).
     The high frame rate of this vehicle (> 1600/sec) causes watchdog

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/src/vehicle_vwegolf.cpp
@@ -227,6 +227,22 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
                        StandardMetrics.ms_v_bat_current->AsFloat()) /
                       1000.0F;
             StandardMetrics.ms_v_bat_power->SetValue(tmp_f32);
+
+            // Report the DC pack-side current/power as the charge current/power. The comfort
+            // bus carries no AC charger-side telemetry — a scan of all ~214 KCAN ids during a
+            // full charge found no AC line voltage, AC current, or charger-input power frame;
+            // the only live charge measurement is the DC pack side here (0x5AC byte 3 mirrors it
+            // as integer amps). ms_v_charge_voltage is likewise the pack voltage (set in 0x594).
+            // Sign flips to the charge convention: ms_v_charge_current / ms_v_charge_power are
+            // positive while charging, whereas ms_v_bat_current / ms_v_bat_power are output-
+            // positive (negative while charging). Without this the app's charge screen shows 0 A.
+            // The charging flag is driven by 0x594; when it clears we zero these there.
+            if (StandardMetrics.ms_v_charge_inprogress->AsBool()) {
+                StandardMetrics.ms_v_charge_current->SetValue(
+                    -StandardMetrics.ms_v_bat_current->AsFloat());
+                StandardMetrics.ms_v_charge_power->SetValue(
+                    -StandardMetrics.ms_v_bat_power->AsFloat());
+            }
             ESP_LOGV(TAG, "0x0191 I=%.1fA V=%.2fV", StandardMetrics.ms_v_bat_current->AsFloat(),
                      StandardMetrics.ms_v_bat_voltage->AsFloat());
             break;
@@ -364,6 +380,12 @@ void OvmsVehicleVWeGolf::IncomingFrameCan3(CAN_frame_t* p_frame) {
                 if (is_charging) {
                     StdMetrics.ms_v_charge_voltage->SetValue(
                         StandardMetrics.ms_v_bat_voltage->AsFloat());
+                } else {
+                    // Charge not running: 0x191 only mirrors the pack current/power into the charge
+                    // metrics while charging, so zero them here or the app keeps showing the last
+                    // charge value after a stop.
+                    StdMetrics.ms_v_charge_current->SetValue(0);
+                    StdMetrics.ms_v_charge_power->SetValue(0);
                 }
                 if (is_charging != was_charging) {
                     if (is_charging)

--- a/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_can_decode.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_vwegolf/tests/test_can_decode.cpp
@@ -260,6 +260,55 @@ void test_sentinel_filters() {
 }
 
 // ---------------------------------------------------------------------------
+// Charge current / power mirroring (0x191 while charging, gated by 0x594)
+// ---------------------------------------------------------------------------
+void test_charge_current_0x191() {
+    printf("\ntest_charge_current_0x191\n");
+
+    // Real on-car capture bytes (mid-charge): 0x191 d1=0x30 d2=0x81 d3=0x00 d4=0x05
+    // decode -> I = 2047 - ((0x30&0xf0)>>4 | (0x81<<4)) = 2047 - 2067 = -20 A (charge),
+    //           V = (0x00 | (0x05&0xf)<<8) * 0.25 = 1280 * 0.25 = 320.0 V,
+    //           P = 320 * -20 / 1000 = -6.4 kW. Charge side flips the sign: +20 A / +6.4 kW.
+    auto charge_frame = make_frame(0x191, {0x00, 0x30, 0x81, 0x00, 0x05, 0x00, 0x00, 0x00});
+
+    // Not charging yet: 0x191 must NOT touch the charge metrics.
+    {
+        auto* v = make_vehicle();
+        v->IncomingFrameCan3(&charge_frame);
+        CHECK(near(StandardMetrics.ms_v_bat_current->AsFloat(), -20.0f), "0x191 bat_current -20 A");
+        CHECK(near(StandardMetrics.ms_v_charge_current->AsFloat(), 0.0f),
+              "charge_current stays 0 A when not charging");
+        CHECK(near(StandardMetrics.ms_v_charge_power->AsFloat(), 0.0f),
+              "charge_power stays 0 kW when not charging");
+        delete v;
+    }
+
+    // Charging (0x594 d[3] bit5 set) then 0x191: charge current/power mirror the pack, sign flipped.
+    {
+        auto* v = make_vehicle();
+        // Real steady-charge 0x594 capture: d[3]=0xA3, bit5 set = charging.
+        auto on = make_frame(0x594, {0x00, 0xF0, 0x21, 0xA3, 0x06, 0x34, 0x30, 0x0D});
+        v->IncomingFrameCan3(&on);
+        CHECK(StandardMetrics.ms_v_charge_inprogress->AsBool(), "0x594 sets charge in progress");
+        v->IncomingFrameCan3(&charge_frame);
+        CHECK(near(StandardMetrics.ms_v_charge_current->AsFloat(), 20.0f),
+              "charge_current +20 A while charging");
+        CHECK(near(StandardMetrics.ms_v_charge_power->AsFloat(), 6.4f),
+              "charge_power +6.4 kW while charging");
+
+        // Charge ends: 0x594 with bit5 clear (d[3]=0x03) zeroes the charge metrics.
+        auto off = make_frame(0x594, {0x00, 0x00, 0x20, 0x03, 0x00, 0x00, 0x10, 0x0D});
+        v->IncomingFrameCan3(&off);
+        CHECK(!StandardMetrics.ms_v_charge_inprogress->AsBool(), "0x594 clears charge in progress");
+        CHECK(near(StandardMetrics.ms_v_charge_current->AsFloat(), 0.0f),
+              "charge_current zeroed on charge stop");
+        CHECK(near(StandardMetrics.ms_v_charge_power->AsFloat(), 0.0f),
+              "charge_power zeroed on charge stop");
+        delete v;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 
@@ -275,6 +324,7 @@ int main() {
     test_vin_0x6B4();
     test_gps_0x486();
     test_sentinel_filters();
+    test_charge_current_0x191();
     test_crtd_replay();
     test_bat_ctrl_all();
 


### PR DESCRIPTION
## What
Report `v.c.current` and `v.c.power` for the VW e-Golf while charging.

## Why
The app showed no charge current while charging, only voltage and power (DC side).

## How
While a charge is in progress (`v.c.charging`, driven by 0x594), mirror the DC pack-side current and power measured on 0x191 into `v.c.current` / `v.c.power`, sign-flipped to the charge convention (positive while charging). They are zeroed when 0x594 reports charging has stopped. An AC side charging metric may not exist or was not found yet.
