### PR TITLE
Leaf: Add 12v Battery Current, Fix Battery Type detection, Update WebUI, Battery capacity calculation fix, Code tidy up

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/nl_web.cpp
@@ -168,7 +168,7 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
 
   c.input_radio_start("SOC Display", "socnewcar");
   c.input_radio_option("socnewcar", "from dashboard display",   "no",  socnewcar == false);
-  c.input_radio_option("socnewcar", "relative to fixed value:", "yes", socnewcar == true);
+  c.input_radio_option("socnewcar", "relative to fixed value (required for AZE0):", "yes", socnewcar == true);
   c.input_radio_end("");
   c.input("number", NULL, "maxgids", maxgids.c_str(), "Default: " STR(GEN_1_NEW_CAR_GIDS),
       "<p>Enter the maximum GIDS value when fully charged. Default values are " STR(GEN_1_NEW_CAR_GIDS) " (24kWh) or " STR(GEN_1_30_NEW_CAR_GIDS) " (30kWh) or " STR(GEN_2_40_NEW_CAR_GIDS) " (40kWh) or " STR(GEN_2_62_NEW_CAR_GIDS) " (62kWh)</p>",
@@ -176,13 +176,13 @@ void OvmsVehicleNissanLeaf::WebCfgFeatures(PageEntry_t& p, PageContext_t& c)
 
   c.input_radio_start("SOH Display", "sohnewcar");
   c.input_radio_option("sohnewcar", "from dashboard display",   "no",  sohnewcar == false);
-  c.input_radio_option("sohnewcar", "relative to fixed value:", "yes", sohnewcar == true);
+  c.input_radio_option("sohnewcar", "relative to fixed value (required for AZE0):", "yes", sohnewcar == true);
   c.input_radio_end("");
   c.input("number", NULL, "newcarah", newcarah.c_str(), "Default: " STR(GEN_1_NEW_CAR_AH),
       "<p>This is the usable capacity of your battery when new. Default values are " STR(GEN_1_NEW_CAR_AH) " (24kWh) or " STR(GEN_1_30_NEW_CAR_AH) " (30kWh) or " STR(GEN_2_40_NEW_CAR_AH) " (40kWh) or " STR(GEN_2_62_NEW_CAR_AH) " (62kWh)</p>",
       "min=\"1\" step=\"1\"", "Ah");
   c.input("number", "Cabin Temperature Offset", "cabintempoffset", cabintempoffset.c_str(), "Default: " STR(DEFAULT_CABINTEMP_OFFSET),
-      "<p>This allows an offset adjustment to the cabin temperature sensor readings in Celcius.</p>",
+      "<p>This allows an offset adjustment to the cabin temperature sensor readings in Celcius.  Unnecessary on ZE1 models.</p>",
       "step=\"0.1\"", "");
   c.input("number", "Speed Divisor", "speeddivisor", speeddivisor.c_str(), "Default: " STR(DEFAULT_SPEED_DIVISOR),
       "<p>This allows the speed readings to be adjusted (which also affects the trip odometer), e.g. if wheel diameter has changed. This can be estimated by comparing trip odometer to GPS track distance.</p>"

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1747,11 +1747,11 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         {
         /* Battery type 1 and 2 use different (* and conficting)
          * mx values to identify the charge duration type:
-         *         |    |  full 100% 	    | range 80%  	|
+         *         |    |  full 100% 	      | range 80%  	|
          *   type  | QC | 6.6kW  200V  100V | 6.6kW  200V  100V |
          *  ------ | -- |  --    --    --   |  --    --    --   |
          *   ZE0 1 |  0 |  NA    9     17   |  NA    10    18*	|
-         *  AZE0 2 |  0 |  5	 8     11   |  18*   21    24	|
+         *  AZE0 2 |  0 |  5	   8     11   |  18*   21    24	  |
          *
          * Only type 1 and type 2 24kwh models from before 2016 will report a valid 'range 80%'.
          * Any type 2 24 or 30kwh models starting mid 2015 (USA/Jap) or 2016 (UK), will always
@@ -2240,24 +2240,25 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
         }
       }
     }
-    else
+
+  // If 12V voltage is above 12.8V, then the car is charging the 12V battery.
+  // Using 12V current is no ideal as the battery can be discharging under heavy
+  // load but the 12V charger may still be active.  
+  if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
     {
-      if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
-      {
-      StandardMetrics.ms_v_env_charging12v->SetValue(true);
-      }
-    else StandardMetrics.ms_v_env_charging12v->SetValue(false);
-
-    StandardMetrics.ms_v_env_charging12v->SetStale(false);
-    // FIXME
-    // detecting that on is stale and therefor should turn off probably shouldn't
-    // be done like this
-    // perhaps there should be a car on-off state tracker and event generator in
-    // the core framework?
-    // perhaps interested code should be able to subscribe to "onChange" and
-    // "onStale" events for each metric?
+    StandardMetrics.ms_v_env_charging12v->SetValue(true);
     }
+  else StandardMetrics.ms_v_env_charging12v->SetValue(false);
 
+  StandardMetrics.ms_v_env_charging12v->SetStale(false);
+  // FIXME
+  // detecting that on is stale and therefor should turn off probably shouldn't
+  // be done like this
+  // perhaps there should be a car on-off state tracker and event generator in
+  // the core framework?
+  // perhaps interested code should be able to subscribe to "onChange" and
+  // "onStale" events for each metric?
+  
   ESP_LOGD(TAG, "Poll state: %d", m_poll_state);
   if (StandardMetrics.ms_v_env_awake->AsBool() && StandardMetrics.ms_v_env_awake->IsStale())
     {

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -221,11 +221,6 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   MyMetrics.InitString("v.c.state",SM_STALE_MID,"stopped");
   
   StandardMetrics.ms_v_bat_12v_current->SetAutoStale(30);
-  
-  m_ZE0_charger = false;
-  m_kWh_capacity_read = false;
-  m_AZE0_charger = false;
-  m_climate_really_off = false;
 
   cfg_soh_newcar = MyConfig.GetParamValueBool("xnl", "soh.newcar", false);
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -124,23 +124,17 @@ void ccDisableTimer(TimerHandle_t timer)
   nl->CcDisableTimer();
   }
 
-
-
-
-
-// This seems to be used as a proxy for the model of the vehicle.  It could be that
-// this logic could be removed and we could standardise on just using a standardised model enum.
 // The published battery types are...
 // ZE0 - 24kWh (3 variants 2011-12, 2013-14, 2015)
 // AZE0 - 24kWh (2 variants 2013-15, 2015), 30kWh
 // ZE1 - 40kWh, 62kWh
+// We only care about the ZE0 and AZE0 as they report charge times
+// different based on the battery type. The ZE1 just uses type 2 batteries
 enum battery_type
   {
-  BATTERY_TYPE_1_24kWh,
-  BATTERY_TYPE_2_24kWh,
-  BATTERY_TYPE_2_30kWh,
-  BATTERY_TYPE_2_40kWh,
-  BATTERY_TYPE_2_62kWh
+  BATTERY_TYPE_UNKNOWN,
+  BATTERY_TYPE_1,
+  BATTERY_TYPE_2
   };
 
 enum charge_duration_index
@@ -1680,10 +1674,11 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           break;
         }
 
-
-      // ZE0 SOH
-      if (!cfg_ze1) {
-        if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
+      // This is valid for all batteries by there is better accuracy for ZE1 by polling the battery management system directly.  
+      if (!cfg_ze1) 
+      {
+        // This was only tagged on Battery Type 1 (24kWh) but it is also valid for Type 2 (30kWh, 40kWh, 62kWh)
+        //if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
           uint8_t soh = (d[4] >> 1 & 0xF7);
           m_soh_instrument->SetValue(soh);
           ESP_LOGD(TAG, "IncomingFrameCan1 SOH: %d", soh);
@@ -1691,59 +1686,68 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           {
             StandardMetrics.ms_v_bat_soh->SetValue(soh);
           }
-        }
+        //}
+        
       }
 
+      // This is the multiplex flag for d[2], 1 indicates the value in d[2] is capacity
+      // bars, 0 indicates that it is the charge bars.  Note that this is not just ZE0
+      // but other variants have been seen to use this same multiplexing.
+      uint8_t  mx_bars = (d[4] & 0x01);
 
-      // Either the remaining charge or the total capacity in GIDS depending
-      // on the value of mx_bars_ZE0
-      uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
+      // Charge / capacity bars are multiplexed by mx_bars and encoded
+      // differently on each variant:
+      //   ZE0 (200X-2012)  -> lower 4 bits of d[2], direct 0-12 bars
+      //   AZE0 (2013-2017) -> upper 4 bits of d[2], 0-15 mapped to 0-12 bars
+      //   ZE1 (2018+)      -> upper 4 bits of d[2], 0-15 mapped to 0-12 bars
+      uint8_t bars;
+      if (cfg_ze1 || m_AZE0_charger)
+        {
+        static const uint8_t map_15_to_12[] = {0, 1, 2, 3, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 12};
+        bars = map_15_to_12[(d[2] >> 4) & 0x0F];
+        }
+      else
+        {
+        bars = d[2] & 0x0F;
+        }
+
+      if (mx_bars) 
+        {
+        m_capacitybars->SetValue(bars);
+        }
+      else
+        {
+        m_remaining_chargebars->SetValue(bars);
+        }
+
+      
+
+
 
       // This indicates if the value in nl_gids is the remaining battery charge or the
       // total capacity.  If 1 then the values in the packet are the total capacity,
       // if 0 then the values in the packet are the remaining charge.
+      // Using the captures from Dala's git repository this never set to 1 on a 24kWh battery,
+      // but is set on larger capacity batteries. Confirmed for 40kWh but assumend from the
+      // comments below to also work for the 30kWh. Always 0 on 24kWh battery.
       uint8_t  mx_gids = (d[5] & 0x10) >> 4;
 
-      // This is the multiplex flag for d[2], 1 indicates the value in d[2] is capacity
-      // bars, 0 indicates that it is the charge bars
-      uint8_t  mx_bars_ZE0 = (d[4] & 0x01);
+      // Either the remaining charge or the total capacity in GIDS depending
+      // on the value of mx_bars
+      uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
       
-      int type = -1;
-
       // gids is invalid during startup
       if (nl_gids != 1023)
       {
-        // On LEAF ZE0 200X-2012, some values differ from AZE0
-        // On a ZE0 the lower 4 bits are used for charge / capacity bars
-        // On a AZE0 all 8 bits of d[2] is used for the charge / capacity bars
-        // On a ZE1 the higher 4 bits are used for the charger / capacity bars
-        // TODO: The below needs to be updated to reflect the changing algorithm
-        switch (mx_bars_ZE0) {
-         case 0x00:
-           {
-             if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
-               uint8_t chargebars = (d[2] & 0x0F);
-               m_remaining_chargebars->SetValue(chargebars);
-             }
-           }
-           break;
-          case 0x01:
-           {
-             uint8_t capbars = (d[2] & 0x0F);
-             m_capacitybars->SetValue(capbars);
-             type = BATTERY_TYPE_1_24kWh;  // TODO: This is an invalid assignment on a ZE1
-           }
-           break;
-        }
         switch (mx_gids)
           {
           case 0x00:
             {
-            // Current gids on 24 and 30kwh models
+            // Current gids
             m_gids->SetValue(nl_gids);
             m_battery_energy_available->SetValue(nl_gids * GEN_1_WH_PER_GID, WattHours);
 
-            // new car soc -- 100% when the battery is new, less when it's degraded
+            // new car soc is calculated from the current gids and the max gids from config
             uint16_t max_gids = MyConfig.GetParamValueInt("xnl", "maxGids", GEN_1_NEW_CAR_GIDS);
             float soc_new_car = (nl_gids * 100.0) / max_gids;
             m_soc_new_car->SetValue(soc_new_car);
@@ -1753,11 +1757,23 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
               {
               StandardMetrics.ms_v_bat_soc->SetValue(soc_new_car);
               }
+
+            if (m_ze0_charger)
+              {
+              uint16_t raw_fullcap = ((d[1] & 0x3F) << 4) | ((d[2] & 0xF0) >> 4);
+              uint16_t fullcap_wh = (raw_fullcap + 250) * 80;
+              m_battery_energy_capacity->SetValue(fullcap_wh, WattHours);
+              m_kWh_capacity_read = true;
+              }
+            
+            // The there is no such parameter as soc.newcar.capacity this appears to be old code
+            /* 
             // 2012 Leaf has no instrument soc, battery capacity and max gids will be set from config, because it is not available on CAN
             if (MyConfig.GetParamValueBool("xnl", "soc.newcar.capacity", false)) {
               m_battery_energy_capacity->SetValue(max_gids * GEN_1_WH_PER_GID, WattHours);
               m_kWh_capacity_read = true;
               }
+            */
             }
             break;
           case  0x01:
@@ -1765,7 +1781,6 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
             // Max gids, this mx value only occurs on 30kWh models and up
             m_max_gids->SetValue(nl_gids);
             m_battery_energy_capacity->SetValue(nl_gids * GEN_1_WH_PER_GID, WattHours);
-            type = BATTERY_TYPE_2_30kWh;
             m_kWh_capacity_read = true;
             }
             break;
@@ -1785,42 +1800,47 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
          *         |    |  full 100% 	      | range 80%  	|
          *   type  | QC | 6.6kW  200V  100V | 6.6kW  200V  100V |
          *  ------ | -- |  --    --    --   |  --    --    --   |
-         *   ZE0 1 |  0 |  NA    9     17   |  NA    10    18*	|
-         *  AZE0 2 |  0 |  5	   8     11   |  18*   21    24	  |
-         *   ZE1   |  0 |  5	   8     11   |  22    25    28	  | <-- From Dala's ZE1 DBC files
+         *   1     |  0 |  NA    9     17   |  NA    10    18*	|
+         *   2     |  0 |  5	   8     11   |  18*   21    24	  |
          *
          * Only type 1 and type 2 24kwh models from before 2016 will report a valid 'range 80%'.
          * Any type 2 24 or 30kwh models starting mid 2015 (USA/Jap) or 2016 (UK), will always
          * return 0x1fff, and therefore never enter this if with mx values 18, 21 or 24.
          * This is linked to Nissan removing the 'long life mode (80%)' from the car settings.
+         * ZE1 variants will return all vallues from 1 to 17.
          */
-        int cd = -1;
-        switch (mx)
+
+        if (m_battery_type->AsInt(BATTERY_TYPE_UNKNOWN) == BATTERY_TYPE_UNKNOWN)
+        {
+          if (cfg_ze1 || mx == 21 ) { m_battery_type->SetValue(BATTERY_TYPE_2); }
+          else if (mx == 9) { m_battery_type->SetValue(BATTERY_TYPE_1); }
+        }
+        else
+        {
+          int cd = -1;
+          switch (mx)
           {
           case  0: m_quick_charge->SetValue(val); break;
           case  5: cd = CHARGE_DURATION_FULL_L2;  break;
           case  8: cd = CHARGE_DURATION_FULL_L1;  break;
-          case  9: cd = CHARGE_DURATION_FULL_L1;  type = BATTERY_TYPE_1_24kWh; break;
-          case 10: cd = CHARGE_DURATION_RANGE_L1; type = BATTERY_TYPE_1_24kWh; break;
+          case  9: cd = CHARGE_DURATION_FULL_L1;  break;
+          case 10: cd = CHARGE_DURATION_RANGE_L1; break;
           case 11: cd = CHARGE_DURATION_FULL_L0;  break;
-          case 17: cd = CHARGE_DURATION_FULL_L0;  type = BATTERY_TYPE_1_24kWh; break;
+          case 17: cd = CHARGE_DURATION_FULL_L0;  break;
           case 18: // meaning of mx 18 differs by battery version
-            switch(m_battery_type->AsInt(BATTERY_TYPE_2_24kWh))
-              {
-              case BATTERY_TYPE_1_24kWh: cd = CHARGE_DURATION_RANGE_L0; break;
-              case BATTERY_TYPE_2_24kWh: cd = CHARGE_DURATION_RANGE_L2; break;
-              case BATTERY_TYPE_2_30kWh: break;  // Will never occur with val != 0x1fff
-              }
+            if (m_battery_type->AsInt(BATTERY_TYPE_UNKNOWN) == BATTERY_TYPE_1)
+            {
+              cd = CHARGE_DURATION_RANGE_L0;
+            }
+            else
+            {
+              cd = CHARGE_DURATION_RANGE_L2;
+            }
             break;
-          case 21: cd = CHARGE_DURATION_RANGE_L1; type = BATTERY_TYPE_2_24kWh; break;
-          case 24: cd = CHARGE_DURATION_RANGE_L0; type = BATTERY_TYPE_2_24kWh; break;
+          case 21: cd = CHARGE_DURATION_RANGE_L1; break;
+          case 24: cd = CHARGE_DURATION_RANGE_L0; break;
           }
-        if (cd != -1) m_charge_duration->SetElemValue(cd, val/2);
-        }
-      // If detected, save battery type
-      if (type != -1)
-        {
-        m_battery_type->SetValue(type);  //TODO: this flips between 0 and 2 when charging a ZE1 40kWh, need to investigate why
+          if (cd != -1) m_charge_duration->SetElemValue(cd, val/2);
         }
       }
       break;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1718,11 +1718,11 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
         {
         /* Battery type 1 and 2 use different (* and conficting)
          * mx values to identify the charge duration type:
-         *         |    |  full 100% 	    | range 80%  	|
+         *         |    |  full 100% 	      | range 80%  	|
          *   type  | QC | 6.6kW  200V  100V | 6.6kW  200V  100V |
          *  ------ | -- |  --    --    --   |  --    --    --   |
          *   ZE0 1 |  0 |  NA    9     17   |  NA    10    18*	|
-         *  AZE0 2 |  0 |  5	 8     11   |  18*   21    24	|
+         *  AZE0 2 |  0 |  5	   8     11   |  18*   21    24	  |
          *
          * Only type 1 and type 2 24kwh models from before 2016 will report a valid 'range 80%'.
          * Any type 2 24 or 30kwh models starting mid 2015 (USA/Jap) or 2016 (UK), will always
@@ -2204,24 +2204,25 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
         }
       }
     }
-    else
+
+  // If 12V voltage is above 12.8V, then the car is charging the 12V battery.
+  // Using 12V current is no ideal as the battery can be discharging under heavy
+  // load but the 12V charger may still be active.  
+  if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
     {
-      if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
-      {
-      StandardMetrics.ms_v_env_charging12v->SetValue(true);
-      }
-    else StandardMetrics.ms_v_env_charging12v->SetValue(false);
-
-    StandardMetrics.ms_v_env_charging12v->SetStale(false);
-    // FIXME
-    // detecting that on is stale and therefor should turn off probably shouldn't
-    // be done like this
-    // perhaps there should be a car on-off state tracker and event generator in
-    // the core framework?
-    // perhaps interested code should be able to subscribe to "onChange" and
-    // "onStale" events for each metric?
+    StandardMetrics.ms_v_env_charging12v->SetValue(true);
     }
+  else StandardMetrics.ms_v_env_charging12v->SetValue(false);
 
+  StandardMetrics.ms_v_env_charging12v->SetStale(false);
+  // FIXME
+  // detecting that on is stale and therefor should turn off probably shouldn't
+  // be done like this
+  // perhaps there should be a car on-off state tracker and event generator in
+  // the core framework?
+  // perhaps interested code should be able to subscribe to "onChange" and
+  // "onStale" events for each metric?
+  
   ESP_LOGD(TAG, "Poll state: %d", m_poll_state);
   if (StandardMetrics.ms_v_env_awake->AsBool() && StandardMetrics.ms_v_env_awake->IsStale())
     {

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -59,6 +59,7 @@ static const char *TAG = "v-nissanleaf";
 #define VIN_PID                   0x81
 #define QC_COUNT_PID              0x1203
 #define L1L2_COUNT_PID            0x1205
+#define BAT_12V_CURRENT_PID       0x1183
 
 enum poll_states
   {
@@ -74,10 +75,11 @@ enum poll_states
 // Should only do this if we are charging.
 static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
   {
-    // BUS 2                                                                         Off,   On,  Run, Charge 
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,            {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,    {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // QC [2] Only changes when charging.
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,  {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
+    // BUS 2                                                                             Off,   On,  Run, Charge 
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,                {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,        {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // QC [2] Only changes when charging.
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,      {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, BAT_12V_CURRENT_PID, {  0,   10,   10,      0 }, 2, ISOTP_STD }, // 12V battery current [2]
     // BUS 1
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
@@ -93,6 +95,7 @@ static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID, {  0, 3600, 0, 0 }, 2, ISOTP_STD },           // VIN [19]
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID, {  0, 0, 0, 3600 }, 2, ISOTP_STD },   // QC [2]
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID, {  0, 0, 0, 3600 }, 2, ISOTP_STD }, // L0/L1/L2 [2]
+    // { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, BAT_12V_CURRENT_PID, { 0, 10, 10, 0 }, 2, ISOTP_STD }, // 12V battery current [2] This may work but someone needs to test before we enable.
     // BUS 1
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
@@ -216,6 +219,9 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   MyMetrics.InitBool("v.e.awake", SM_STALE_MID, false);
   MyMetrics.InitBool("v.e.locked", SM_STALE_MID, false);
   MyMetrics.InitString("v.c.state",SM_STALE_MID,"stopped");
+  
+  StandardMetrics.ms_v_bat_12v_current->SetAutoStale(30);
+  
   m_ZE0_charger = false;
   m_kWh_capacity_read = false;
   m_AZE0_charger = false;
@@ -943,6 +949,24 @@ void OvmsVehicleNissanLeaf::PollReply_L0L1L2(const uint8_t *reply_data, uint16_t
     }
   }
 
+void OvmsVehicleNissanLeaf::PollReply_12VCurrent(const uint8_t *reply_data, uint16_t reply_len)
+  {
+  //  > 0x797 22 11 83
+  //  < 0x79a 62 11 83
+  // [ 0..1] FF 72  (signed, 1/256 A per bit)
+  if (reply_len < 2)
+    {
+    ESP_LOGI(TAG, "PollReply_12VCurrent: len=%d < 2", reply_len);
+    return;
+    }
+
+  int16_t raw = (reply_data[0] << 8) | reply_data[1];
+  float current = raw / 256.0f;
+  StandardMetrics.ms_v_bat_12v_current->SetValue(current, Amps);
+
+  ESP_LOGD(TAG, "12V Current: %.4f A (raw 0x%04X)", current, (uint16_t)raw);
+  }
+
 void OvmsVehicleNissanLeaf::PollReply_VIN(const uint8_t *reply_data, uint16_t reply_len)
   {
   if (reply_len != 19)
@@ -1005,6 +1029,9 @@ void OvmsVehicleNissanLeaf::IncomingPollReply(const OvmsPoller::poll_job_t &job,
         break;
       case CHARGER_RXID<<16 | VIN_PID: // VIN
         PollReply_VIN(buf, rxbuf.size());
+        break;
+      case CHARGER_RXID<<16 | BAT_12V_CURRENT_PID: // 12V battery current
+        PollReply_12VCurrent(buf, rxbuf.size());
         break;
       default:
         ESP_LOGI(TAG, "IncomingPollReply: unknown reply module|pid=%#" PRIx32 " len=%d", id_pid, rxbuf.size());
@@ -2155,20 +2182,46 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
   HandleCharging();
   HandleChargeEstimation();
   HandleExporting();
-  if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
+  
+  if (cfg_ze1)
     {
-    StandardMetrics.ms_v_env_charging12v->SetValue(true);
+    // Clear 12V current if it has gone stale (CAN2 may be shut down by the car).
+    if (StandardMetrics.ms_v_bat_12v_current->IsStale())
+      {
+      StandardMetrics.ms_v_bat_12v_current->Clear();
+      StandardMetrics.ms_v_env_charging12v->Clear();
+      }
+    else
+      {
+      // If 12V current is positive, then the car is charging the 12V battery.  
+      if (StandardMetrics.ms_v_bat_12v_current->AsFloat() > 0)
+        {
+        StandardMetrics.ms_v_env_charging12v->SetValue(true);
+        }
+      else 
+        {
+        StandardMetrics.ms_v_env_charging12v->SetValue(false);
+        }
+      }
     }
-  else StandardMetrics.ms_v_env_charging12v->SetValue(false);
+    else
+    {
+      if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
+      {
+      StandardMetrics.ms_v_env_charging12v->SetValue(true);
+      }
+    else StandardMetrics.ms_v_env_charging12v->SetValue(false);
 
-  StandardMetrics.ms_v_env_charging12v->SetStale(false);
-  // FIXME
-  // detecting that on is stale and therefor should turn off probably shouldn't
-  // be done like this
-  // perhaps there should be a car on-off state tracker and event generator in
-  // the core framework?
-  // perhaps interested code should be able to subscribe to "onChange" and
-  // "onStale" events for each metric?
+    StandardMetrics.ms_v_env_charging12v->SetStale(false);
+    // FIXME
+    // detecting that on is stale and therefor should turn off probably shouldn't
+    // be done like this
+    // perhaps there should be a car on-off state tracker and event generator in
+    // the core framework?
+    // perhaps interested code should be able to subscribe to "onChange" and
+    // "onStale" events for each metric?
+    }
+
   ESP_LOGD(TAG, "Poll state: %d", m_poll_state);
   if (StandardMetrics.ms_v_env_awake->AsBool() && StandardMetrics.ms_v_env_awake->IsStale())
     {

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -59,6 +59,7 @@ static const char *TAG = "v-nissanleaf";
 #define VIN_PID                   0x81
 #define QC_COUNT_PID              0x1203
 #define L1L2_COUNT_PID            0x1205
+#define BAT_12V_CURRENT_PID       0x1183
 
 enum poll_states
   {
@@ -74,10 +75,11 @@ enum poll_states
 // Should only do this if we are charging.
 static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
   {
-    // BUS 2                                                                         Off,   On,  Run, Charge 
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,            {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,    {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // QC [2] Only changes when charging.
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,  {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
+    // BUS 2                                                                             Off,   On,  Run, Charge 
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,                {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,        {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // QC [2] Only changes when charging.
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,      {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, BAT_12V_CURRENT_PID, {  0,   10,   10,      0 }, 2, ISOTP_STD }, // 12V battery current [2]
     // BUS 1
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
@@ -93,6 +95,7 @@ static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID, {  0, 3600, 0, 0 }, 2, ISOTP_STD },           // VIN [19]
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID, {  0, 0, 0, 3600 }, 2, ISOTP_STD },   // QC [2]
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID, {  0, 0, 0, 3600 }, 2, ISOTP_STD }, // L0/L1/L2 [2]
+    // { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, BAT_12V_CURRENT_PID, { 0, 10, 10, 0 }, 2, ISOTP_STD }, // 12V battery current [2] This may work but someone needs to test before we enable.
     // BUS 1
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
@@ -216,6 +219,9 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   MyMetrics.InitBool("v.e.awake", SM_STALE_MID, false);
   MyMetrics.InitBool("v.e.locked", SM_STALE_MID, false);
   MyMetrics.InitString("v.c.state",SM_STALE_MID,"stopped");
+  
+  StandardMetrics.ms_v_bat_12v_current->SetAutoStale(30);
+  
   m_ZE0_charger = false;
   m_kWh_capacity_read = false;
   m_AZE0_charger = false;
@@ -972,6 +978,24 @@ void OvmsVehicleNissanLeaf::PollReply_L0L1L2(const uint8_t *reply_data, uint16_t
     }
   }
 
+void OvmsVehicleNissanLeaf::PollReply_12VCurrent(const uint8_t *reply_data, uint16_t reply_len)
+  {
+  //  > 0x797 22 11 83
+  //  < 0x79a 62 11 83
+  // [ 0..1] FF 72  (signed, 1/256 A per bit)
+  if (reply_len < 2)
+    {
+    ESP_LOGI(TAG, "PollReply_12VCurrent: len=%d < 2", reply_len);
+    return;
+    }
+
+  int16_t raw = (reply_data[0] << 8) | reply_data[1];
+  float current = raw / 256.0f;
+  StandardMetrics.ms_v_bat_12v_current->SetValue(current, Amps);
+
+  ESP_LOGD(TAG, "12V Current: %.4f A (raw 0x%04X)", current, (uint16_t)raw);
+  }
+
 void OvmsVehicleNissanLeaf::PollReply_VIN(const uint8_t *reply_data, uint16_t reply_len)
   {
   if (reply_len != 19)
@@ -1034,6 +1058,9 @@ void OvmsVehicleNissanLeaf::IncomingPollReply(const OvmsPoller::poll_job_t &job,
         break;
       case CHARGER_RXID<<16 | VIN_PID: // VIN
         PollReply_VIN(buf, rxbuf.size());
+        break;
+      case CHARGER_RXID<<16 | BAT_12V_CURRENT_PID: // 12V battery current
+        PollReply_12VCurrent(buf, rxbuf.size());
         break;
       default:
         ESP_LOGI(TAG, "IncomingPollReply: unknown reply module|pid=%#" PRIx32 " len=%d", id_pid, rxbuf.size());
@@ -2191,20 +2218,46 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
   HandleCharging();
   HandleChargeEstimation();
   HandleExporting();
-  if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
+  
+  if (cfg_ze1)
     {
-    StandardMetrics.ms_v_env_charging12v->SetValue(true);
+    // Clear 12V current if it has gone stale (CAN2 may be shut down by the car).
+    if (StandardMetrics.ms_v_bat_12v_current->IsStale())
+      {
+      StandardMetrics.ms_v_bat_12v_current->Clear();
+      StandardMetrics.ms_v_env_charging12v->Clear();
+      }
+    else
+      {
+      // If 12V current is positive, then the car is charging the 12V battery.  
+      if (StandardMetrics.ms_v_bat_12v_current->AsFloat() > 0)
+        {
+        StandardMetrics.ms_v_env_charging12v->SetValue(true);
+        }
+      else 
+        {
+        StandardMetrics.ms_v_env_charging12v->SetValue(false);
+        }
+      }
     }
-  else StandardMetrics.ms_v_env_charging12v->SetValue(false);
+    else
+    {
+      if (StandardMetrics.ms_v_bat_12v_voltage->AsFloat() > 12.8)
+      {
+      StandardMetrics.ms_v_env_charging12v->SetValue(true);
+      }
+    else StandardMetrics.ms_v_env_charging12v->SetValue(false);
 
-  StandardMetrics.ms_v_env_charging12v->SetStale(false);
-  // FIXME
-  // detecting that on is stale and therefor should turn off probably shouldn't
-  // be done like this
-  // perhaps there should be a car on-off state tracker and event generator in
-  // the core framework?
-  // perhaps interested code should be able to subscribe to "onChange" and
-  // "onStale" events for each metric?
+    StandardMetrics.ms_v_env_charging12v->SetStale(false);
+    // FIXME
+    // detecting that on is stale and therefor should turn off probably shouldn't
+    // be done like this
+    // perhaps there should be a car on-off state tracker and event generator in
+    // the core framework?
+    // perhaps interested code should be able to subscribe to "onChange" and
+    // "onStale" events for each metric?
+    }
+
   ESP_LOGD(TAG, "Poll state: %d", m_poll_state);
   if (StandardMetrics.ms_v_env_awake->AsBool() && StandardMetrics.ms_v_env_awake->IsStale())
     {

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -35,6 +35,7 @@ static const char *TAG = "v-nissanleaf";
 #include <stdio.h>
 #include <string.h>
 #include "pcp.h"
+#include "vehicle_common.h"
 #include "vehicle_nissanleaf.h"
 #include "ovms_events.h"
 #include "ovms_metrics.h"
@@ -67,15 +68,16 @@ enum poll_states
   POLLSTATE_CHARGING  //- car is charging
   };
 
-// Leaf does not respond to polls when car is off
-// So there is no point polling when car is off
-
+// BUS2 is off on the ZE1 when car is off or Charging, CAN is active if ignition
+// is in Accessories, On or Running. But we dont map all those states here.
+// We can "Wakeup" BUS2 but this seems to put a heavy load on the 12v battery
+// Should only do this if we are charging.
 static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
   {
-    // BUS 2                                                                         Off,   On, Run, Charge 
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,            {  0, 3600,   0,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,    {  0,    0,   0,   3600 }, 2, ISOTP_STD }, // QC [2] Only changes when charging. Do not update when car is active to reduce traffic.
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,  {  0,    0,   0,   3600 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging. Do not update when car is active to reduce traffic.
+    // BUS 2                                                                         Off,   On,  Run, Charge 
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,            {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,    {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // QC [2] Only changes when charging.
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,  {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
     // BUS 1
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
@@ -2158,6 +2160,8 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
     StandardMetrics.ms_v_env_charging12v->SetValue(true);
     }
   else StandardMetrics.ms_v_env_charging12v->SetValue(false);
+
+  StandardMetrics.ms_v_env_charging12v->SetStale(false);
   // FIXME
   // detecting that on is stale and therefor should turn off probably shouldn't
   // be done like this

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1629,6 +1629,16 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
             }
           }
         }
+      
+      // From the original commit
+      /* This does not give a sensible capacity estimate for 30kWh battery,
+       * but leave it here for now until we either figure out what this
+       * really is or find a way to read capacity some other way.
+       */
+      // From Dala's DBC files this is related to Quick Charges capacityonly 
+      // eg the capacity available for a quick charge.  It is not the total 
+      // capacity of the battery. Hence the misleading values observed.
+      /*      
       switch(m_battery_type->AsInt(BATTERY_TYPE_2_24kWh))
         {
         case BATTERY_TYPE_1_24kWh:
@@ -1644,6 +1654,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           // instead m_battery_energy_capacity is set from message 0x5bc
           break;
         }
+      */
       }
       break;
     case 0x5bc:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -81,14 +81,16 @@ static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,      {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, BAT_12V_CURRENT_PID, {  0,   10,   10,      0 }, 2, ISOTP_STD }, // 12V battery current [2]
     // BUS 1
-    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
-    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
-    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x06, {  0, 0, 0, 60 }, 1, ISOTP_STD },   // battery shunts [96] Only in use when charging. Do not update when car is active to reduce traffic.
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },    // bat [39/41]
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },    // battery voltages [196]
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x06, {  0, 0, 0, 60 }, 1, ISOTP_STD },      // battery shunts [96] Only in use when charging. Do not update when car is active to reduce traffic.
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {  0, 180, 180, 180 }, 1, ISOTP_STD }, // battery temperatures [14]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {  0, 900, 900, 900 }, 1, ISOTP_STD }, // SOH for ZE1
     POLL_LIST_END
   };
 
+  // There is a very good chance that the AZE0 and ZE1 can use the same polling list, but we will keep them separate for now
+  // as I have not been able to test the AZE0 and confirm this. 
   static const OvmsPoller::poll_pid_t obdii_polls_aze0[] =
   {
     // BUS 2
@@ -122,12 +124,23 @@ void ccDisableTimer(TimerHandle_t timer)
   nl->CcDisableTimer();
   }
 
+
+
+
+
+// This seems to be used as a proxy for the model of the vehicle.  It could be that
+// this logic could be removed and we could standardise on just using a standardised model enum.
+// The published battery types are...
+// ZE0 - 24kWh (3 variants 2011-12, 2013-14, 2015)
+// AZE0 - 24kWh (2 variants 2013-15, 2015), 30kWh
+// ZE1 - 40kWh, 62kWh
 enum battery_type
   {
   BATTERY_TYPE_1_24kWh,
   BATTERY_TYPE_2_24kWh,
   BATTERY_TYPE_2_30kWh,
-  // there may be more...
+  BATTERY_TYPE_2_40kWh,
+  BATTERY_TYPE_2_62kWh
   };
 
 enum charge_duration_index
@@ -1669,15 +1682,29 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       }
 
 
-
+      // Either the remaining charge or the total capacity in GIDS depending
+      // on the value of mx_bars_ZE0
       uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
+
+      // This indicates if the value in nl_gids is the remaining battery charge or the
+      // total capacity.  If 1 then the values in the packet are the total capacity,
+      // if 0 then the values in the packet are the remaining charge.
       uint8_t  mx_gids = (d[5] & 0x10) >> 4;
+
+      // This is the multiplex flag for d[2], 1 indicates the value in d[2] is capacity
+      // bars, 0 indicates that it is the charge bars
       uint8_t  mx_bars_ZE0 = (d[4] & 0x01);
+      
       int type = -1;
+
       // gids is invalid during startup
       if (nl_gids != 1023)
       {
         // On LEAF ZE0 200X-2012, some values differ from AZE0
+        // On a ZE0 the lower 4 bits are used for charge / capacity bars
+        // On a AZE0 all 8 bits of d[2] is used for the charge / capacity bars
+        // On a ZE1 the higher 4 bits are used for the charger / capacity bars
+        // TODO: The below needs to be updated to reflect the changing algorithm
         switch (mx_bars_ZE0) {
          case 0x00:
            {
@@ -1691,7 +1718,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
            {
              uint8_t capbars = (d[2] & 0x0F);
              m_capacitybars->SetValue(capbars);
-             type = BATTERY_TYPE_1_24kWh;
+             type = BATTERY_TYPE_1_24kWh;  // TODO: This is an invalid assignment on a ZE1
            }
            break;
         }
@@ -1747,6 +1774,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
          *  ------ | -- |  --    --    --   |  --    --    --   |
          *   ZE0 1 |  0 |  NA    9     17   |  NA    10    18*	|
          *  AZE0 2 |  0 |  5	   8     11   |  18*   21    24	  |
+         *   ZE1   |  0 |  5	   8     11   |  22    25    28	  | <-- From Dala's ZE1 DBC files
          *
          * Only type 1 and type 2 24kwh models from before 2016 will report a valid 'range 80%'.
          * Any type 2 24 or 30kwh models starting mid 2015 (USA/Jap) or 2016 (UK), will always
@@ -1779,7 +1807,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       // If detected, save battery type
       if (type != -1)
         {
-        m_battery_type->SetValue(type);
+        m_battery_type->SetValue(type);  //TODO: this flips between 0 and 2 when charging a ZE1 40kWh, need to investigate why
         }
       }
       break;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1880,6 +1880,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
 
   switch (p_frame->MsgID)
     {
+    /* 
     case 0x180: // Filtered out by CAN RX filter on ZE1
       if (d[5] != 0xff)
         {
@@ -1892,6 +1893,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_env_footbrake->SetValue(d[6] / 1.39);
         }
       break;
+    */
     case 0x355:
      // The odometer value on the bus is always in units appropriate
      // for the car's intended market and is unaffected by the dash

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1927,7 +1927,6 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_env_footbrake->SetValue(d[6] / 1.39);
         }
       break;
-    */
     case 0x355:
      // The odometer value on the bus is always in units appropriate
      // for the car's intended market and is unaffected by the dash

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1986,9 +1986,17 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
       }
       ESP_LOGV(TAG, "IncomingFrameCan2 Charge bars: %d, 3kW minutes: %d", m_remaining_chargebars->AsInt(), m_charge_minutes_3kW_remaining->AsInt());
       break;
+
+
+    // The original comment for this code is that it is "soh as percentage" and dates back to 2019, but
+    // a) the code does not work for ZE1 (it returns a invalid value)
+    // b) there are no 5b3 messages in the ZE0 or AZE0 captures from Dala's git repository
+    // Additional in the DBC files this is tagged as NV200 only.
+    // Maybe we need a NV200 specific config option.
+    /*
     case 0x5b3:
       {
-      // soh as percentage
+
       if (!cfg_ze1) // ZE1 gets SOH by polling group 61
         {
           uint8_t soh = d[1] >> 1;
@@ -2005,6 +2013,8 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         }
       break;
       }
+    */
+
     case 0x5c5:
       // This is the parking brake (which is foot-operated on some models).
       StandardMetrics.ms_v_env_handbrake->SetValue(d[0] & 4);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1729,7 +1729,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
               StandardMetrics.ms_v_bat_soc->SetValue(soc_new_car);
               }
 
-            if (m_ze0_charger)
+            if (m_ZE0_charger)
               {
               uint16_t raw_fullcap = ((d[1] & 0x3F) << 4) | ((d[2] & 0xF0) >> 4);
               uint16_t fullcap_wh = (raw_fullcap + 250) * 80;
@@ -1813,6 +1813,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           }
           if (cd != -1) m_charge_duration->SetElemValue(cd, val/2);
         }
+      }
       }
       break;
     case 0x5bf:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1950,9 +1950,17 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
       }
       ESP_LOGV(TAG, "IncomingFrameCan2 Charge bars: %d, 3kW minutes: %d", m_remaining_chargebars->AsInt(), m_charge_minutes_3kW_remaining->AsInt());
       break;
+
+
+    // The original comment for this code is that it is "soh as percentage" and dates back to 2019, but
+    // a) the code does not work for ZE1 (it returns a invalid value)
+    // b) there are no 5b3 messages in the ZE0 or AZE0 captures from Dala's git repository
+    // Additional in the DBC files this is tagged as NV200 only.
+    // Maybe we need a NV200 specific config option.
+    /*
     case 0x5b3:
       {
-      // soh as percentage
+
       if (!cfg_ze1) // ZE1 gets SOH by polling group 61
         {
           uint8_t soh = d[1] >> 1;
@@ -1969,6 +1977,8 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         }
       break;
       }
+    */
+
     case 0x5c5:
       // This is the parking brake (which is foot-operated on some models).
       StandardMetrics.ms_v_env_handbrake->SetValue(d[0] & 4);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1600,6 +1600,16 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
             }
           }
         }
+      
+      // From the original commit
+      /* This does not give a sensible capacity estimate for 30kWh battery,
+       * but leave it here for now until we either figure out what this
+       * really is or find a way to read capacity some other way.
+       */
+      // From Dala's DBC files this is related to Quick Charges capacityonly 
+      // eg the capacity available for a quick charge.  It is not the total 
+      // capacity of the battery. Hence the misleading values observed.
+      /*      
       switch(m_battery_type->AsInt(BATTERY_TYPE_2_24kWh))
         {
         case BATTERY_TYPE_1_24kWh:
@@ -1615,6 +1625,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           // instead m_battery_energy_capacity is set from message 0x5bc
           break;
         }
+      */
       }
       break;
     case 0x5bc:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1948,6 +1948,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan2(CAN_frame_t* p_frame)
         StandardMetrics.ms_v_env_footbrake->SetValue(d[6] / 1.39);
         }
       break;
+    */
     case 0x355:
      // The odometer value on the bus is always in units appropriate
      // for the car's intended market and is unaffected by the dash

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -124,23 +124,17 @@ void ccDisableTimer(TimerHandle_t timer)
   nl->CcDisableTimer();
   }
 
-
-
-
-
-// This seems to be used as a proxy for the model of the vehicle.  It could be that
-// this logic could be removed and we could standardise on just using a standardised model enum.
 // The published battery types are...
 // ZE0 - 24kWh (3 variants 2011-12, 2013-14, 2015)
 // AZE0 - 24kWh (2 variants 2013-15, 2015), 30kWh
 // ZE1 - 40kWh, 62kWh
+// We only care about the ZE0 and AZE0 as they report charge times
+// different based on the battery type. The ZE1 just uses type 2 batteries
 enum battery_type
   {
-  BATTERY_TYPE_1_24kWh,
-  BATTERY_TYPE_2_24kWh,
-  BATTERY_TYPE_2_30kWh,
-  BATTERY_TYPE_2_40kWh,
-  BATTERY_TYPE_2_62kWh
+  BATTERY_TYPE_UNKNOWN,
+  BATTERY_TYPE_1,
+  BATTERY_TYPE_2
   };
 
 enum charge_duration_index
@@ -1651,10 +1645,11 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           break;
         }
 
-
-      // ZE0 SOH
-      if (!cfg_ze1) {
-        if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
+      // This is valid for all batteries by there is better accuracy for ZE1 by polling the battery management system directly.  
+      if (!cfg_ze1) 
+      {
+        // This was only tagged on Battery Type 1 (24kWh) but it is also valid for Type 2 (30kWh, 40kWh, 62kWh)
+        //if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
           uint8_t soh = (d[4] >> 1 & 0xF7);
           m_soh_instrument->SetValue(soh);
           ESP_LOGD(TAG, "IncomingFrameCan1 SOH: %d", soh);
@@ -1662,59 +1657,68 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           {
             StandardMetrics.ms_v_bat_soh->SetValue(soh);
           }
-        }
+        //}
+        
       }
 
+      // This is the multiplex flag for d[2], 1 indicates the value in d[2] is capacity
+      // bars, 0 indicates that it is the charge bars.  Note that this is not just ZE0
+      // but other variants have been seen to use this same multiplexing.
+      uint8_t  mx_bars = (d[4] & 0x01);
 
-      // Either the remaining charge or the total capacity in GIDS depending
-      // on the value of mx_bars_ZE0
-      uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
+      // Charge / capacity bars are multiplexed by mx_bars and encoded
+      // differently on each variant:
+      //   ZE0 (200X-2012)  -> lower 4 bits of d[2], direct 0-12 bars
+      //   AZE0 (2013-2017) -> upper 4 bits of d[2], 0-15 mapped to 0-12 bars
+      //   ZE1 (2018+)      -> upper 4 bits of d[2], 0-15 mapped to 0-12 bars
+      uint8_t bars;
+      if (cfg_ze1 || m_AZE0_charger)
+        {
+        static const uint8_t map_15_to_12[] = {0, 1, 2, 3, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 12};
+        bars = map_15_to_12[(d[2] >> 4) & 0x0F];
+        }
+      else
+        {
+        bars = d[2] & 0x0F;
+        }
+
+      if (mx_bars) 
+        {
+        m_capacitybars->SetValue(bars);
+        }
+      else
+        {
+        m_remaining_chargebars->SetValue(bars);
+        }
+
+      
+
+
 
       // This indicates if the value in nl_gids is the remaining battery charge or the
       // total capacity.  If 1 then the values in the packet are the total capacity,
       // if 0 then the values in the packet are the remaining charge.
+      // Using the captures from Dala's git repository this never set to 1 on a 24kWh battery,
+      // but is set on larger capacity batteries. Confirmed for 40kWh but assumend from the
+      // comments below to also work for the 30kWh. Always 0 on 24kWh battery.
       uint8_t  mx_gids = (d[5] & 0x10) >> 4;
 
-      // This is the multiplex flag for d[2], 1 indicates the value in d[2] is capacity
-      // bars, 0 indicates that it is the charge bars
-      uint8_t  mx_bars_ZE0 = (d[4] & 0x01);
+      // Either the remaining charge or the total capacity in GIDS depending
+      // on the value of mx_bars
+      uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
       
-      int type = -1;
-
       // gids is invalid during startup
       if (nl_gids != 1023)
       {
-        // On LEAF ZE0 200X-2012, some values differ from AZE0
-        // On a ZE0 the lower 4 bits are used for charge / capacity bars
-        // On a AZE0 all 8 bits of d[2] is used for the charge / capacity bars
-        // On a ZE1 the higher 4 bits are used for the charger / capacity bars
-        // TODO: The below needs to be updated to reflect the changing algorithm
-        switch (mx_bars_ZE0) {
-         case 0x00:
-           {
-             if (m_battery_type->AsInt(0) == BATTERY_TYPE_1_24kWh) {
-               uint8_t chargebars = (d[2] & 0x0F);
-               m_remaining_chargebars->SetValue(chargebars);
-             }
-           }
-           break;
-          case 0x01:
-           {
-             uint8_t capbars = (d[2] & 0x0F);
-             m_capacitybars->SetValue(capbars);
-             type = BATTERY_TYPE_1_24kWh;  // TODO: This is an invalid assignment on a ZE1
-           }
-           break;
-        }
         switch (mx_gids)
           {
           case 0x00:
             {
-            // Current gids on 24 and 30kwh models
+            // Current gids
             m_gids->SetValue(nl_gids);
             m_battery_energy_available->SetValue(nl_gids * GEN_1_WH_PER_GID, WattHours);
 
-            // new car soc -- 100% when the battery is new, less when it's degraded
+            // new car soc is calculated from the current gids and the max gids from config
             uint16_t max_gids = MyConfig.GetParamValueInt("xnl", "maxGids", GEN_1_NEW_CAR_GIDS);
             float soc_new_car = (nl_gids * 100.0) / max_gids;
             m_soc_new_car->SetValue(soc_new_car);
@@ -1724,11 +1728,23 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
               {
               StandardMetrics.ms_v_bat_soc->SetValue(soc_new_car);
               }
+
+            if (m_ze0_charger)
+              {
+              uint16_t raw_fullcap = ((d[1] & 0x3F) << 4) | ((d[2] & 0xF0) >> 4);
+              uint16_t fullcap_wh = (raw_fullcap + 250) * 80;
+              m_battery_energy_capacity->SetValue(fullcap_wh, WattHours);
+              m_kWh_capacity_read = true;
+              }
+            
+            // The there is no such parameter as soc.newcar.capacity this appears to be old code
+            /* 
             // 2012 Leaf has no instrument soc, battery capacity and max gids will be set from config, because it is not available on CAN
             if (MyConfig.GetParamValueBool("xnl", "soc.newcar.capacity", false)) {
               m_battery_energy_capacity->SetValue(max_gids * GEN_1_WH_PER_GID, WattHours);
               m_kWh_capacity_read = true;
               }
+            */
             }
             break;
           case  0x01:
@@ -1736,7 +1752,6 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
             // Max gids, this mx value only occurs on 30kWh models and up
             m_max_gids->SetValue(nl_gids);
             m_battery_energy_capacity->SetValue(nl_gids * GEN_1_WH_PER_GID, WattHours);
-            type = BATTERY_TYPE_2_30kWh;
             m_kWh_capacity_read = true;
             }
             break;
@@ -1756,42 +1771,47 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
          *         |    |  full 100% 	      | range 80%  	|
          *   type  | QC | 6.6kW  200V  100V | 6.6kW  200V  100V |
          *  ------ | -- |  --    --    --   |  --    --    --   |
-         *   ZE0 1 |  0 |  NA    9     17   |  NA    10    18*	|
-         *  AZE0 2 |  0 |  5	   8     11   |  18*   21    24	  |
-         *   ZE1   |  0 |  5	   8     11   |  22    25    28	  | <-- From Dala's ZE1 DBC files
+         *   1     |  0 |  NA    9     17   |  NA    10    18*	|
+         *   2     |  0 |  5	   8     11   |  18*   21    24	  |
          *
          * Only type 1 and type 2 24kwh models from before 2016 will report a valid 'range 80%'.
          * Any type 2 24 or 30kwh models starting mid 2015 (USA/Jap) or 2016 (UK), will always
          * return 0x1fff, and therefore never enter this if with mx values 18, 21 or 24.
          * This is linked to Nissan removing the 'long life mode (80%)' from the car settings.
+         * ZE1 variants will return all vallues from 1 to 17.
          */
-        int cd = -1;
-        switch (mx)
+
+        if (m_battery_type->AsInt(BATTERY_TYPE_UNKNOWN) == BATTERY_TYPE_UNKNOWN)
+        {
+          if (cfg_ze1 || mx == 21 ) { m_battery_type->SetValue(BATTERY_TYPE_2); }
+          else if (mx == 9) { m_battery_type->SetValue(BATTERY_TYPE_1); }
+        }
+        else
+        {
+          int cd = -1;
+          switch (mx)
           {
           case  0: m_quick_charge->SetValue(val); break;
           case  5: cd = CHARGE_DURATION_FULL_L2;  break;
           case  8: cd = CHARGE_DURATION_FULL_L1;  break;
-          case  9: cd = CHARGE_DURATION_FULL_L1;  type = BATTERY_TYPE_1_24kWh; break;
-          case 10: cd = CHARGE_DURATION_RANGE_L1; type = BATTERY_TYPE_1_24kWh; break;
+          case  9: cd = CHARGE_DURATION_FULL_L1;  break;
+          case 10: cd = CHARGE_DURATION_RANGE_L1; break;
           case 11: cd = CHARGE_DURATION_FULL_L0;  break;
-          case 17: cd = CHARGE_DURATION_FULL_L0;  type = BATTERY_TYPE_1_24kWh; break;
+          case 17: cd = CHARGE_DURATION_FULL_L0;  break;
           case 18: // meaning of mx 18 differs by battery version
-            switch(m_battery_type->AsInt(BATTERY_TYPE_2_24kWh))
-              {
-              case BATTERY_TYPE_1_24kWh: cd = CHARGE_DURATION_RANGE_L0; break;
-              case BATTERY_TYPE_2_24kWh: cd = CHARGE_DURATION_RANGE_L2; break;
-              case BATTERY_TYPE_2_30kWh: break;  // Will never occur with val != 0x1fff
-              }
+            if (m_battery_type->AsInt(BATTERY_TYPE_UNKNOWN) == BATTERY_TYPE_1)
+            {
+              cd = CHARGE_DURATION_RANGE_L0;
+            }
+            else
+            {
+              cd = CHARGE_DURATION_RANGE_L2;
+            }
             break;
-          case 21: cd = CHARGE_DURATION_RANGE_L1; type = BATTERY_TYPE_2_24kWh; break;
-          case 24: cd = CHARGE_DURATION_RANGE_L0; type = BATTERY_TYPE_2_24kWh; break;
+          case 21: cd = CHARGE_DURATION_RANGE_L1; break;
+          case 24: cd = CHARGE_DURATION_RANGE_L0; break;
           }
-        if (cd != -1) m_charge_duration->SetElemValue(cd, val/2);
-        }
-      // If detected, save battery type
-      if (type != -1)
-        {
-        m_battery_type->SetValue(type);  //TODO: this flips between 0 and 2 when charging a ZE1 40kWh, need to investigate why
+          if (cd != -1) m_charge_duration->SetElemValue(cd, val/2);
         }
       }
       break;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -81,14 +81,16 @@ static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,      {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
     { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, BAT_12V_CURRENT_PID, {  0,   10,   10,      0 }, 2, ISOTP_STD }, // 12V battery current [2]
     // BUS 1
-    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
-    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
-    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x06, {  0, 0, 0, 60 }, 1, ISOTP_STD },   // battery shunts [96] Only in use when charging. Do not update when car is active to reduce traffic.
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },    // bat [39/41]
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },    // battery voltages [196]
+    { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x06, {  0, 0, 0, 60 }, 1, ISOTP_STD },      // battery shunts [96] Only in use when charging. Do not update when car is active to reduce traffic.
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x04, {  0, 180, 180, 180 }, 1, ISOTP_STD }, // battery temperatures [14]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x61, {  0, 900, 900, 900 }, 1, ISOTP_STD }, // SOH for ZE1
     POLL_LIST_END
   };
 
+  // There is a very good chance that the AZE0 and ZE1 can use the same polling list, but we will keep them separate for now
+  // as I have not been able to test the AZE0 and confirm this. 
   static const OvmsPoller::poll_pid_t obdii_polls_aze0[] =
   {
     // BUS 2
@@ -122,12 +124,23 @@ void ccDisableTimer(TimerHandle_t timer)
   nl->CcDisableTimer();
   }
 
+
+
+
+
+// This seems to be used as a proxy for the model of the vehicle.  It could be that
+// this logic could be removed and we could standardise on just using a standardised model enum.
+// The published battery types are...
+// ZE0 - 24kWh (3 variants 2011-12, 2013-14, 2015)
+// AZE0 - 24kWh (2 variants 2013-15, 2015), 30kWh
+// ZE1 - 40kWh, 62kWh
 enum battery_type
   {
   BATTERY_TYPE_1_24kWh,
   BATTERY_TYPE_2_24kWh,
   BATTERY_TYPE_2_30kWh,
-  // there may be more...
+  BATTERY_TYPE_2_40kWh,
+  BATTERY_TYPE_2_62kWh
   };
 
 enum charge_duration_index
@@ -1640,15 +1653,29 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       }
 
 
-
+      // Either the remaining charge or the total capacity in GIDS depending
+      // on the value of mx_bars_ZE0
       uint16_t nl_gids = ((uint16_t) d[0] << 2) | ((d[1] & 0xc0) >> 6);
+
+      // This indicates if the value in nl_gids is the remaining battery charge or the
+      // total capacity.  If 1 then the values in the packet are the total capacity,
+      // if 0 then the values in the packet are the remaining charge.
       uint8_t  mx_gids = (d[5] & 0x10) >> 4;
+
+      // This is the multiplex flag for d[2], 1 indicates the value in d[2] is capacity
+      // bars, 0 indicates that it is the charge bars
       uint8_t  mx_bars_ZE0 = (d[4] & 0x01);
+      
       int type = -1;
+
       // gids is invalid during startup
       if (nl_gids != 1023)
       {
         // On LEAF ZE0 200X-2012, some values differ from AZE0
+        // On a ZE0 the lower 4 bits are used for charge / capacity bars
+        // On a AZE0 all 8 bits of d[2] is used for the charge / capacity bars
+        // On a ZE1 the higher 4 bits are used for the charger / capacity bars
+        // TODO: The below needs to be updated to reflect the changing algorithm
         switch (mx_bars_ZE0) {
          case 0x00:
            {
@@ -1662,7 +1689,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
            {
              uint8_t capbars = (d[2] & 0x0F);
              m_capacitybars->SetValue(capbars);
-             type = BATTERY_TYPE_1_24kWh;
+             type = BATTERY_TYPE_1_24kWh;  // TODO: This is an invalid assignment on a ZE1
            }
            break;
         }
@@ -1718,6 +1745,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
          *  ------ | -- |  --    --    --   |  --    --    --   |
          *   ZE0 1 |  0 |  NA    9     17   |  NA    10    18*	|
          *  AZE0 2 |  0 |  5	   8     11   |  18*   21    24	  |
+         *   ZE1   |  0 |  5	   8     11   |  22    25    28	  | <-- From Dala's ZE1 DBC files
          *
          * Only type 1 and type 2 24kwh models from before 2016 will report a valid 'range 80%'.
          * Any type 2 24 or 30kwh models starting mid 2015 (USA/Jap) or 2016 (UK), will always
@@ -1750,7 +1778,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
       // If detected, save battery type
       if (type != -1)
         {
-        m_battery_type->SetValue(type);
+        m_battery_type->SetValue(type);  //TODO: this flips between 0 and 2 when charging a ZE1 40kWh, need to investigate why
         }
       }
       break;

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -173,8 +173,8 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   BmsSetCellArrangementVoltage(96, 32);
   BmsSetCellArrangementTemperature(3, 1);
 
-  m_gids = MyMetrics.InitInt("xnl.v.b.gids", SM_STALE_HIGH, 0);
-  m_max_gids = MyMetrics.InitInt("xnl.v.b.max.gids", SM_STALE_HIGH, 0);
+  m_gids = MyMetrics.InitInt("xnl.v.b.gids", SM_STALE_HIGH, 0);   // Remaining energy in GIDS (1 GID = 80 Wh)
+  m_max_gids = MyMetrics.InitInt("xnl.v.b.max.gids", SM_STALE_HIGH, 0);  // Original (before degredation) maximum battery capacity in GIDS (1 GID = 80 Wh)
   m_hx = MyMetrics.InitFloat("xnl.v.b.hx", SM_STALE_HIGH, 0);
   m_soc_new_car = MyMetrics.InitFloat("xnl.v.b.soc.newcar", SM_STALE_HIGH, 0, Percentage);
   m_soc_instrument = MyMetrics.InitFloat("xnl.v.b.soc.instrument", SM_STALE_HIGH, 0, Percentage);
@@ -184,9 +184,9 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   m_bms_balancing = MyMetrics.InitBitset<96>("xnl.bms.balancing", SM_STALE_HIGH, 0);
   m_soh_new_car = MyMetrics.InitFloat("xnl.v.b.soh.newcar", SM_STALE_HIGH, 0, Percentage);
   m_soh_instrument = MyMetrics.InitFloat("xnl.v.b.soh.instrument", SM_STALE_HIGH, 0, Percentage);
-  m_battery_energy_capacity = MyMetrics.InitFloat("xnl.v.b.e.capacity", SM_STALE_HIGH, 0, kWh);
-  m_battery_energy_available = MyMetrics.InitFloat("xnl.v.b.e.available", SM_STALE_HIGH, 0, kWh);
-  m_battery_type = MyMetrics.InitInt("xnl.v.b.type", SM_STALE_HIGH, 0); // auto-detect version and size by can traffic
+  m_battery_energy_capacity = MyMetrics.InitFloat("xnl.v.b.e.capacity", SM_STALE_HIGH, 0, kWh);  // Total battery energy capacity in kWh
+  m_battery_energy_available = MyMetrics.InitFloat("xnl.v.b.e.available", SM_STALE_HIGH, 0, kWh); // Available battery energy in kWh
+  m_battery_type = MyMetrics.InitInt("xnl.v.b.type", SM_STALE_HIGH, BATTERY_TYPE_UNKNOWN); // Auto-detect version by can traffic - TODO: this does not need to be a metric, it could be a global variable
   m_battery_heaterpresent = MyMetrics.InitBool("xnl.v.b.heaterpresent", SM_STALE_HIGH, false);
   m_battery_heatrequested = MyMetrics.InitBool("xnl.v.b.heatrequested", SM_STALE_HIGH, false);
   m_battery_heatergranted = MyMetrics.InitBool("xnl.v.b.heatergranted", SM_STALE_HIGH, false);
@@ -776,6 +776,8 @@ void OvmsVehicleNissanLeaf::PollReply_Battery(const uint8_t *reply_data, uint16_
   float ah = ah10000 / 10000.0;
   StandardMetrics.ms_v_bat_cac->SetValue(ah);
 
+
+  // NOTE: capacity is read from other places that 59e
   if (!m_kWh_capacity_read) {
     // Because older LEAF models seem not to transmit 0x59e, calculate based on Ah and pack voltage
     m_battery_energy_capacity->SetValue((ah*StandardMetrics.ms_v_bat_voltage->AsFloat())/1000.0);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -35,6 +35,7 @@ static const char *TAG = "v-nissanleaf";
 #include <stdio.h>
 #include <string.h>
 #include "pcp.h"
+#include "vehicle_common.h"
 #include "vehicle_nissanleaf.h"
 #include "ovms_events.h"
 #include "ovms_metrics.h"
@@ -67,15 +68,16 @@ enum poll_states
   POLLSTATE_CHARGING  //- car is charging
   };
 
-// Leaf does not respond to polls when car is off
-// So there is no point polling when car is off
-
+// BUS2 is off on the ZE1 when car is off or Charging, CAN is active if ignition
+// is in Accessories, On or Running. But we dont map all those states here.
+// We can "Wakeup" BUS2 but this seems to put a heavy load on the 12v battery
+// Should only do this if we are charging.
 static const OvmsPoller::poll_pid_t obdii_polls_ze1[] =
   {
-    // BUS 2                                                                         Off,   On, Run, Charge 
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,            {  0, 3600,   0,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,    {  0,    0,   0,   3600 }, 2, ISOTP_STD }, // QC [2] Only changes when charging. Do not update when car is active to reduce traffic.
-    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,  {  0,    0,   0,   3600 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging. Do not update when car is active to reduce traffic.
+    // BUS 2                                                                         Off,   On,  Run, Charge 
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, VIN_PID,            {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // VIN [19] Never changes
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, QC_COUNT_PID,    {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // QC [2] Only changes when charging.
+    { CHARGER_TXID, CHARGER_RXID, VEHICLE_POLL_TYPE_OBDIIEXTENDED, L1L2_COUNT_PID,  {  0, 3600, 3600,      0 }, 2, ISOTP_STD }, // L0/L1/L2 [2] Only changes when charging.
     // BUS 1
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x01, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // bat [39/41]
     { BMS_TXID, BMS_RXID, VEHICLE_POLL_TYPE_OBDIIGROUP, 0x02, {  0, 60, 60, 60 }, 1, ISOTP_STD },   // battery voltages [196]
@@ -2194,6 +2196,8 @@ void OvmsVehicleNissanLeaf::Ticker10(uint32_t ticker)
     StandardMetrics.ms_v_env_charging12v->SetValue(true);
     }
   else StandardMetrics.ms_v_env_charging12v->SetValue(false);
+
+  StandardMetrics.ms_v_env_charging12v->SetStale(false);
   // FIXME
   // detecting that on is stale and therefor should turn off probably shouldn't
   // be done like this

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -173,8 +173,8 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   BmsSetCellArrangementVoltage(96, 32);
   BmsSetCellArrangementTemperature(3, 1);
 
-  m_gids = MyMetrics.InitInt("xnl.v.b.gids", SM_STALE_HIGH, 0);
-  m_max_gids = MyMetrics.InitInt("xnl.v.b.max.gids", SM_STALE_HIGH, 0);
+  m_gids = MyMetrics.InitInt("xnl.v.b.gids", SM_STALE_HIGH, 0);   // Remaining energy in GIDS (1 GID = 80 Wh)
+  m_max_gids = MyMetrics.InitInt("xnl.v.b.max.gids", SM_STALE_HIGH, 0);  // Original (before degredation) maximum battery capacity in GIDS (1 GID = 80 Wh)
   m_hx = MyMetrics.InitFloat("xnl.v.b.hx", SM_STALE_HIGH, 0);
   m_soc_new_car = MyMetrics.InitFloat("xnl.v.b.soc.newcar", SM_STALE_HIGH, 0, Percentage);
   m_soc_instrument = MyMetrics.InitFloat("xnl.v.b.soc.instrument", SM_STALE_HIGH, 0, Percentage);
@@ -184,9 +184,9 @@ OvmsVehicleNissanLeaf::OvmsVehicleNissanLeaf()
   m_bms_balancing = MyMetrics.InitBitset<96>("xnl.bms.balancing", SM_STALE_HIGH, 0);
   m_soh_new_car = MyMetrics.InitFloat("xnl.v.b.soh.newcar", SM_STALE_HIGH, 0, Percentage);
   m_soh_instrument = MyMetrics.InitFloat("xnl.v.b.soh.instrument", SM_STALE_HIGH, 0, Percentage);
-  m_battery_energy_capacity = MyMetrics.InitFloat("xnl.v.b.e.capacity", SM_STALE_HIGH, 0, kWh);
-  m_battery_energy_available = MyMetrics.InitFloat("xnl.v.b.e.available", SM_STALE_HIGH, 0, kWh);
-  m_battery_type = MyMetrics.InitInt("xnl.v.b.type", SM_STALE_HIGH, 0); // auto-detect version and size by can traffic
+  m_battery_energy_capacity = MyMetrics.InitFloat("xnl.v.b.e.capacity", SM_STALE_HIGH, 0, kWh);  // Total battery energy capacity in kWh
+  m_battery_energy_available = MyMetrics.InitFloat("xnl.v.b.e.available", SM_STALE_HIGH, 0, kWh); // Available battery energy in kWh
+  m_battery_type = MyMetrics.InitInt("xnl.v.b.type", SM_STALE_HIGH, BATTERY_TYPE_UNKNOWN); // Auto-detect version by can traffic - TODO: this does not need to be a metric, it could be a global variable
   m_battery_heaterpresent = MyMetrics.InitBool("xnl.v.b.heaterpresent", SM_STALE_HIGH, false);
   m_battery_heatrequested = MyMetrics.InitBool("xnl.v.b.heatrequested", SM_STALE_HIGH, false);
   m_battery_heatergranted = MyMetrics.InitBool("xnl.v.b.heatergranted", SM_STALE_HIGH, false);
@@ -805,6 +805,8 @@ void OvmsVehicleNissanLeaf::PollReply_Battery(const uint8_t *reply_data, uint16_
   float ah = ah10000 / 10000.0;
   StandardMetrics.ms_v_bat_cac->SetValue(ah);
 
+
+  // NOTE: capacity is read from other places that 59e
   if (!m_kWh_capacity_read) {
     // Because older LEAF models seem not to transmit 0x59e, calculate based on Ah and pack voltage
     m_battery_energy_capacity->SetValue((ah*StandardMetrics.ms_v_bat_voltage->AsFloat())/1000.0);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.cpp
@@ -1758,7 +1758,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
               StandardMetrics.ms_v_bat_soc->SetValue(soc_new_car);
               }
 
-            if (m_ze0_charger)
+            if (m_ZE0_charger)
               {
               uint16_t raw_fullcap = ((d[1] & 0x3F) << 4) | ((d[2] & 0xF0) >> 4);
               uint16_t fullcap_wh = (raw_fullcap + 250) * 80;
@@ -1842,6 +1842,7 @@ void OvmsVehicleNissanLeaf::IncomingFrameCan1(CAN_frame_t* p_frame)
           }
           if (cd != -1) m_charge_duration->SetElemValue(cd, val/2);
         }
+      }
       }
       break;
     case 0x5bf:

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -196,8 +196,8 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     OvmsMetricInt *m_gids;
     OvmsMetricInt *m_max_gids;
     OvmsMetricFloat *m_hx;
-    OvmsMetricFloat *m_soc_new_car;
-    OvmsMetricFloat *m_soc_instrument;
+    OvmsMetricFloat *m_soc_new_car;                       // SOC based on fixed value from web config 
+    OvmsMetricFloat *m_soc_instrument;                    // SOC read from BMS
     OvmsMetricInt *m_range_instrument;
     OvmsMetricVector<int> *m_bms_thermistor;
     OvmsMetricVector<int> *m_bms_temp_int;
@@ -259,8 +259,8 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
 
     int         m_MITM = 0;
     double      m_trip_odo;                             // trip distance estimated from speed
-    uint32_t    m_trip_last_upd_time;                  // timestamp as of last trip counter update
-    float       m_trip_last_upd_speed;                 // speed as of last trip counter update
+    uint32_t    m_trip_last_upd_time;                   // timestamp as of last trip counter update
+    float       m_trip_last_upd_speed;                  // speed as of last trip counter update
     float       m_cum_energy_used_wh;                   // Cumulated energy (in wh) used within 1 second ticker interval
     float       m_cum_energy_recd_wh;                   // Cumulated energy (in wh) recovered  within 1 second ticker interval
     float       m_cum_energy_charge_wh;                 // Cumulated energy (in wh) charged within 10 second ticker interval

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -180,6 +180,7 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     void PollReply_Battery(const uint8_t *reply_data, uint16_t reply_len);
     void PollReply_QC(const uint8_t *reply_data, uint16_t reply_len);
     void PollReply_L0L1L2(const uint8_t *reply_data, uint16_t reply_len);
+    void PollReply_12VCurrent(const uint8_t *reply_data, uint16_t reply_len);
     void PollReply_VIN(const uint8_t *reply_data, uint16_t reply_len);
     void PollReply_BMS_Volt(const uint8_t *reply_data, uint16_t reply_len);
     void PollReply_BMS_Shunt(const uint8_t *reply_data, uint16_t reply_len);

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -265,10 +265,12 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     float       m_cum_energy_recd_wh;                   // Cumulated energy (in wh) recovered  within 1 second ticker interval
     float       m_cum_energy_charge_wh;                 // Cumulated energy (in wh) charged within 10 second ticker interval
     float       m_cum_energy_gen_wh;                    // Cumulated energy (in wh) exported within 10 second ticker interval
-    bool        m_ZE0_charger;                          // True if 2011-2012 ZE0 LEAF with 0x380 message (Gen 1)
-    bool        m_AZE0_charger;                         // True if 2013+ AZE0 LEAF with 0x390 message (Gen 2)
-    bool        m_climate_really_off;                   // Needed for AZE0 to shown correct hvac status while charging
-    bool        m_kWh_capacity_read;                    // m_battery_energy_capacity Ah*V fallback inhibitor
+    bool        m_ZE0_charger = false;                  // True if 2011-2012 ZE0 LEAF with 0x380 message (Gen 1)
+    bool        m_AZE0_charger = false;                 // True if 2013+ AZE0, NV200, ZE1 LEAF with 0x390 message (Gen 2)
+    bool        m_climate_really_off = false;           // Needed for AZE0 to shown correct hvac status while charging
+    bool        m_kWh_capacity_read = false;            // m_battery_energy_capacity Ah*V fallback inhibitor
+
+    Model m_model = MODEL_UNKNOWN;                      // Model of the vehicle
 
     OvmsPoller::poll_pid_t* obdii_polls;
 

--- a/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
+++ b/vehicle/OVMS.V3/components/vehicle_nissanleaf/src/vehicle_nissanleaf.h
@@ -270,8 +270,6 @@ class OvmsVehicleNissanLeaf : public OvmsVehicle
     bool        m_climate_really_off = false;           // Needed for AZE0 to shown correct hvac status while charging
     bool        m_kWh_capacity_read = false;            // m_battery_energy_capacity Ah*V fallback inhibitor
 
-    Model m_model = MODEL_UNKNOWN;                      // Model of the vehicle
-
     OvmsPoller::poll_pid_t* obdii_polls;
 
   protected:


### PR DESCRIPTION
- Add 12v Battery Current polling
- Fix battery type detection so that battery type logic works properly on ZE1
- Update WebUI with more descriptive comments on
- Remove code for packets that are now filtered out
- Remove the capacity calculation from 59e packets as 59e is for QC capacity not total capacity
- Explicitly constrain 5b3 SOH code to non ZE1 variants